### PR TITLE
Eim 237 add name param

### DIFF
--- a/docs/src/cli_commands.md
+++ b/docs/src/cli_commands.md
@@ -61,6 +61,7 @@ Options:
 - `--idf-features <IDF_FEATURES>`: Comma-separated list of additional IDF features (ci, docs, pytests, etc.) to be installed with ESP-IDF
 - `--repo-stub <REPO_STUB>`: Custom repository stub to use instead of the default ESP-IDF repository. Allows using custom IDF repositories
 - `--skip-prerequisites-check`: Skip prerequisites check. This is useful if you are sure that all prerequisites are already installed and you want to skip the check. This is not recommended unless you know what you are doing. This can produce installation which will not work or kill your kittens. use at your own risk.
+- `--version-name`: Version name to be used for the installation. If not provided, the version will be derived from the ESP-IDF repository tag or commit hash.
 
 ### Wizard Command
 

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -44,6 +44,7 @@ The installer uses TOML format for configuration files. Here is an example:
 
 ```toml
 path = "/Users/Username/.espressif"
+idf_path = "/tmp/esp-new/pepajedenakole/esp-idf"
 esp_idf_json_path = "/Users/Username/.espressif/tools"
 tool_download_folder_name = "dist"
 tool_install_folder_name = "tools"
@@ -58,6 +59,8 @@ mirror = "https://github.com"
 idf_mirror = "https://github.com"
 recurse_submodules = false
 install_all_prerequisites = false
+skip_prerequisites_check = false
+version_name = "someversionname"
 ```
 
 After completing installation through either the GUI wizard or CLI, you have the option to save your configuration for future use. This saved configuration can be shared with other users to replicate the same installation setup.

--- a/docs/src/faq.md
+++ b/docs/src/faq.md
@@ -10,7 +10,14 @@
 No, the installer does not require elevated rights and should **not** be run as an administrator. Running the installer with admin privileges is unnecessary and could lead to unintended permission issues.
 
 ### Can I use an existing ESP-IDF Git repository with EIM?
-Yes, EIM is designed to work with existing ESP-IDF Git repositories on your filesystem. During the installation process (both GUI and CLI), when prompted for the installation path, you can specify the path to your existing ESP-IDF repository.
+Yes, simply run:
+```bash
+eim install -p PATH_TO_REPO
+```
+where PATH_TO_REPO is path to your IDF git repository on your local machine.
+
+
+EIM is designed to work with existing ESP-IDF Git repositories on your filesystem. During the installation process (both GUI and CLI), when prompted for the installation path, you can specify the path to your existing ESP-IDF repository.
 
 If EIM detects a valid ESP-IDF Git repository at the selected path, it will:
 - **Utilize that existing repository**: It will not download a new copy or overwrite your existing files.
@@ -42,7 +49,7 @@ You can either:
 ### What if I want to install a specific version of IDF that is not listed?
 You can install any tagged version of ESP-IDF using the `-i` or `--idf-version` flag:
 ```bash
-eim -i v4.4.1
+eim install -i v4.4.1
 ```
 
 ### I am getting the error `/lib64/libm.so.6: version 'GLIBC_2.38' not found`. What should I do?

--- a/src-tauri/bash_scripts/activate_idf_template.sh
+++ b/src-tauri/bash_scripts/activate_idf_template.sh
@@ -44,7 +44,7 @@ parse_cmake_version() {
 }
 
 IDF_VERSION=$(parse_cmake_version)
