### PR TITLE
Eim 239 fix path handling

### DIFF
--- a/src-tauri/src/cli/cli_args.rs
+++ b/src-tauri/src/cli/cli_args.rs
@@ -1,5 +1,6 @@
 use clap::builder::styling::{AnsiColor, Color, Style, Styles};
 use clap::{arg, command, ColorChoice, Parser, Subcommand};
+use idf_im_lib::to_absolute_path;
 use std::path::PathBuf;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -102,7 +103,10 @@ pub struct InstallArgs {
     #[arg(
         short,
         long,
-        help = "Base Path to which all the files and folder will be installed"
+        help = "Base Path to which all the files and folder will be installed",
+        value_parser = |s: &str| -> Result<String, String> {
+            to_absolute_path(s).map_err(|e| e.to_string())
+        }
     )]
     path: Option<String>,
 

--- a/src-tauri/src/cli/wizard.rs
+++ b/src-tauri/src/cli/wizard.rs
@@ -338,7 +338,6 @@ pub async fn run_wizzard_run(mut config: Settings) -> Result<(), String> {
     let mut using_existing_idf = false;
     for mut idf_version in config.idf_versions.clone().unwrap() {
       let mut version_instalation_path = config.path.clone().unwrap();
-      version_instalation_path = idf_im_lib::expand_tilde(version_instalation_path.as_path());
       let mut idf_path = version_instalation_path.clone();
 
       if is_valid_idf_directory(idf_path.to_str().unwrap()) {

--- a/src-tauri/src/gui/commands/installation.rs
+++ b/src-tauri/src/gui/commands/installation.rs
@@ -38,8 +38,7 @@ fn prepare_installation_directories(
   settings: &Settings,
   version: &str,
 ) -> Result<PathBuf, Box<dyn std::error::Error>> {
-  let mut version_path = settings.path.as_ref().unwrap().as_path();
-  version_path.join(version);
+  let version_path = settings.path.as_ref().unwrap().as_path().join(version);
 
   ensure_path(version_path.to_str().unwrap())?;
   send_message(
@@ -51,7 +50,7 @@ fn prepare_installation_directories(
       "info".to_string(),
   );
 
-  Ok(version_path.to_path_buf())
+  Ok(version_path)
 }
 
 /// Spawns a progress monitor thread for installation
@@ -143,7 +142,7 @@ async fn install_single_version(
   let mut using_existing_idf = false;
 
   let p = settings.path.as_ref().unwrap().as_path();
-  let mut idf_path;
+  let idf_path;
   let mut version_path = PathBuf::from(p.clone());
   let mut version = version.clone();
   let mut idf_path_buf = PathBuf::new();
@@ -165,9 +164,10 @@ async fn install_single_version(
     };
 
     debug!("Using IDF version: {}", version);
+    idf_path_buf = idf_path.to_path_buf();
   } else {
     version_path = prepare_installation_directories(&app_handle.clone(), settings, &version)?;
-    idf_path_buf = version_path.clone().join("esp-idf").to_path_buf();
+    idf_path_buf = version_path.clone().join("esp-idf");
     idf_path = idf_path_buf.as_path();
     download_idf(&app_handle, settings, &version, &idf_path_buf).await?;
   }

--- a/src-tauri/src/gui/mod.rs
+++ b/src-tauri/src/gui/mod.rs
@@ -37,8 +37,7 @@ fn prepare_installation_directories(
     settings: &Settings,
     version: &str,
 ) -> Result<PathBuf, Box<dyn std::error::Error>> {
-    let mut version_path = settings.path.as_ref().unwrap().as_path();
-    version_path.join(version);
+    let version_path = settings.path.as_ref().unwrap().as_path().join(version);
 
     ensure_path(version_path.to_str().unwrap())?;
     send_message(
@@ -50,7 +49,7 @@ fn prepare_installation_directories(
         "info".to_string(),
     );
 
-    Ok(version_path.to_path_buf())
+    Ok(version_path)
 }
 
 async fn download_idf(

--- a/src-tauri/src/gui/mod.rs
+++ b/src-tauri/src/gui/mod.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 #[cfg(target_os = "linux")]
 use fork::{daemon, Fork};
 use idf_im_lib::{
-    add_path_to_path, ensure_path, expand_tilde,
+    add_path_to_path, ensure_path,
     settings::Settings,
     ProgressMessage,
 };
@@ -37,8 +37,8 @@ fn prepare_installation_directories(
     settings: &Settings,
     version: &str,
 ) -> Result<PathBuf, Box<dyn std::error::Error>> {
-    let mut version_path = expand_tilde(settings.path.as_ref().unwrap().as_path());
-    version_path.push(version);
+    let mut version_path = settings.path.as_ref().unwrap().as_path();
+    version_path.join(version);
 
     ensure_path(version_path.to_str().unwrap())?;
     send_message(
@@ -50,7 +50,7 @@ fn prepare_installation_directories(
         "info".to_string(),
     );
 
-    Ok(version_path)
+    Ok(version_path.to_path_buf())
 }
 
 async fn download_idf(

--- a/src-tauri/src/lib/mod.rs
+++ b/src-tauri/src/lib/mod.rs
@@ -1445,6 +1445,22 @@ pub fn expand_tilde(path: &Path) -> PathBuf {
     }
 }
 
+/// Converts a relative or absolute path to an absolute path.
+//////
+/// This function takes a string representing a path and returns a `PathBuf`
+/// representing the absolute path. If the input path is already absolute, it will return it as is.
+/// If the input path is relative, it will resolve it against the current working directory.
+////// # Parameters
+/// * `path`: A string slice representing the path to be converted.
+////// # Return Value
+/// * `Ok(String)` if the conversion is successful.
+/// * `Err(Box<dyn std::error::Error>)` if an error occurs during the conversion, such as if the path does not exist or cannot be resolved.
+pub fn to_absolute_path(path: &str) -> Result<String, Box<dyn std::error::Error>> {
+    let path = Path::new(path);
+    let absolute_path = fs::canonicalize(path)?;
+    Ok(absolute_path.to_string_lossy().to_string().into())
+}
+
 /// Performs post-installation tasks for a single version of ESP-IDF.
 ///
 /// This function creates a desktop shortcut on Windows systems and generates an activation shell script


### PR DESCRIPTION
In some cases, when user user `~` or `.` as path it could lead to some errors, now the path should be expanded to absolute on the application boundary, which should make the path handling more resilient. 