### PR TITLE
Eim 222 prerequisities on fedora

### DIFF
--- a/docs/src/cli_commands.md
+++ b/docs/src/cli_commands.md
@@ -60,6 +60,7 @@ Options:
 - `--config-file-save-path <CONFIG_FILE_SAVE_PATH>`: Path to save the configuration file
 - `--idf-features <IDF_FEATURES>`: Comma-separated list of additional IDF features (ci, docs, pytests, etc.) to be installed with ESP-IDF
 - `--repo-stub <REPO_STUB>`: Custom repository stub to use instead of the default ESP-IDF repository. Allows using custom IDF repositories
+- `--skip-prerequisites-check`: Skip prerequisites check. This is useful if you are sure that all prerequisites are already installed and you want to skip the check. This is not recommended unless you know what you are doing. This can produce installation which will not work or kill your kittens. use at your own risk.
 
 ### Wizard Command
 

--- a/src-tauri/src/cli/cli_args.rs
+++ b/src-tauri/src/cli/cli_args.rs
@@ -208,6 +208,12 @@ pub struct InstallArgs {
         help = "Repo stub to be used in case you want to use a custom repository. This is the 'espressif/esp-idf' part of the repository URL."
     )]
     pub repo_stub: Option<String>,
+
+    #[arg(
+        long,
+        help = "Skip prerequisites check. This is useful if you are sure that all prerequisites are already installed and you want to skip the check. This is not recommended unless you know what you are doing, as it can result in a non-functional installation. Use at your own risk.",
+    )]
+    pub skip_prerequisites_check: Option<bool>,
 }
 
 impl IntoIterator for InstallArgs {
@@ -287,6 +293,10 @@ impl IntoIterator for InstallArgs {
             (
                 "repo_stub".to_string(),
                 self.repo_stub.map(Into::into),
+            ),
+            (
+                "skip_prerequisites_check".to_string(),
+                self.skip_prerequisites_check.map(Into::into),
             ),
         ]
         .into_iter()

--- a/src-tauri/src/cli/wizard.rs
+++ b/src-tauri/src/cli/wizard.rs
@@ -309,11 +309,16 @@ async fn download_and_extract_tools(
 pub async fn run_wizzard_run(mut config: Settings) -> Result<(), String> {
     debug!("Config entering wizard: {:?}", config);
 
-    // Check prerequisites
-    check_and_install_prerequisites(
-        config.non_interactive.unwrap_or_default(),
-        config.install_all_prerequisites.unwrap_or_default(),
-    )?;
+    if config.skip_prerequisites_check.unwrap_or(false) {
+        info!("Skipping prerequisites check as per user request.");
+    } else {
+       // Check prerequisites
+      check_and_install_prerequisites(
+          config.non_interactive.unwrap_or_default(),
+          config.install_all_prerequisites.unwrap_or_default(),
+      )?;
+    }
+
 
     // Python sanity check
     check_and_install_python(

--- a/src-tauri/src/lib/settings.rs
+++ b/src-tauri/src/lib/settings.rs
@@ -42,6 +42,7 @@ pub struct Settings {
     pub install_all_prerequisites: Option<bool>,
     pub idf_features: Option<Vec<String>>,
     pub repo_stub: Option<String>,
+    pub skip_prerequisites_check: Option<bool>,
 }
 
 impl Default for Settings {
@@ -94,6 +95,7 @@ impl Default for Settings {
             install_all_prerequisites: Some(false),
             idf_features: None,
             repo_stub: None,
+            skip_prerequisites_check: Some(false),
         }
     }
 }
@@ -216,6 +218,11 @@ impl Settings {
             }
             if cli_settings_struct.repo_stub.is_some() && !cli_settings_struct.is_default("repo_stub") {
                 settings.repo_stub = cli_settings_struct.repo_stub.clone();
+            }
+            if cli_settings_struct.skip_prerequisites_check.is_some()
+                && !cli_settings_struct.is_default("skip_prerequisites_check")
+            {
+                settings.skip_prerequisites_check = cli_settings_struct.skip_prerequisites_check;
             }
         }
 


### PR DESCRIPTION
This makes checking for prerequisites on Linux more robust and also provides a workaround for #133, but it's not yet a fully fledged, proper solution for Fedora.
The prerequisities identification still failes on libffi-dev, libusb-1.0.0 and libssl-dev 
but if coresponding rhel libraries are installed, the check can now be skipped with 
```
./eim install --skip-prerequisites-check true
```
this way the project can be build, did not test the flashing


with the last commit the prerequisities detection works as expected. Problem should be solved