### PR TITLE
Eim 281 broadening python support in offline installer

### DIFF
--- a/.github/workflows/build_offline_installer_archives.yaml
+++ b/.github/workflows/build_offline_installer_archives.yaml
@@ -23,6 +23,11 @@ on:
         description: "The run id from which to take binaries"
         required: true
         type: string
+      update_json:
+        description: "Update offline_archives.json in S3"
+        required: false
+        type: boolean
+        default: true
 
 jobs:
   build-offline-archives:
@@ -151,6 +156,7 @@ jobs:
   update-json:
     needs: build-offline-archives
     runs-on: ubuntu-latest
+    if: ${{ inputs.update_json }}
     steps:
       - name: Download all build info artifacts
         uses: actions/download-artifact@v4

--- a/src-tauri/src/lib/python_utils.rs
+++ b/src-tauri/src/lib/python_utils.rs
@@ -398,7 +398,7 @@ fn detect_python_version(python_executable: &str) -> Result<String, String> {
     }
 }
 
-/// Finds the appropriate wheel directory for the detected Python version from offline installation archive.
+/// Finds the appropriate wheel directory for the detected Python version
 ///
 /// # Arguments
 /// * `offline_archive_dir` - Base offline archive directory
@@ -407,15 +407,21 @@ fn detect_python_version(python_executable: &str) -> Result<String, String> {
 /// # Returns
 /// * `Option<PathBuf>` - Path to the appropriate wheel directory, or None if not found
 fn find_wheel_directory(offline_archive_dir: &Path, python_version: &str) -> Option<PathBuf> {
-    // Convert "3.11" to "py311" format
-    let version_suffix = python_version.replace('.', "");
-    let versioned_wheel_dir = offline_archive_dir.join(format!("wheels_{}", version_suffix));
+    // Try different naming formats
+    let possible_formats = vec![
+        format!("wheels_py{}", python_version.replace('.', "")),
+        format!("wheels_py{}", python_version.replace('.', "_")),
+        format!("wheels_py{}", python_version.replace(".", "_")),
+    ];
 
-    debug!("Looking for wheels in: {}", versioned_wheel_dir.display());
+    for format_name in possible_formats {
+        let versioned_wheel_dir = offline_archive_dir.join(&format_name);
+        debug!("Looking for wheels in: {}", versioned_wheel_dir.display());
 
-    if versioned_wheel_dir.exists() {
-        info!("Found Python {}-specific wheel directory: {}", python_version, versioned_wheel_dir.display());
-        return Some(versioned_wheel_dir);
+        if versioned_wheel_dir.exists() {
+            info!("Found Python {}-specific wheel directory: {}", python_version, versioned_wheel_dir.display());
+            return Some(versioned_wheel_dir);
+        }
     }
 
     // Fallback: try the old "wheels" directory for backward compatibility

--- a/src-tauri/src/lib/python_utils.rs
+++ b/src-tauri/src/lib/python_utils.rs
@@ -368,6 +368,82 @@ pub fn pip_install_requirements(
     }
 }
 
+/// Detects the Python version being used in the virtual environment
+///
+/// # Arguments
+/// * `python_executable` - Path to the Python executable
+///
+/// # Returns
+/// * `Result<String, String>` - Python version string (e.g., "3.11") or error
+fn detect_python_version(python_executable: &str) -> Result<String, String> {
+    use crate::command_executor::execute_command;
+
+    match execute_command(python_executable, &["--version"]) {
+        Ok(output) => {
+            if output.status.success() {
+                let version_output = String::from_utf8_lossy(&output.stdout);
+                // Parse "Python 3.11.x" to get "3.11"
+                if let Some(version_part) = version_output.split_whitespace().nth(1) {
+                    let version_parts: Vec<&str> = version_part.split('.').collect();
+                    if version_parts.len() >= 2 {
+                        return Ok(format!("{}.{}", version_parts[0], version_parts[1]));
+                    }
+                }
+                Err(format!("Could not parse Python version from: {}", version_output))
+            } else {
+                Err(format!("Failed to get Python version: {}", String::from_utf8_lossy(&output.stderr)))
+            }
+        }
+        Err(e) => Err(format!("Failed to execute Python version check: {}", e))
+    }
+}
+
+/// Finds the appropriate wheel directory for the detected Python version from offline installation archive.
+///
+/// # Arguments
+/// * `offline_archive_dir` - Base offline archive directory
+/// * `python_version` - Python version string (e.g., "3.11")
+///
+/// # Returns
+/// * `Option<PathBuf>` - Path to the appropriate wheel directory, or None if not found
+fn find_wheel_directory(offline_archive_dir: &Path, python_version: &str) -> Option<PathBuf> {
+    // Convert "3.11" to "py311" format
+    let version_suffix = python_version.replace('.', "");
+    let versioned_wheel_dir = offline_archive_dir.join(format!("wheels_{}", version_suffix));
+
+    debug!("Looking for wheels in: {}", versioned_wheel_dir.display());
+
+    if versioned_wheel_dir.exists() {
+        info!("Found Python {}-specific wheel directory: {}", python_version, versioned_wheel_dir.display());
+        return Some(versioned_wheel_dir);
+    }
+
+    // Fallback: try the old "wheels" directory for backward compatibility
+    let legacy_wheel_dir = offline_archive_dir.join("wheels");
+    if legacy_wheel_dir.exists() {
+        warn!("Using legacy wheel directory (may not be compatible): {}", legacy_wheel_dir.display());
+        return Some(legacy_wheel_dir);
+    }
+
+    // List available wheel directories for debugging
+    if let Ok(entries) = std::fs::read_dir(offline_archive_dir) {
+        let wheel_dirs: Vec<String> = entries
+            .filter_map(|entry| entry.ok())
+            .filter(|entry| {
+                entry.file_name().to_string_lossy().starts_with("wheels_")
+            })
+            .map(|entry| entry.file_name().to_string_lossy().to_string())
+            .collect();
+
+        if !wheel_dirs.is_empty() {
+            warn!("Available wheel directories: {:?}", wheel_dirs);
+            warn!("Could not find wheels for Python {}, you might need to rebuild the offline archive with this Python version", python_version);
+        }
+    }
+
+    None
+}
+
 /// Installs or updates the Python virtual environment for a specific ESP-IDF version.
 ///
 /// This asynchronous function orchestrates the creation of a Python virtual environment,
@@ -388,6 +464,8 @@ pub fn pip_install_requirements(
 /// * `features` - A slice of `String`s, where each string represents an additional
 ///   feature whose Python requirements should be installed (e.g., "esp_gh_action").
 ///   These correspond to files like `requirements_esp_gh_action.txt`.
+/// * `offline_archive_dir` - Optional path to offline archive directory containing
+///   pre-downloaded wheels and constraints files.
 ///
 /// # Returns
 ///
@@ -519,13 +597,32 @@ pub async fn install_python_env(
           }
       }
     };
-    //
-    // install the requirements from files
+
+    // Determine the appropriate wheel directory for offline mode
     let wheel_dir = if offline_mode {
-        Some(offline_archive_dir.unwrap().join("wheels"))
+        let archive_dir = offline_archive_dir.unwrap();
+
+        // Detect the Python version being used
+        let python_version = detect_python_version(&python_executable)
+            .map_err(|e| format!("Failed to detect Python version: {}", e))?;
+
+        info!("Detected Python version: {}", python_version);
+
+        // Find the appropriate wheel directory
+        match find_wheel_directory(archive_dir, &python_version) {
+            Some(wheel_path) => Some(wheel_path),
+            None => {
+                return Err(format!(
+                    "No compatible wheel directory found for Python {}. Available wheel directories should be named like 'wheels_py311', 'wheels_py312', etc.",
+                    python_version
+                ));
+            }
+        }
     } else {
         None
     };
+
+    // install the requirements from files
     for requirements_file in requirements_file_list {
         match pip_install_requirements(&venv_path, &requirements_file, &constraint_file, &wheel_dir) {
             Ok(_) => {

--- a/src-tauri/src/offline_installer_builder.rs
+++ b/src-tauri/src/offline_installer_builder.rs
@@ -12,7 +12,10 @@ use idf_im_lib::utils::parse_cmake_version;
 use idf_im_lib::verify_file_checksum;
 use idf_im_lib::ProgressMessage;
 use indicatif::{ProgressBar, ProgressState, ProgressStyle};
-use log::{debug, info, warn, error};
+use log::debug;
+use log::error;
+use log::info;
+use log::warn;
 use std::fmt::Write;
 use std::fs;
 use std::fs::File;
@@ -209,7 +212,7 @@ async fn download_wheels_for_python_versions(
 
         // Create version-specific directories
         let python_env = archive_dir.join(format!("python_env_{}", python_version.replace('.', "_")));
-        let wheel_dir = archive_dir.join(format!("wheels_py{}", python_version.replace('.', "_")));
+        let wheel_dir = archive_dir.join(format!("wheels_py{}", python_version.replace('.', "")));
 
         // Ensure directories exist
         ensure_path(python_env.to_str().unwrap())

--- a/src-tauri/src/offline_installer_builder.rs
+++ b/src-tauri/src/offline_installer_builder.rs
@@ -12,10 +12,7 @@ use idf_im_lib::utils::parse_cmake_version;
 use idf_im_lib::verify_file_checksum;
 use idf_im_lib::ProgressMessage;
 use indicatif::{ProgressBar, ProgressState, ProgressStyle};
-use log::debug;
-use log::error;
-use log::info;
-use log::warn;
+use log::{debug, info, warn, error};
 use std::fmt::Write;
 use std::fs;
 use std::fs::File;
@@ -36,6 +33,7 @@ use log4rs::encode::pattern::PatternEncoder;
 use idf_im_lib::get_log_directory;
 
 pub const PYTHON_VERSION: &str = "3.11";
+pub const SUPPORTED_PYTHON_VERSIONS: &[&str] = &["3.10", "3.11", "3.12", "3.13"];
 
 fn setup_logging(verbose: u8) -> anyhow::Result<()> {
     let log_file_name = get_log_directory()
@@ -165,6 +163,159 @@ pub fn merge_requirements_files(folder_path: &Path) -> Result<(), io::Error> {
     Ok(())
 }
 
+/// Downloads wheels for multiple Python versions
+///
+/// # Arguments
+/// * `archive_dir` - Base directory for the archive
+/// * `requirements_path` - Path to the requirements file
+/// * `constraint_file` - Path to the constraints file
+/// * `python_versions` - List of Python versions to download wheels for
+///
+/// # Returns
+/// `Result<(), String>` - Ok(()) on success, error message on failure
+async fn download_wheels_for_python_versions(
+    archive_dir: &Path,
+    requirements_path: &Path,
+    constraint_file: &Path,
+    python_versions: &[&str],
+) -> Result<(), String> {
+    info!("Downloading wheels for Python versions: {:?}", python_versions);
+
+    // First, ensure all Python versions are installed
+    for python_version in python_versions {
+        info!("Installing Python {}...", python_version);
+        match execute_command("uv", &["python", "install", python_version]) {
+            Ok(output) => {
+                if output.status.success() {
+                    info!("Python {} installed successfully.", python_version);
+                } else {
+                    warn!(
+                        "Python {} might already be installed or failed to install: {}",
+                        python_version,
+                        String::from_utf8_lossy(&output.stderr)
+                    );
+                    // Continue anyway, it might already be installed
+                }
+            }
+            Err(err) => {
+                error!("Failed to install Python {}: {}", python_version, err);
+                return Err(format!("Failed to install Python {}: {}", python_version, err));
+            }
+        }
+    }
+
+    for python_version in python_versions {
+        info!("Processing Python version: {}", python_version);
+
+        // Create version-specific directories
+        let python_env = archive_dir.join(format!("python_env_{}", python_version.replace('.', "_")));
+        let wheel_dir = archive_dir.join(format!("wheels_py{}", python_version.replace('.', "_")));
+
+        // Ensure directories exist
+        ensure_path(python_env.to_str().unwrap())
+            .map_err(|e| format!("Failed to create Python env directory for {}: {}", python_version, e))?;
+        ensure_path(wheel_dir.to_str().unwrap())
+            .map_err(|e| format!("Failed to create wheel directory for {}: {}", python_version, e))?;
+
+        info!("Creating virtual environment for Python {}...", python_version);
+
+        // Create virtual environment for this Python version
+        match execute_command(
+            "uv",
+            &[
+                "venv",
+                "--relocatable",
+                "--python",
+                python_version,
+                python_env.to_str().unwrap(),
+            ],
+        ) {
+            Ok(output) => {
+                if output.status.success() {
+                    info!("Python {} virtual environment created successfully.", python_version);
+                } else {
+                    error!(
+                        "Failed to create Python {} virtual environment: {}",
+                        python_version,
+                        String::from_utf8_lossy(&output.stderr)
+                    );
+                    continue; // Skip this version and continue with others
+                }
+            }
+            Err(err) => {
+                error!("Failed to create venv for Python {}: {}", python_version, err);
+                continue; // Skip this version and continue with others
+            }
+        }
+
+        // Determine Python executable path
+        let python_executable = match std::env::consts::OS {
+            "windows" => python_env.join("Scripts/python.exe"),
+            _ => python_env.join("bin/python"),
+        };
+
+        // Ensure pip is available
+        info!("Ensuring pip is available for Python {}...", python_version);
+        match execute_command(
+            python_executable.to_str().unwrap(),
+            &["-m", "ensurepip", "--upgrade"],
+        ) {
+            Ok(output) => {
+                if output.status.success() {
+                    info!("Successfully ensured pip for Python {}.", python_version);
+                } else {
+                    warn!(
+                        "Failed to upgrade pip for Python {}: {}",
+                        python_version,
+                        String::from_utf8_lossy(&output.stderr)
+                    );
+                    // Continue anyway, pip might already be available
+                }
+            }
+            Err(err) => {
+                warn!("Failed to ensure pip for Python {}: {}", python_version, err);
+                // Continue anyway
+            }
+        }
+
+        // Download wheels for this Python version
+        info!("Downloading wheels for Python {}...", python_version);
+        match execute_command(
+            python_executable.to_str().unwrap(),
+            &[
+                "-m",
+                "pip",
+                "download",
+                "-r",
+                requirements_path.to_str().unwrap(),
+                "-c",
+                constraint_file.to_str().unwrap(),
+                "--dest",
+                wheel_dir.to_str().unwrap(),
+            ],
+        ) {
+            Ok(output) => {
+                if output.status.success() {
+                    info!("Python {} packages downloaded successfully.", python_version);
+                } else {
+                    error!(
+                        "Failed to download Python {} packages: {}",
+                        python_version,
+                        String::from_utf8_lossy(&output.stderr)
+                    );
+                    // Continue with other versions even if one fails
+                }
+            }
+            Err(err) => {
+                error!("Failed to download packages for Python {}: {}", python_version, err);
+                // Continue with other versions even if one fails
+            }
+        }
+    }
+
+    Ok(())
+}
+
 #[derive(Parser, Debug)]
 #[command(
     name = "offline_installer_builder",
@@ -199,6 +350,11 @@ struct Args {
         default_value = PYTHON_VERSION,
     )]
     python_version: Option<String>,
+
+    /// Python versions to download wheels for (comma-separated, e.g., "3.10,3.11,3.12")
+    /// If not specified, uses all supported versions for POSIX systems, single version for Windows
+    #[arg(long, value_delimiter = ',')]
+    wheel_python_versions: Option<Vec<String>>,
 }
 
 #[tokio::main]
@@ -244,6 +400,19 @@ async fn main() {
         let archive_dir = TempDir::new().expect("Failed to create temporary directory");
         let global_python_version = args.python_version.unwrap_or_else(|| PYTHON_VERSION.to_string());
         info!("Using Python version: {}", global_python_version);
+
+        // Determine which Python versions to download wheels for
+        let wheel_python_versions: Vec<String> = if let Some(versions) = args.wheel_python_versions {
+            versions
+        } else {
+            // Default behavior: for Windows, use single version; for POSIX, use all supported
+            match std::env::consts::OS {
+                "windows" => vec![global_python_version.clone()],
+                _ => SUPPORTED_PYTHON_VERSIONS.iter().map(|s| s.to_string()).collect(),
+            }
+        };
+
+        info!("Will download wheels for Python versions: {:?}", wheel_python_versions);
 
         // Download prerequisities and python
         match std::env::consts::OS {
@@ -473,125 +642,29 @@ async fn main() {
                     idf_version
                 );
             }
-            // download python packages
-            let python_env = archive_dir.path().clone().join("python_env");
-            match ensure_path(python_env.to_str().unwrap()) {
-                Ok(_) => {
-                    info!("Python environment directory created: {:?}", python_env);
-                }
-                Err(err) => {
-                    error!("Failed to create Python environment directory: {}", err);
-                    return;
-                }
-            }
-            match execute_command(
-            "uv",
-              &[
-                  "python", "install", &global_python_version
-              ],
-            ) {
-              Ok(output) => {
-                  if output.status.success() {
-                      info!("Python {} installed successfully.", global_python_version);
-                  } else {
-                      error!(
-                          "Failed to install Python {}: {}",
-                          global_python_version,
-                          String::from_utf8_lossy(&output.stderr)
-                      );
-                      return;
-                  }
-              }
-              Err(err) => {
-                  error!("Failed to execute command: {}", err);
-                  return;
-              }
-            };
-            match execute_command(
-            "uv",
-              &[
-                  "venv", "--relocatable", "--python", &global_python_version, python_env.clone().to_str().unwrap()
-              ],
-            ) {
-              Ok(output) => {
-                  if output.status.success() {
-                      info!("Python virtual environment created successfully.");
-                  } else {
-                      error!(
-                          "Failed to create Python virtual environment: {}",
-                          String::from_utf8_lossy(&output.stderr)
-                      );
-                      return;
-                  }
-              }
-              Err(err) => {
-                  error!("Failed to execute command: {}", err);
-                  return;
-              }
-            }
-            let wheel_dir = archive_dir.path().join("wheels");
-            ensure_path(wheel_dir.to_str().unwrap()).expect("Failed to ensure path for wheel files");
+
+            // Merge requirements files
             let requirements_dir = idf_path.join("tools").join("requirements");
             if let Err(e) = merge_requirements_files(&requirements_dir) {
                 error!("Failed to merge requirements files: {}", e);
                 return;
             }
 
-            let python_executable = match std::env::consts::OS {
-                "windows" => python_env.join("Scripts/python.exe"),
-                _ => python_env.join("bin/python"),
-            };
+            // Download wheels for multiple Python versions
+            let requirements_file = requirements_dir.join("requirements.merged.txt");
+            let constraint_file = constraint_file.unwrap();
 
-            match execute_command(
-            python_executable.to_str().unwrap(),
-              &[
-                  "-m", "ensurepip", "--upgrade"
-              ]
-            ) {
-              Ok(output) => {
-                  if output.status.success() {
-                      info!("Successfully installed pip.");
-                  } else {
-                      error!(
-                          "Failed to upgrade pip: {}",
-                          String::from_utf8_lossy(&output.stderr)
-                      );
-                      return;
-                  }
-              }
-              Err(err) => {
-                  error!("Failed to execute command: {}", err);
-                  return;
-              }
+            let wheel_versions: Vec<&str> = wheel_python_versions.iter().map(|s| s.as_str()).collect();
+
+            if let Err(e) = download_wheels_for_python_versions(
+                archive_dir.path(),
+                &requirements_file,
+                &constraint_file,
+                &wheel_versions,
+            ).await {
+                error!("Failed to download wheels: {}", e);
+                return;
             }
-
-
-
-            match execute_command(
-                python_executable.to_str().unwrap(),
-              &[
-                  "-m", "pip", "download",
-                  "-r", requirements_dir.join("requirements.merged.txt").to_str().unwrap(),
-                  "-c", constraint_file.unwrap().to_str().unwrap(),
-                  "--dest", wheel_dir.to_str().unwrap(),
-              ],
-          ) {
-              Ok(output) => {
-                  if output.status.success() {
-                      info!("Python packages downloaded successfully.");
-                  } else {
-                      error!(
-                          "Failed to download Python packages: {}",
-                          String::from_utf8_lossy(&output.stderr)
-                      );
-                      return;
-                  }
-              }
-              Err(err) => {
-                  error!("Failed to execute command: {}", err);
-                  return;
-              }
-          };
         }
 
         settings.config_file_save_path = Some(archive_dir.path().join("config.toml"));


### PR DESCRIPTION
on windows we still rely on the python 3.11 as we are installing it ourselves
on POSIX we should now support python versions "3.10", "3.11", "3.12", "3.13"