### PR TITLE
EIM-194 add eim path to eim_ide.json

### DIFF
--- a/src-tauri/src/lib/idf_config.rs
+++ b/src-tauri/src/lib/idf_config.rs
@@ -235,6 +235,8 @@ mod tests {
     use std::fs;
     use tempfile::tempdir;
 
+
+
     fn create_test_config() -> IdfConfig {
         IdfConfig {
             git_path: String::from("/opt/homebrew/bin/git"),
@@ -390,4 +392,32 @@ mod tests {
 
         Ok(())
     }
+
+  #[test]
+  fn test_eim_path_auto_set() -> Result<()> {
+      let dir = tempdir()?;
+      let config_path = dir.path().join("eim_path_test_config.json");
+      let mut config = create_test_config();
+
+      // Ensure eim_path is None
+      config.eim_path = None;
+
+      // Save config to file
+      config.to_file(&config_path, true, false)?;
+
+      // Read the config back
+      let read_config = IdfConfig::from_file(&config_path)?;
+
+      // Check that eim_path is now set to the current executable path
+      assert!(read_config.eim_path.is_some());
+
+      // Get current executable path to compare
+      let current_exe = env::current_exe()?;
+      let current_exe_str = current_exe.to_str().unwrap();
+
+      // Compare paths
+      assert_eq!(read_config.eim_path.unwrap(), current_exe_str);
+
+      Ok(())
+  }
 }

--- a/src-tauri/src/lib/settings.rs
+++ b/src-tauri/src/lib/settings.rs
@@ -377,6 +377,7 @@ impl Settings {
                 .map(|install| install.id.clone())
                 .unwrap_or_default(),
             idf_installed: idf_installations,
+            eim_path: None, // this will be autofilled on file save
         };
 
         let json_path =


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description
this adds the field eim_path to eim_ide.json this is breaking change as old version of eim will not parse new format of the file.

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR !does! introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
