### PR TITLE
Fixed the issue with wrong paths in the activation script

### DIFF
--- a/src-tauri/src/cli/wizard.rs
+++ b/src-tauri/src/cli/wizard.rs
@@ -570,29 +570,34 @@ pub async fn run_wizzard_run(mut config: Settings) -> Result<(), String> {
             &tool_install_directory,
         )
         .await?;
-
-        let env_vars = idf_im_lib::setup_environment_variables(&tool_install_directory, &idf_path)?;
-
+        let parent_tools = tool_install_directory.parent().unwrap();
+        let env_vars =
+            idf_im_lib::setup_environment_variables(&parent_tools.to_path_buf(), &idf_path)?;
+        let real_env_vars = idf_im_lib::setup_environment_variables(
+            &tool_install_directory.to_path_buf(),
+            &idf_path,
+        )?;
         let idf_tools_path = get_and_validate_idf_tools_path(&mut config, &idf_path)?;
-
         if config.idf_features.is_some() {
             let features = config.idf_features.clone().unwrap();
             idf_im_lib::python_utils::run_idf_tools_py_with_features(
                 idf_tools_path.to_str().unwrap(),
                 &env_vars,
+                &real_env_vars,
                 &features,
             )?;
         } else {
             idf_im_lib::python_utils::run_idf_tools_py(
                 idf_tools_path.to_str().unwrap(),
                 &env_vars,
+                &real_env_vars,
             )?;
         }
 
         let export_paths = idf_im_lib::idf_tools::get_tools_export_paths(
             tools,
             config.target.clone().unwrap().clone(),
-            tool_install_directory.join("tools").to_str().unwrap(),
+            tool_install_directory.to_str().unwrap(),
         )
         .into_iter()
         .map(|p| {

--- a/src-tauri/src/lib/mod.rs
+++ b/src-tauri/src/lib/mod.rs
@@ -531,7 +531,7 @@ pub fn setup_environment_variables(
 /// * `Result<PathBuf, std::io::Error>` - On success, returns a `PathBuf` representing the path to the ELF ROM directory.
 ///   On error, returns a `std::io::Error` indicating the cause of the error.
 fn get_elf_rom_dir(idf_tools_path: &PathBuf) -> Result<PathBuf, std::io::Error> {
-    let elf_rom_dir = idf_tools_path.join("tools").join("esp-rom-elfs");
+    let elf_rom_dir = idf_tools_path.join("esp-rom-elfs");
     if elf_rom_dir.exists() {
         let mut subdirs = vec![];
         // Read the entries in the elf_rom_dir
@@ -570,7 +570,7 @@ fn get_elf_rom_dir(idf_tools_path: &PathBuf) -> Result<PathBuf, std::io::Error> 
 /// * `Result<PathBuf, std::io::Error>` - On success, returns a `PathBuf` representing the path to the OpenOCD scripts folder.
 ///   On error, returns a `std::io::Error` indicating the cause of the error.
 fn get_openocd_scripts_folder(idf_tools_path: &PathBuf) -> Result<String, std::io::Error> {
-    let search_path = idf_tools_path.join("tools").join("openocd-esp32");
+    let search_path = idf_tools_path.join("openocd-esp32");
 
     let result = find_directories_by_name(&search_path, "scripts");
 

--- a/src-tauri/src/lib/python_utils.rs
+++ b/src-tauri/src/lib/python_utils.rs
@@ -1,4 +1,4 @@
-use log::trace;
+use log::{info, trace};
 #[cfg(feature = "userustpython")]
 use rustpython_vm as vm;
 #[cfg(feature = "userustpython")]
@@ -117,14 +117,21 @@ pub fn run_python_script_from_file(
 pub fn run_idf_tools_py(
     // todo: rewrite functionality to rust
     idf_tools_path: &str,
-    environment_variables: &Vec<(String, String)>,
+    environment_variables_install: &Vec<(String, String)>,
+    environment_variables_python: &Vec<(String, String)>,
 ) -> Result<String, String> {
-    run_idf_tools_py_with_features(idf_tools_path, environment_variables, &vec![])
+    run_idf_tools_py_with_features(
+        idf_tools_path,
+        environment_variables_install,
+        environment_variables_python,
+        &vec![],
+    )
 }
 
 pub fn run_idf_tools_py_with_features(
     idf_tools_path: &str,
-    environment_variables: &Vec<(String, String)>,
+    environment_variables_install: &Vec<(String, String)>,
+    environment_variables_python: &Vec<(String, String)>,
     features: &Vec<String>,
 ) -> Result<String, String> {
     let escaped_path = if std::env::consts::OS == "windows" {
@@ -132,8 +139,19 @@ pub fn run_idf_tools_py_with_features(
     } else {
         replace_unescaped_spaces_posix(&idf_tools_path)
     };
-    run_install_script(&escaped_path, environment_variables)?;
-    run_install_python_env_script_with_features(&escaped_path, environment_variables, features)
+    match run_install_script(&escaped_path, environment_variables_install) {
+        Ok(_) => {
+            info!("install success");
+        }
+        Err(e) => {
+            info!("Instal failed {:?}", e);
+        }
+    }
+    run_install_python_env_script_with_features(
+        &escaped_path,
+        environment_variables_python,
+        features,
+    )
 }
 
 fn run_install_script(

--- a/src-tauri/src/lib/utils.rs
+++ b/src-tauri/src/lib/utils.rs
@@ -48,6 +48,30 @@ pub fn get_git_path() -> Result<String, String> {
         Err(stderr.trim().to_string())
     }
 }
+
+/// Filters a vector of strings containing paths to only include directories.
+///
+/// # Purpose
+///
+/// This function takes a vector of strings representing paths and filters out any paths that are not directories.
+/// It uses the `PathBuf::is_dir` method to check if each path is a directory.
+///
+/// # Parameters
+///
+/// * `paths`: A vector of strings containing paths to be filtered.
+///
+/// # Return Value
+///
+/// * `Vec<String>`: A vector of strings containing the paths of directories.
+fn filter_directories(paths: Vec<String>) -> Vec<String> {
+    paths
+        .into_iter()
+        .filter(|path_str| {
+            let path = PathBuf::from(path_str);
+            path.is_dir()
+        })
+        .collect()
+}
 // Finds all directories in the specified path that match the given name.
 // The function recursively searches subdirectories and collects matching paths in a vector.
 // Returns a vector of PathBuf containing the paths of matching directories.
@@ -62,7 +86,7 @@ pub fn find_directories_by_name(path: &Path, name: &str) -> Vec<String> {
         .hidden()
         .build()
         .collect();
-    filter_subpaths(search)
+    filter_directories(filter_subpaths(search))
 }
 
 /// Checks if the given path is a valid ESP-IDF directory.


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description
Now the exported paths should be ok and the tolls will be not duplicate anymore.

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
