### PR TITLE
EIM-168 fixed missing button for checking prerequisities

### DIFF
--- a/src/components/wizard_steps/PrerequisitiesCheck.vue
+++ b/src/components/wizard_steps/PrerequisitiesCheck.vue
@@ -41,12 +41,12 @@
             </n-button>
           </div>
           <div v-else class="manual-install" data-id="manual-install-section">
-            <p class="hint" data-id="manual-install-hint">Please install these components and run the check again:
+            <p class="hint" data-id="manual-install-hint">Please install the prerequisites and run the check again.
             </p>
           </div>
         </div>
       </div>
-      <div v-else>
+      <div v-if="missing_prerequisities.length > 0 || !did_the_check_run">
         <n-button @click="check_prerequisites" type="error" :loading="loading" data-id="check-prerequisites-button">
           {{ loading ? 'Checking...' : 'Check Prerequisites' }}
         </n-button>


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

The button to recheck prerequisites on posix system was missing

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
