### PR TITLE
EIM-208 quoted the strings when creating venv, so they can now contain whitespace characters

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1402,6 +1402,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha2",
+ "shlex",
  "struct_iterable",
  "tar",
  "tauri",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -68,6 +68,7 @@ rustpython-vm = { git = "https://github.com/Hahihula/RustPython.git", branch = "
 rustpython-stdlib = { git = "https://github.com/Hahihula/RustPython.git", branch = "test-rust-build", features = ["ssl-vendor"], optional = true }
 struct_iterable = "0.1.1"
 regex = "1.11.1"
+shlex = "1.3.0"
 
 
 # OS-specific dependency

--- a/src-tauri/src/lib/python_utils.rs
+++ b/src-tauri/src/lib/python_utils.rs
@@ -281,18 +281,11 @@ pub fn pip_install_requirements(
     match std::env::consts::OS {
         "windows" => {
             match command_executor::execute_command_with_env(
-                "powershell",
+                python_location.to_str().unwrap(),
                 &vec![
-                    "-Command",
-                    python_location.to_str().unwrap(),
-                    "-m",
-                    "pip",
-                    "install",
-                    "-r",
+                    "-m", "pip", "install", "-r",
                     requirements_file.to_str().unwrap(),
-                    "--upgrade",
-                    "--constraint",
-                    constrain_path,
+                    "--upgrade", "--constraint", constrain_path
                 ],
                 vec![("VIRTUAL_ENV", venv_path.to_str().unwrap())],
             ) {
@@ -316,9 +309,9 @@ pub fn pip_install_requirements(
                     "-c",
                     &format!(
                         "{} -m pip install -r {} --upgrade --constraint {}",
-                        python_location.to_str().unwrap(),
-                        requirements_file.to_str().unwrap(),
-                        constrain_path
+                        shlex::quote(python_location.to_str().unwrap()),
+                        shlex::quote(requirements_file.to_str().unwrap()),
+                        shlex::quote(constrain_path)
                     ),
                 ],
                 vec![("VIRTUAL_ENV", venv_path.to_str().unwrap())],


### PR DESCRIPTION
works on macos -> installed idf and build hello_world
works on windows -> installed idf and build hello_world