### PR TITLE
invalidation of cache on s3 dl page

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -613,3 +613,4 @@ jobs:
           curl -s https://api.github.com/repos/espressif/idf-im-ui/releases/latest > eim_unified_release.json
           echo "Latest GUI release tag: $(jq -r .tag_name eim_unified_release.json)"
           aws s3 cp --acl=public-read "eim_unified_release.json" s3://espdldata/dl/eim/eim_unified_release.json
+          aws cloudfront create-invalidation --distribution-id ${DL_DISTRIBUTION_ID} --paths "/dl/eim/eim_unified_release.json"


### PR DESCRIPTION
this adds cache invalidation on the s3 bucket so after we do the release it will be avalible as soon as possible

it's working now... tested https://github.com/espressif/idf-im-ui/actions/runs/16443376987/job/46469160807