-
+ENV_VAR_PAIRS=$(get_env_var_pairs)
 
 # Function to print environment variables
 print_env_variables() {
@@ -96,22 +96,28 @@ activate_venv() {
     fi
 }
 
-# Handle command line arguments
+# Check if the script is being sourced or executed
+is_sourced() {
+  if [ -n "$ZSH_VERSION" ]; then
+      case $ZSH_EVAL_CONTEXT in *:file:*) return 0;; esac
+  else  # Add additional POSIX-compatible shell names here, if needed.
+      case ${0##*/} in dash|-dash|bash|-bash|ksh|-ksh|sh|-sh) return 0;; esac
+  fi
+  return 1  # NOT sourced.
+}
+
+# Sample call.
+is_sourced && sourced=1 || sourced=0
+
 if [ "$1" = "-e" ]; then
     print_env_variables
     exit 0
-fi
-
-sourced=0
-(return 0 2>/dev/null) || sourced=1
-
-if [ "$sourced" -eq 0 ]; then
-    : # Do nothing, continue with script this due to different shell compatibility
 else
-    printf '%s\n' "This script should be sourced, not executed."
-    printf '%s\n' "Usage: source $0 or . $0"
-    printf '%s\n' "If you want to print environment variables, run it with the -e parameter."
-    exit 1
+    if [ "$sourced" -eq 0 ]; then
+        echo "This script should be sourced, not executed."
+        echo "If you want to print environment variables, run it with the -e parameter."
+        exit 1
+    fi
 fi
 
 alias idf.py="{{idf_python_env_path_escaped}}/bin/python3 {{idf_path_escaped}}/tools/idf.py"

--- a/src-tauri/bash_scripts/activate_idf_template.sh
+++ b/src-tauri/bash_scripts/activate_idf_template.sh
@@ -79,7 +79,7 @@ add_env_variable() {
 
 # Function to add a directory to the system PATH
 add_to_path() {
-    export PATH="$PATH:{{addition_to_path}}"
+    export PATH="{{addition_to_path}}:$PATH"
     printf '%s\n' "Added proper directory to PATH"
 }
 
@@ -102,12 +102,10 @@ if [ "$1" = "-e" ]; then
     exit 0
 fi
 
-is_sourced() {
-    # Check if we can return from the script (only works when sourced)
-    (return 0 2>/dev/null) && return 0 || return 1
-}
+sourced=0
+(return 0 2>/dev/null) || sourced=1
 
-if is_sourced; then
+if [ "$sourced" -eq 0 ]; then
     : # Do nothing, continue with script this due to different shell compatibility
 else
     printf '%s\n' "This script should be sourced, not executed."

--- a/src-tauri/bash_scripts/activate_idf_template.sh
+++ b/src-tauri/bash_scripts/activate_idf_template.sh
@@ -1,9 +1,9 @@
-#!/bin/bash
+#!/bin/sh
 
 {{env_var_pairs}}
 
 parse_cmake_version() {
-    local cmake_file="{{idf_path_escaped}}/tools/cmake/version.cmake"
+    cmake_file="{{idf_path_escaped}}/tools/cmake/version.cmake"
 
     # Check if file exists
     if [ ! -f "$cmake_file" ]; then
@@ -11,20 +11,25 @@ parse_cmake_version() {
         return 1
     fi
 
-    local major=""
-    local minor=""
+    major=""
+    minor=""
 
-    # Read the file and extract version numbers
-    while IFS= read -r line; do
-        line=$(echo "$line" | sed 's/^[[:space:]]*//') # trim leading whitespace
+    # Read the file and extract version numbers using POSIX tools
+    while IFS= read -r line || [ -n "$line" ]; do
+        # Trim leading whitespace using parameter expansion
+        line=$(printf '%s\n' "$line" | sed 's/^[[:space:]]*//')
 
-        if [[ "$line" =~ ^set\(IDF_VERSION_MAJOR ]]; then
-            # Extract first number from the line
-            major=$(echo "$line" | grep -o '[0-9]\+' | head -1)
-        elif [[ "$line" =~ ^set\(IDF_VERSION_MINOR ]]; then
-            # Extract first number from the line
-            minor=$(echo "$line" | grep -o '[0-9]\+' | head -1)
-        fi
+        # Check for version lines using case statement (POSIX compatible)
+        case "$line" in
+            "set(IDF_VERSION_MAJOR "*)
+                # Extract number using sed
+                major=$(printf '%s\n' "$line" | sed 's/.*set(IDF_VERSION_MAJOR[[:space:]]*\([0-9]*\).*/\1/')
+                ;;
+            "set(IDF_VERSION_MINOR "*)
+                # Extract number using sed
+                minor=$(printf '%s\n' "$line" | sed 's/.*set(IDF_VERSION_MINOR[[:space:]]*\([0-9]*\).*/\1/')
+                ;;
+        esac
     done < "$cmake_file"
 
     # Check if both versions were found
@@ -33,69 +38,82 @@ parse_cmake_version() {
         return 1
     fi
 
-    # Return the version (you can modify format as needed)
-    echo "${major}.${minor}"
+    # Return the version
+    printf '%s.%s\n' "$major" "$minor"
     return 0
 }
 
-IDF_VERSION=$(parse_cmake_version "{{idf_path_escaped}}")
+IDF_VERSION=$(parse_cmake_version)
 
 
 # Function to print environment variables
 print_env_variables() {
-    echo "PATH={{addition_to_path}}"
-    echo "SYSTEM_PATH={{current_system_path}}"
-    echo "ESP_IDF_VERSION=$IDF_VERSION"
-    for pair in "${env_var_pairs[@]}"; do
-        key="${pair%%:*}"
-        value="${pair#*:}"
-        echo "$key=$value"
+    printf '%s\n' "PATH={{addition_to_path}}"
+    printf '%s\n' "SYSTEM_PATH={{current_system_path}}"
+    printf '%s\n' "ESP_IDF_VERSION=$IDF_VERSION"
+
+    # Process environment variables
+    printf '%s\n' "$ENV_VAR_PAIRS" | while read -r pair; do
+        if [ -n "$pair" ]; then
+            key="${pair%%:*}"
+            value="${pair#*:}"
+            printf '%s=%s\n' "$key" "$value"
+        fi
     done
 }
 
-# Function to add an environment variable
 add_env_variable() {
     export ESP_IDF_VERSION="$IDF_VERSION"
-    echo "Added environment variable ESP_IDF_VERSION = $ESP_IDF_VERSION"
-    for pair in "${env_var_pairs[@]}"; do
-        key="${pair%%:*}"
-        value="${pair#*:}"
-        export "${key}=${value}"
-        echo "Added environment variable $key = $value"
-    done
+    printf '%s\n' "Added environment variable ESP_IDF_VERSION = $ESP_IDF_VERSION"
 
+    # Process environment variables
+    printf '%s\n' "$ENV_VAR_PAIRS" | while read -r pair; do
+        if [ -n "$pair" ]; then
+            key="${pair%%:*}"
+            value="${pair#*:}"
+            eval "export $key=\"$value\""
+            printf '%s\n' "Added environment variable $key = $value"
+        fi
+    done
 }
 
 # Function to add a directory to the system PATH
 add_to_path() {
     export PATH="$PATH:{{addition_to_path}}"
-    echo "Added proper directory to PATH"
+    printf '%s\n' "Added proper directory to PATH"
 }
 
-# Function to activate a Python virtual environment
+# Function to activate Python virtual environment
 activate_venv() {
-    VENV_PATH="$1"
-    if [ -f "${VENV_PATH}/bin/activate" ]; then
-        source "${VENV_PATH}/bin/activate"
-        echo "Activated virtual environment at ${VENV_PATH}"
+    venv_path="$1"
+    if [ -f "$venv_path/bin/activate" ]; then
+        # shellcheck disable=SC1090
+        . "$venv_path/bin/activate"
+        printf '%s\n' "Activated virtual environment at $venv_path"
     else
-        echo "Virtual environment not found at ${VENV_PATH}"
+        printf '%s\n' "Virtual environment not found at $venv_path"
         return 1
     fi
 }
 
-# Check if the script is being sourced or executed
-(return 0 2>/dev/null) && sourced=1 || sourced=0
-
+# Handle command line arguments
 if [ "$1" = "-e" ]; then
     print_env_variables
     exit 0
+fi
+
+is_sourced() {
+    # Check if we can return from the script (only works when sourced)
+    (return 0 2>/dev/null) && return 0 || return 1
+}
+
+if is_sourced; then
+    : # Do nothing, continue with script this due to different shell compatibility
 else
-    if [ "$sourced" -eq 0 ]; then
-        echo "This script should be sourced, not executed."
-        echo "If you want to print environment variables, run it with the -e parameter."
-        exit 1
-    fi
+    printf '%s\n' "This script should be sourced, not executed."
+    printf '%s\n' "Usage: source $0 or . $0"
+    printf '%s\n' "If you want to print environment variables, run it with the -e parameter."
+    exit 1
 fi
 
 alias idf.py="{{idf_python_env_path_escaped}}/bin/python3 {{idf_path_escaped}}/tools/idf.py"
@@ -116,8 +134,9 @@ add_env_variable
 add_to_path
 
 # Activate virtual environment (uncomment and provide the correct path)
-activate_venv "${IDF_PYTHON_ENV_PATH}"
+venv_default="{{idf_python_env_path_escaped}}"
+activate_venv "${IDF_PYTHON_ENV_PATH:-$venv_default}"
 
-echo "Environment setup complete for the current shell session."
-echo "These changes will be lost when you close this terminal."
-echo "You are now using IDF version $IDF_VERSION."
+printf '%s\n' "Environment setup complete for the current shell session."
+printf '%s\n' "These changes will be lost when you close this terminal."
+printf '%s\n' "You are now using IDF version $IDF_VERSION."

--- a/src-tauri/powershell_scripts/idf_tools_profile_template.ps1
+++ b/src-tauri/powershell_scripts/idf_tools_profile_template.ps1
@@ -79,7 +79,7 @@ $env_var_pairs.GetEnumerator() | ForEach-Object {
 }
 
 # Set system path
-$env:PATH += ";{{add_paths_extras}}"
+$env:PATH = "{{add_paths_extras}};$env:PATH"
 
 # Define the Invoke-idfpy function
 function global:Invoke-idfpy {

--- a/src-tauri/powershell_scripts/idf_tools_profile_template.ps1
+++ b/src-tauri/powershell_scripts/idf_tools_profile_template.ps1
@@ -5,11 +5,61 @@ param(
 
 {{env_var_pairs}}
 
+function Parse-CMakeVersion {
+
+    $cmakeFile = "{{idf_path}}\tools\cmake\version.cmake"
+
+    # Check if file exists
+    if (-not (Test-Path $cmakeFile)) {
+        Write-Error "CMake version file not found at: $cmakeFile"
+        return $null
+    }
+
+    $major = $null
+    $minor = $null
+
+    try {
+        # Read the file content
+        $content = Get-Content $cmakeFile -ErrorAction Stop
+
+        foreach ($line in $content) {
+            $line = $line.Trim()
+
+            if ($line -match '^set\(IDF_VERSION_MAJOR') {
+                # Extract first number from the line
+                if ($line -match '\d+') {
+                    $major = $matches[0]
+                }
+            }
+            elseif ($line -match '^set\(IDF_VERSION_MINOR') {
+                # Extract first number from the line
+                if ($line -match '\d+') {
+                    $minor = $matches[0]
+                }
+            }
+        }
+
+        # Check if both versions were found
+        if ($null -eq $major -or $null -eq $minor) {
+            Write-Error "Could not find both major and minor version numbers"
+            return $null
+        }
+
+        # Return the version
+        return "$major.$minor"
+    }
+    catch {
+        Write-Error "Failed to read CMake version file: $($_.Exception.Message)"
+        return $null
+    }
+}
+
+$IdfVersion = Parse-CMakeVersion
 
 # Function to print environment variables
 function Print-EnvVariables {
     "PATH={{add_paths_extras}}"
-    "ESP_IDF_VERSION={{idf_version}}"
+    "ESP_IDF_VERSION=$IdfVersion"
     "SYSTEM_PATH={{current_system_path}}"
     $env_var_pairs.GetEnumerator() | ForEach-Object {
         Write-Host "$($_.Key)=$($_.Value)"
@@ -23,7 +73,7 @@ if ($e) {
 }
 
 # Set environment variables
-$env:ESP_IDF_VERSION = "{{idf_version}}"
+$env:ESP_IDF_VERSION = "$IdfVersion"
 $env_var_pairs.GetEnumerator() | ForEach-Object {
     Set-Item -Path "env:$($_.Key)" -Value $_.Value
 }

--- a/src-tauri/src/cli/cli_args.rs
+++ b/src-tauri/src/cli/cli_args.rs
@@ -221,7 +221,7 @@ pub struct InstallArgs {
 
     #[arg(
         long,
-        help = "Version name to be used for the installation. If not provided, the version will be derived from the ESP-IDF repository tag or commit hash. If installing multiple versions at once, it will be used as prefix."
+        help = "Version name to be used for the installation. If not provided, the version will be derived from the ESP-IDF repository tag or commit hash."
     )]
     pub version_name: Option<String>,
 }

--- a/src-tauri/src/cli/cli_args.rs
+++ b/src-tauri/src/cli/cli_args.rs
@@ -218,6 +218,12 @@ pub struct InstallArgs {
         help = "Skip prerequisites check. This is useful if you are sure that all prerequisites are already installed and you want to skip the check. This is not recommended unless you know what you are doing, as it can result in a non-functional installation. Use at your own risk.",
     )]
     pub skip_prerequisites_check: Option<bool>,
+
+    #[arg(
+        long,
+        help = "Version name to be used for the installation. If not provided, the version will be derived from the ESP-IDF repository tag or commit hash. If installing multiple versions at once, it will be used as prefix."
+    )]
+    pub version_name: Option<String>,
 }
 
 impl IntoIterator for InstallArgs {
@@ -301,6 +307,10 @@ impl IntoIterator for InstallArgs {
             (
                 "skip_prerequisites_check".to_string(),
                 self.skip_prerequisites_check.map(Into::into),
+            ),
+            (
+                "version_name".to_string(),
+                self.version_name.map(Into::into),
             ),
         ]
         .into_iter()

--- a/src-tauri/src/lib/idf_tools.rs
+++ b/src-tauri/src/lib/idf_tools.rs
@@ -123,6 +123,7 @@ pub fn apply_platform_overrides(mut tools_file: ToolsFile, platform: &str) -> To
         if let Some(platform_overrides) = &tool.platform_overrides {
             for override_entry in platform_overrides {
                 if override_entry.platforms.contains(&platform.to_string()) {
+                    debug!("Applying platform override for tool: {} on platform: {}", tool.name, platform);
                     if let Some(install) = &override_entry.install {
                         tool.install = install.clone();
                     }
@@ -132,6 +133,8 @@ pub fn apply_platform_overrides(mut tools_file: ToolsFile, platform: &str) -> To
                     }
 
                     break; // Apply only the first matching override
+                } else {
+                    debug!("No matching platform override for tool: {} on platform: {}", tool.name, platform);
                 }
             }
         }

--- a/src-tauri/src/lib/idf_tools.rs
+++ b/src-tauri/src/lib/idf_tools.rs
@@ -1,4 +1,4 @@
-use log::debug;
+use log::{debug, trace};
 use regex::Regex;
 use serde::{de, Deserialize};
 use std::collections::{HashMap, HashSet};
@@ -775,6 +775,7 @@ pub fn verify_tool_installation(tool_name: &str, tools_file: &ToolsFile, install
         .ok_or(format!("No version found for tool '{}'", tool_name)).map_err(|e| anyhow!(e))?;
 
     // adding to PATH the directory where the tool is(or will be) installed
+    debug!("Checking tool: {}, expected version: {} and install dir: {}", tool_name, expected_version.name, install_dir.display());
     let mut expected_dir = install_dir.join(&tool_name).join(expected_version.clone().name);
     for ex_path in &tool.export_paths {
         for level in ex_path {
@@ -804,19 +805,55 @@ pub fn verify_tool_installation(tool_name: &str, tools_file: &ToolsFile, install
             tmp_path = format!("{}:{}", expected_dir.to_str().unwrap(), tmp_path);
         }
     }
+
     // Execute the version command
-    let args = match tool.version_cmd.get(1) {
+    // first try exactly expected binary
+    let output = {
+      let tool_name = &tool.version_cmd[0];
+      let args = match tool.version_cmd.get(1) {
         Some(arg) => vec![arg.as_str()],
         None => vec![],
-    };
-    let output = match execute_command_with_env(
-        &tool.version_cmd[0],
-        &args,
-        vec![("PATH", tmp_path.as_str())]
-    ) {
-        Ok(output) => output,
-        Err(_) => return Ok(ToolStatus::Missing),
-    };
+      };
+      let env = vec![("PATH", tmp_path.as_str())];
+
+      // Try 1: Exact tool path
+      let exact_tool_path = expected_dir.join(tool_name);
+      if exact_tool_path.try_exists().unwrap_or(false) {
+          log::debug!("Found exact tool at: {}", exact_tool_path.display());
+          if let Ok(output) = execute_command_with_env(&exact_tool_path.to_string_lossy(), &args, env.clone()) {
+              output
+          } else {
+              return Ok(ToolStatus::Missing);
+          }
+      }
+      // Try 2: Windows .exe extension
+      else if std::env::consts::OS == "windows" {
+          let exact_tool_path_exe = expected_dir.join(format!("{}.exe", tool_name));
+          if exact_tool_path_exe.try_exists().unwrap_or(false) {
+              log::debug!("Found exact tool at: {}", exact_tool_path_exe.display());
+              if let Ok(output) = execute_command_with_env(&exact_tool_path_exe.to_string_lossy(), &args, env.clone()) {
+                  output
+              } else {
+                  return Ok(ToolStatus::Missing);
+              }
+          } else {
+              // Try 3: Fallback to PATH
+              log::debug!("Exact tool not found at path: {}, falling back to version command", exact_tool_path.display());
+              match execute_command_with_env(tool_name, &args, env) {
+                  Ok(output) => output,
+                  Err(_) => return Ok(ToolStatus::Missing),
+              }
+          }
+      }
+      // Try 3: Non-Windows fallback to PATH
+      else {
+          log::debug!("Exact tool not found at path: {}, falling back to version command", exact_tool_path.display());
+          match execute_command_with_env(tool_name, &args, env) {
+              Ok(output) => output,
+              Err(_) => return Ok(ToolStatus::Missing),
+          }
+      }
+  };
 
     // Convert output to string
     let output_str = String::from_utf8_lossy(&output.stdout);

--- a/src-tauri/src/lib/mod.rs
+++ b/src-tauri/src/lib/mod.rs
@@ -753,7 +753,6 @@ pub fn decompress_archive(
     match result {
         Ok(_) => {
             log::info!("Decompression completed successfully.");
-            move_contents_folder_up(destination_path)?;
             Ok(())
         }
         Err(e) => match e {
@@ -984,6 +983,8 @@ fn move_contents_folder_up(destination_path: &Path) -> Result<(), DecompressionE
 
             std::fs::remove_dir(&temp_dir)?;
         }
+    } else {
+      log::debug!("No single subdirectory found in {}", destination_path.display());
     }
 
     Ok(())

--- a/src-tauri/src/lib/mod.rs
+++ b/src-tauri/src/lib/mod.rs
@@ -82,7 +82,11 @@ fn format_bash_env_pairs(pairs: &[(String, String)]) -> String {
         .map(|(key, value)| format!("    \"{}:{}\"", key, value))
         .collect();
 
-    format!("env_var_pairs=(\n{}\n)", formatted_pairs.join("\n"))
+    format!("get_env_var_pairs() {{
+cat << 'EOF'
+{}
+EOF
+}}", formatted_pairs.join("\n"))
 }
 
 /// Formats a vector of key-value pairs into a PowerShell-compatible format for environment variables.

--- a/src-tauri/src/lib/settings.rs
+++ b/src-tauri/src/lib/settings.rs
@@ -458,10 +458,7 @@ impl Settings {
       let tool_download_directory = version_installation_path.join(tool_download_folder);
       let tool_install_directory = version_installation_path.join(tool_install_folder);
 
-      let python_venv_path = match std::env::consts::OS {
-        "windows" => tool_install_directory.join("python").join(&actual_version).join("venv"),
-        _ => tool_install_directory.join("python").join(&actual_version).join("venv"),
-      };
+      let python_venv_path = tool_install_directory.join("python").join(&actual_version).join("venv");
 
       let python_path = match std::env::consts::OS {
         "windows" => python_venv_path.join("Scripts").join("python.exe"),


### PR DESCRIPTION
This PR add the 'version_name' param:
```
--version-name <VERSION_NAME>
          Version name to be used for the installation. If not provided, the version will be derived from the ESP-IDF repository tag or commit hash.
```
This is mostly useful for the cases when user uses own preexisting esp-idf repository...

Because of the changes needed in activation script, the activation script now reads the version from CMAKE and is compatible with DASH and FISH shell

tested on MacOs & Windows

rebased on top of master