### PR TITLE
Fixed release windows extension

### DIFF
--- a/.github/workflows/build_tauri.yaml
+++ b/.github/workflows/build_tauri.yaml
@@ -246,7 +246,7 @@ jobs:
         with:
           upload_url: ${{ github.event.release.upload_url }}
           asset_path: src-tauri/target/release/eim.exe
-          asset_name: ${{ matrix.binname }}
+          asset_name: ${{ matrix.binname }}.exe
           asset_content_type: application/octet-stream
 
       - name: Upload app Windows


### PR DESCRIPTION
on windows the release artifacts are missing the .exe extension, this should fix it