### PR TITLE
EIM-193 tools download refactoring

### DIFF
--- a/src-tauri/locales/app.yml
+++ b/src-tauri/locales/app.yml
@@ -138,7 +138,7 @@ wizard.idf_path_exists.prompt:
   en: The path already exists. Do you want to proceed with installation without redownloading IDF?
   cn: 该路径已存在。是​​否要继续安装而不重新下载 IDF?
 wizard.tools_download.progress:
-  en: Downloading tools
+  en: Downloading tools to
   cn: 下载工具
 wizard.tool_download.progress:
   en: Downloading tool

--- a/src-tauri/src/lib/mod.rs
+++ b/src-tauri/src/lib/mod.rs
@@ -588,7 +588,11 @@ fn get_openocd_scripts_folder(idf_tools_path: &PathBuf) -> Result<String, std::i
 }
 
 pub enum DownloadProgress {
+    Start(String),
     Progress(u64, u64), // (downloaded, total)
+    Downloaded(String),
+    Verified(String),
+    Extracted(String),
     Complete,
     Error(String),
 }

--- a/src-tauri/src/lib/system_dependencies.rs
+++ b/src-tauri/src/lib/system_dependencies.rs
@@ -645,7 +645,7 @@ pub fn copy_openocd_rules(tools_path: &str) -> Result<()> {
   })?;
   fs::copy(openocd_rules_source, openocd_rules_path).with_context(|| {
     format!(
-      "Failed to copy {} to {}",
+      "Failed to copy {} to {} . Make sure you have the necessary permissions. Now you can copy it manually.",
       openocd_rules_source,
       openocd_rules_path.display()
     )


### PR DESCRIPTION
After initial refactoring the tools installation was unified between cli and gui and logic moved to library
the tools installations are now contained in a subfolder named after tool version
globally installed tools are not installed again