### PR TITLE
pipeline will now build offline installer archives for all versions

### DIFF
--- a/.github/workflows/build_offline_installer_archives.yaml
+++ b/.github/workflows/build_offline_installer_archives.yaml
@@ -91,7 +91,9 @@ jobs:
           aws-region: ap-east-1
 
       - name: Download current offline_archives.json
+        if: runner.os != 'Windows'
         id: download_json
+        shell: bash
         run: |
           aws s3 cp s3://espdldata/dl/eim/offline_archives.json ./offline_archives.json 2>/dev/null || echo "[]" > ./offline_archives.json
           if ! jq -e 'type == "array"' ./offline_archives.json >/dev/null 2>&1; then
@@ -100,6 +102,30 @@ jobs:
           fi
           echo "Current offline_archives.json:"
           cat ./offline_archives.json
+
+      - name: Download current offline_archives.json (Windows)
+        if: runner.os == 'Windows'
+        id: download_json_windows
+        shell: pwsh
+        run: |
+          try {
+            aws s3 cp s3://espdldata/dl/eim/offline_archives.json ./offline_archives.json
+          } catch {
+            Set-Content -Path "./offline_archives.json" -Value "[]"
+          }
+
+          try {
+            $json = Get-Content "./offline_archives.json" | ConvertFrom-Json
+            if (-not ($json -is [array])) {
+              throw "Not an array"
+            }
+          } catch {
+            Write-Host "Invalid JSON, resetting to empty array"
+            Set-Content -Path "./offline_archives.json" -Value "[]"
+          }
+
+          Write-Host "Current offline_archives.json:"
+          Get-Content "./offline_archives.json"
 
       - name: Purge existing archives (if requested)
         if: github.event_name == 'release' || inputs.purge_all == true

--- a/.github/workflows/build_offline_installer_archives.yaml
+++ b/.github/workflows/build_offline_installer_archives.yaml
@@ -1,4 +1,4 @@
-name: Build Offline Installer Archives
+name: Build & Upload Offline Installer Archives
 
 on:
   workflow_call:
@@ -9,10 +9,10 @@ on:
       run_id:
         required: true
         type: string
-      update_json:
+      idf_version:
         required: false
-        type: boolean
-        default: true
+        type: string
+        description: "Specific IDF version to build (e.g., v5.1.2). If empty, builds all versions."
     secrets:
       AWS_ACCESS_KEY_ID:
         required: true
@@ -27,17 +27,24 @@ on:
         description: "The run id from which to take binaries"
         required: true
         type: string
-      update_json:
-        description: "Update offline_archives.json in S3"
+      idf_version:
+        description: "Specific IDF version to build (e.g., v5.1.2). Leave empty to build all."
+        required: false
+        type: string
+      purge_all:
+        description: "Purge all existing archives from S3 before upload (DANGEROUS)"
         required: false
         type: boolean
-        default: true
+        default: false
+
+  release:
+    types: [published]
 
 jobs:
-  build-offline-archives:
-    name: Build Offline Archives (${{ matrix.package_name }})
+  build-and-upload:
+    name: Build & Upload (${{ matrix.package_name }})
     runs-on: ${{ matrix.os }}
-    continue-on-error: true
+    continue-on-error: false
 
     strategy:
       fail-fast: false
@@ -53,7 +60,11 @@ jobs:
             package_name: macos-aarch64
           - os: macos-13
             package_name: macos-x64
+
     steps:
+      - name: Checkout (for scripts if needed)
+        uses: actions/checkout@v4
+
       - name: Download offline_installer_builder artifact
         uses: actions/download-artifact@v5
         with:
@@ -63,181 +74,214 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ inputs.run_id || github.run_id }}
 
-      - name: Download eim artifact
-        uses: actions/download-artifact@v4
-        with:
-          pattern: eim-gui-${{ matrix.package_name }}-*
-          merge-multiple: true
-          path: ./
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          run-id: ${{ inputs.run_id || github.run_id }}
-
       - name: Make binary executable (Unix)
         if: runner.os != 'Windows'
         run: |
           chmod +x ./offline_installer_builder
-          chmod +x ./eim
 
-      - name: Install tooling
+      - name: Install UV (Python package manager)
         run: |
           cargo install --git https://github.com/astral-sh/uv uv
 
-      - name: Run offline_installer_builder
-        run: |
-          if [ "${{ runner.os }}" = "Windows" ]; then
-            ./offline_installer_builder.exe -c default
-          else
-            ./offline_installer_builder -c default
-          fi
-        shell: bash
-
-      - name: Bundle offline installer
-        run: |
-          # Find the archive file
-          ARCHIVE_FILE=$(find . -name "archive_v*.zst" -type f | head -1)
-          if [ -z "$ARCHIVE_FILE" ]; then
-            echo "Error: No archive_v*.zst file found"
-            exit 1
-          fi
-
-          # Extract version from filename (e.g., archive_v1.2.3.zst -> 1.2.3)
-          VERSION=$(basename "$ARCHIVE_FILE" | sed 's/archive_v\(.*\)\.zst/\1/')
-          echo "Found version: $VERSION"
-
-          # Create the README.md file with installation instructions based on the OS.
-          if [ "${{ runner.os }}" = "Windows" ]; then
-            README_CONTENT="You can install the application by simply launching the GUI app named **eim**.\n\nAlternatively, if you prefer using the command line, open PowerShell and run:\n\n\`eim install --use-local-archive $(basename "$ARCHIVE_FILE")\`\n\nWhen using the GUI, the offline installer archive will be offered on the welcome screen. You can also find it manually under the **Install New Version** section."
-          else
-            README_CONTENT="You can install the application by simply launching the GUI app named **eim**.\n\nAlternatively, if you prefer using the command line, run the following in your terminal:\n\n\`eim install --use-local-archive $(basename "$ARCHIVE_FILE")\`\n\nWhen using the GUI, the offline installer archive will be offered on the welcome screen. You can also find it manually under the **Install New Version** section."
-          fi
-          echo -e "$README_CONTENT" > README.md
-
-          # Create zip archive with eim binary and archive file
-          if [ "${{ runner.os }}" = "Windows" ]; then
-            7z a "offline_installer-${{ matrix.package_name }}-${VERSION}.zip" "$ARCHIVE_FILE" "./eim.exe" "README.md"
-          else
-            zip "offline_installer-${{ matrix.package_name }}-${VERSION}.zip" "$ARCHIVE_FILE" "./eim" "README.md"
-          fi
-
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
-        shell: bash
-
-      - name: Upload offline installer artifact
-        uses: actions/upload-artifact@v4
+      - name: Set up AWS CLI
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          name: offline_installer-${{ matrix.package_name }}-${{ env.VERSION }}
-          path: offline_installer-${{ matrix.package_name }}-${{ env.VERSION }}.zip
-          retention-days: 30
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ap-east-1
 
-      - name: Create build info file
-        env:
-          VERSION: ${{ env.VERSION }}
-          PACKAGE_NAME: ${{ matrix.package_name }}
-          FILENAME: offline_installer-${{ matrix.package_name }}-${{ env.VERSION }}.zip
-        shell: bash
+      - name: Download current offline_archives.json
+        id: download_json
         run: |
-          # Calculate file size in bytes
-          if [ "${{ runner.os }}" = "macOS" ]; then
-            FILE_SIZE=$(stat -f %z "$FILENAME")
-          else
-            FILE_SIZE=$(stat -c %s "$FILENAME")
+          aws s3 cp s3://espdldata/dl/eim/offline_archives.json ./offline_archives.json 2>/dev/null || echo "[]" > ./offline_archives.json
+          if ! jq -e 'type == "array"' ./offline_archives.json >/dev/null 2>&1; then
+            echo "Invalid JSON, resetting to empty array"
+            echo "[]" > ./offline_archives.json
           fi
-          # Create build info file with size
-          jq -n \
-            --arg version "$VERSION" \
-            --arg platform "$PACKAGE_NAME" \
-            --arg filename "$FILENAME" \
-            --arg size "$FILE_SIZE" \
-            '{"version": $version, "platform": $platform, "filename": $filename, "size": ($size | tonumber)}' \
-            > build-info.json
-
-      - name: Save build info as artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: build-info-${{ matrix.package_name }}
-          path: build-info.json
-
-  update-json:
-    needs: build-offline-archives
-    runs-on: ubuntu-latest
-    if: ${{ inputs.update_json }}
-    steps:
-      - name: Download all build info artifacts
-        uses: actions/download-artifact@v4
-        with:
-          pattern: build-info-*
-          path: build-infos/
-
-      - name: Update offline_archives.json
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: ap-east-1
-          DL_DISTRIBUTION_ID: ${{ secrets.DL_DISTRIBUTION_ID }}
-        shell: bash
-        run: |
-          # Debug: List downloaded artifacts
-          echo "Listing downloaded artifacts:"
-          find build-infos/ -type f
-
-          # Download existing JSON or create empty array
-          aws s3 cp s3://espdldata/dl/eim/offline_archives.json offline_archives.json 2>/dev/null || echo "[]" > offline_archives.json
-
-          # Ensure valid JSON array
-          if ! jq -e 'type == "array"' offline_archives.json >/dev/null 2>&1; then
-            echo "Invalid or not an array, initializing with empty array"
-            echo "[]" > offline_archives.json
-          fi
-
-          # Debug: Show current offline_archives.json
           echo "Current offline_archives.json:"
-          cat offline_archives.json
+          cat ./offline_archives.json
 
-          # Collect all new build info
-          new_entries="[]"
-          for build_info in build-infos/*/build-info.json; do
-            if [ -f "$build_info" ]; then
-              echo "Processing $build_info"
-              entry=$(cat "$build_info")
-              new_entries=$(echo "$new_entries" | jq --argjson entry "$entry" '. + [$entry]')
-            else
-              echo "No build-info.json found in $build_info"
+      - name: Purge existing archives (if requested)
+        if: github.event_name == 'release' || inputs.purge_all == true
+        run: |
+          echo "Purging existing archives from S3..."
+          jq -r '.[] | .filename' ./offline_archives.json | while read filename; do
+            if [ -n "$filename" ]; then
+              echo "Deleting s3://espdldata/dl/eim/$filename"
+              aws s3 rm "s3://espdldata/dl/eim/$filename" || echo "Failed to delete $filename, continuing..."
             fi
           done
 
-          # Debug: Show new_entries
-          echo "New entries:"
-          echo "$new_entries"
+      - name: Build archives
+        id: build
+        run: |
+          # Determine binary name
+          if [ "${{ runner.os }}" = "Windows" ]; then
+            BINARY="./offline_installer_builder.exe"
+          else
+            BINARY="./offline_installer_builder"
+          fi
 
-          # Remove existing entries with same filenames, then add all new entries
-          updated_json=$(jq --argjson new_entries "$new_entries" '
-            . as $original |
-            ($new_entries | map(.filename)) as $new_filenames |
-            ($original | map(select(.filename as $f | $new_filenames | index($f) | not))) + $new_entries
-          ' offline_archives.json)
+          # Determine arguments
+          if [ -n "${{ inputs.idf_version }}" ]; then
+            echo "Building specific version: ${{ inputs.idf_version }}"
+            ARGS="-c default --idf-version-override ${{ inputs.idf_version }}"
+          else
+            echo "Building ALL versions"
+            ARGS="-c default --build-all-versions"
+          fi
 
-          # Debug: Show updated JSON
-          echo "Updated JSON:"
-          echo "$updated_json"
+          # Run it
+          $BINARY $ARGS
 
-          # Write updated JSON to file
-          echo "$updated_json" > updated_archives.json
+          # Collect and rename all built .zst files to include platform
+          PLATFORM="${{ matrix.package_name }}"
+          mkdir -p built_archives
 
-          # Verify the updated JSON is valid
-          if ! jq empty updated_archives.json 2>/dev/null; then
-            echo "Error: Generated JSON is invalid"
+          for file in archive_v*.zst; do
+            if [ ! -f "$file" ]; then continue; fi
+
+            # Extract version: archive_v5.1.2.zst → 5.1.2
+            VERSION=$(echo "$file" | sed -E 's/archive_v(.*)\.zst/\1/')
+            NEW_NAME="archive_v${VERSION}_${PLATFORM}.zst"
+
+            echo "Renaming $file → $NEW_NAME"
+            mv "$file" "built_archives/$NEW_NAME"
+          done
+
+          # List built files
+          echo "Built archives:"
+          ls -la built_archives/
+
+          # Fail if nothing built
+          if [ ! "$(ls -A built_archives/ 2>/dev/null)" ]; then
+            echo "ERROR: No archives built!" >&2
             exit 1
           fi
 
-          # Upload updated JSON to S3
-          aws s3 cp --acl=public-read updated_archives.json s3://espdldata/dl/eim/offline_archives.json
+        shell: bash
 
-          # Invalidate CloudFront cache
-          aws cloudfront create-invalidation --distribution-id ${DL_DISTRIBUTION_ID} --paths "/dl/eim/offline_archives.json"
+      - name: Upload archives to S3 and generate build info
+        id: upload
+        run: |
+          PLATFORM="${{ matrix.package_name }}"
+          mkdir -p build-infos
 
-  Autotest-CLI-Offline:
-    needs: [build-offline-archives]
-    if: needs.build-offline-archives.result == 'success'
+          # Upload each .zst and record metadata
+          for archive in built_archives/*.zst; do
+            if [ ! -f "$archive" ]; then continue; fi
+
+            # Extract version from new filename: archive_v5.1.2_linux-x64.zst → 5.1.2
+            FILENAME=$(basename "$archive")
+            VERSION=$(echo "$FILENAME" | sed -E 's/archive_v([^_]+)_.*/\1/')
+
+            # Get file size
+            if [ "${{ runner.os }}" = "macOS" ]; then
+              SIZE=$(stat -f %z "$archive")
+            else
+              SIZE=$(stat -c %s "$archive")
+            fi
+
+            # Upload to S3
+            aws s3 cp --acl=public-read "$archive" "s3://espdldata/dl/eim/$FILENAME"
+
+            # Generate build info
+            jq -n \
+              --arg version "$VERSION" \
+              --arg platform "$PLATFORM" \
+              --arg filename "$FILENAME" \
+              --argjson size $SIZE \
+              '{"version": $version, "platform": $platform, "filename": $filename, "size": $size}' \
+              > "build-infos/build-info-${VERSION}-${PLATFORM}.json"
+
+            echo "Uploaded $FILENAME ($SIZE bytes)"
+          done
+
+      - name: Save build infos as artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-infos-${{ matrix.package_name }}
+          path: build-infos/
+          retention-days: 7
+
+  update-json:
+    needs: build-and-upload
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up AWS CLI
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ap-east-1
+
+      - name: Download current offline_archives.json
+        run: |
+          aws s3 cp s3://espdldata/dl/eim/offline_archives.json ./offline_archives.json 2>/dev/null || echo "[]" > ./offline_archives.json
+          if ! jq -e 'type == "array"' ./offline_archives.json >/dev/null 2>&1; then
+            echo "[]" > ./offline_archives.json
+          fi
+
+      - name: Download all build infos
+        uses: actions/download-artifact@v4
+        with:
+          pattern: build-infos-*
+          path: ./all-build-infos/
+          merge-multiple: true
+
+      - name: Merge and update JSON
+        run: |
+          # Collect all new entries
+          NEW_ENTRIES="[]"
+          for info_file in all-build-infos/build-infos/*/build-info-*.json; do
+            if [ -f "$info_file" ]; then
+              echo "Processing: $info_file"
+              entry=$(cat "$info_file")
+              NEW_ENTRIES=$(echo "$NEW_ENTRIES" | jq --argjson entry "$entry" '. + [$entry]')
+            fi
+          done
+
+          # Load current JSON
+          CURRENT=$(cat offline_archives.json)
+
+          # Remove existing entries that are being replaced (same platform + version)
+          # Keep entries for platforms/versions NOT rebuilt
+          UPDATED=$(jq --argjson new "$NEW_ENTRIES" '
+            . as $current |
+            ($new | map({version, platform})) as $to_replace |
+            ($current | map(select(
+              (.version + "-" + .platform) as $key |
+              ($to_replace | map(.version + "-" + .platform) | index($key)) | not
+            ))) + $new
+          ' offline_archives.json)
+
+          echo "Final offline_archives.json:"
+          echo "$UPDATED" | jq .
+
+          # Validate
+          echo "$UPDATED" > updated_offline_archives.json
+          if ! jq empty updated_offline_archives.json; then
+            echo "Generated JSON is invalid!" >&2
+            exit 1
+          fi
+
+          # Upload
+          aws s3 cp --acl=public-read updated_offline_archives.json s3://espdldata/dl/eim/offline_archives.json
+
+          # Invalidate CloudFront
+          aws cloudfront create-invalidation \
+            --distribution-id ${{ secrets.DL_DISTRIBUTION_ID }} \
+            --paths "/dl/eim/offline_archives.json" "/dl/eim/archive_*.zst"
+
+      - name: Upload final JSON as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: final-offline-archives-json
+          path: updated_offline_archives.json
+
+  autotest:
+    needs: [build-and-upload, update-json]
+    if: always() && needs.build-and-upload.result == 'success'
     uses: ./.github/workflows/test_offline.yml
     with:
       ref: ${{ inputs.ref || github.ref }}

--- a/.github/workflows/build_offline_installer_archives.yaml
+++ b/.github/workflows/build_offline_installer_archives.yaml
@@ -37,29 +37,110 @@ on:
         type: boolean
         default: false
 
-  release:
-    types: [published]
-
 jobs:
+  # Get versions first
+  get-versions:
+    runs-on: ubuntu-latest
+    outputs:
+      versions: ${{ steps.get-versions.outputs.versions }}
+      should_purge: ${{ steps.get-versions.outputs.should_purge }}
+    steps:
+      - name: Checkout (for scripts if needed)
+        uses: actions/checkout@v4
+
+      - name: Download offline_installer_builder artifact
+        uses: actions/download-artifact@v5
+        with:
+          pattern: offline_installer_builder-linux-x64-*
+          merge-multiple: true
+          path: ./
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ inputs.run_id || github.run_id }}
+
+      - name: Make binary executable
+        run: chmod +x ./offline_installer_builder
+
+      - name: Install UV (Python package manager)
+        run: cargo install --git https://github.com/astral-sh/uv uv
+
+      - name: Get IDF versions
+        id: get-versions
+        run: |
+          if [ -n "${{ inputs.idf_version }}" ]; then
+            # Single version specified
+            VERSIONS='["${{ inputs.idf_version }}"]'
+          else
+            # Get all available versions from the builder
+            echo "Getting available IDF versions..."
+            VERSIONS_OUTPUT=$(./offline_installer_builder --list-versions)
+            echo "Available versions:"
+            echo "$VERSIONS_OUTPUT"
+
+            # Convert to JSON array
+            VERSIONS=$(echo "$VERSIONS_OUTPUT" | jq -R -s -c 'split("\n") | map(select(length > 0))')
+          fi
+
+          echo "versions=$VERSIONS" >> $GITHUB_OUTPUT
+
+          # Determine if we should purge
+          SHOULD_PURGE=$([ "${{ github.event_name }}" = "release" ] || [ "${{ inputs.purge_all }}" = "true" ] && echo "true" || echo "false")
+          echo "should_purge=$SHOULD_PURGE" >> $GITHUB_OUTPUT
+
+  # Build job with simpler matrix
   build-and-upload:
-    name: Build & Upload (${{ matrix.package_name }})
+    name: Build & Upload (${{ matrix.package_name }}, ${{ matrix.idf_version }})
+    needs: get-versions
     runs-on: ${{ matrix.os }}
     continue-on-error: false
 
     strategy:
       fail-fast: false
       matrix:
-        include:
+        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-latest, macos-13]
+        package_name: [linux-x64, linux-aarch64, windows-x64, macos-aarch64, macos-x64]
+        idf_version: ${{ fromJson(needs.get-versions.outputs.versions) }}
+        exclude:
+          # Only run matching OS/package combinations
           - os: ubuntu-latest
+            package_name: linux-aarch64
+          - os: ubuntu-latest
+            package_name: windows-x64
+          - os: ubuntu-latest
+            package_name: macos-aarch64
+          - os: ubuntu-latest
+            package_name: macos-x64
+          - os: ubuntu-24.04-arm
             package_name: linux-x64
           - os: ubuntu-24.04-arm
+            package_name: windows-x64
+          - os: ubuntu-24.04-arm
+            package_name: macos-aarch64
+          - os: ubuntu-24.04-arm
+            package_name: macos-x64
+          - os: windows-latest
+            package_name: linux-x64
+          - os: windows-latest
             package_name: linux-aarch64
           - os: windows-latest
+            package_name: macos-aarch64
+          - os: windows-latest
+            package_name: macos-x64
+          - os: macos-latest
+            package_name: linux-x64
+          - os: macos-latest
+            package_name: linux-aarch64
+          - os: macos-latest
             package_name: windows-x64
           - os: macos-latest
-            package_name: macos-aarch64
-          - os: macos-13
             package_name: macos-x64
+          - os: macos-13
+            package_name: linux-x64
+          - os: macos-13
+            package_name: linux-aarch64
+          - os: macos-13
+            package_name: windows-x64
+          - os: macos-13
+            package_name: macos-aarch64
 
     steps:
       - name: Checkout (for scripts if needed)
@@ -76,12 +157,10 @@ jobs:
 
       - name: Make binary executable (Unix)
         if: runner.os != 'Windows'
-        run: |
-          chmod +x ./offline_installer_builder
+        run: chmod +x ./offline_installer_builder
 
       - name: Install UV (Python package manager)
-        run: |
-          cargo install --git https://github.com/astral-sh/uv uv
+        run: cargo install --git https://github.com/astral-sh/uv uv
 
       - name: Set up AWS CLI
         uses: aws-actions/configure-aws-credentials@v4
@@ -127,18 +206,37 @@ jobs:
           Write-Host "Current offline_archives.json:"
           Get-Content "./offline_archives.json"
 
-      - name: Purge existing archives (if requested)
-        if: github.event_name == 'release' || inputs.purge_all == true
+      - name: Purge existing archives for this version (if requested) - Unix
+        if: needs.get-versions.outputs.should_purge == 'true' && runner.os != 'Windows'
+        shell: bash
         run: |
-          echo "Purging existing archives from S3..."
-          jq -r '.[] | .filename' ./offline_archives.json | while read filename; do
+          echo "Purging existing archives for version ${{ matrix.idf_version }} from S3..."
+
+          # Only purge archives for THIS specific version and platform
+          aws s3 ls s3://espdldata/dl/eim/ | grep "archive_v${{ matrix.idf_version }}_${{ matrix.package_name }}\.zst" | awk '{print $4}' | while read filename; do
             if [ -n "$filename" ]; then
               echo "Deleting s3://espdldata/dl/eim/$filename"
               aws s3 rm "s3://espdldata/dl/eim/$filename" || echo "Failed to delete $filename, continuing..."
             fi
           done
 
-      - name: Build archives
+      - name: Purge existing archives for this version (if requested) - Windows
+        if: needs.get-versions.outputs.should_purge == 'true' && runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          Write-Host "Purging existing archives for version ${{ matrix.idf_version }} from S3..."
+
+          # Only purge archives for THIS specific version and platform
+          $archives = aws s3 ls s3://espdldata/dl/eim/ | Where-Object { $_.Split()[-1] -match "archive_v${{ matrix.idf_version }}_${{ matrix.package_name }}\.zst" }
+          foreach ($archive in $archives) {
+            $filename = $archive.Split()[-1]
+            if ($filename) {
+              Write-Host "Deleting s3://espdldata/dl/eim/$filename"
+              aws s3 rm "s3://espdldata/dl/eim/$filename"
+            }
+          }
+
+      - name: Build archive for specific version
         id: build
         run: |
           # Determine binary name
@@ -148,19 +246,12 @@ jobs:
             BINARY="./offline_installer_builder"
           fi
 
-          # Determine arguments
-          if [ -n "${{ inputs.idf_version }}" ]; then
-            echo "Building specific version: ${{ inputs.idf_version }}"
-            ARGS="-c default --idf-version-override ${{ inputs.idf_version }}"
-          else
-            echo "Building ALL versions"
-            ARGS="-c default --build-all-versions"
-          fi
+          echo "Building specific version: ${{ matrix.idf_version }}"
 
-          # Run it
-          $BINARY $ARGS
+          # Build only this specific version
+          $BINARY -c default --idf-version-override ${{ matrix.idf_version }}
 
-          # Collect and rename all built .zst files to include platform
+          # Rename the built file to include platform
           PLATFORM="${{ matrix.package_name }}"
           mkdir -p built_archives
 
@@ -184,50 +275,92 @@ jobs:
             echo "ERROR: No archives built!" >&2
             exit 1
           fi
-
         shell: bash
 
-      - name: Upload archives to S3 and generate build info
-        id: upload
+      - name: Upload archive to S3 and generate build info - Unix
+        if: runner.os != 'Windows'
+        id: upload_unix
+        shell: bash
         run: |
           PLATFORM="${{ matrix.package_name }}"
-          mkdir -p build-infos
+          VERSION="${{ matrix.idf_version }}"
 
-          # Upload each .zst and record metadata
-          for archive in built_archives/*.zst; do
-            if [ ! -f "$archive" ]; then continue; fi
+          # Should have exactly one file
+          archive=$(ls built_archives/*.zst | head -1)
 
-            # Extract version from new filename: archive_v5.1.2_linux-x64.zst → 5.1.2
-            FILENAME=$(basename "$archive")
-            VERSION=$(echo "$FILENAME" | sed -E 's/archive_v([^_]+)_.*/\1/')
+          if [ ! -f "$archive" ]; then
+            echo "ERROR: No archive found!" >&2
+            exit 1
+          fi
 
-            # Get file size
-            if [ "${{ runner.os }}" = "macOS" ]; then
-              SIZE=$(stat -f %z "$archive")
-            else
-              SIZE=$(stat -c %s "$archive")
-            fi
+          FILENAME=$(basename "$archive")
 
-            # Upload to S3
-            aws s3 cp --acl=public-read "$archive" "s3://espdldata/dl/eim/$FILENAME"
+          # Get file size
+          if [ "${{ runner.os }}" = "macOS" ]; then
+            SIZE=$(stat -f %z "$archive")
+          else
+            SIZE=$(stat -c %s "$archive")
+          fi
 
-            # Generate build info
-            jq -n \
-              --arg version "$VERSION" \
-              --arg platform "$PLATFORM" \
-              --arg filename "$FILENAME" \
-              --argjson size $SIZE \
-              '{"version": $version, "platform": $platform, "filename": $filename, "size": $size}' \
-              > "build-infos/build-info-${VERSION}-${PLATFORM}.json"
+          # Upload to S3
+          aws s3 cp --acl=public-read "$archive" "s3://espdldata/dl/eim/$FILENAME"
 
-            echo "Uploaded $FILENAME ($SIZE bytes)"
-          done
+          # Generate build info
+          mkdir -p build-info
+          jq -n \
+            --arg version "$VERSION" \
+            --arg platform "$PLATFORM" \
+            --arg filename "$FILENAME" \
+            --argjson size $SIZE \
+            '{"version": $version, "platform": $platform, "filename": $filename, "size": $size}' \
+            > "build-info/build-info.json"
 
-      - name: Save build infos as artifacts
+          echo "Uploaded $FILENAME ($SIZE bytes)"
+
+      - name: Upload archive to S3 and generate build info - Windows
+        if: runner.os == 'Windows'
+        id: upload_windows
+        shell: pwsh
+        run: |
+          $PLATFORM = "${{ matrix.package_name }}"
+          $VERSION = "${{ matrix.idf_version }}"
+
+          # Should have exactly one file
+          $archive = Get-ChildItem "built_archives/*.zst" | Select-Object -First 1
+
+          if (-not $archive) {
+            Write-Error "ERROR: No archive found!"
+            exit 1
+          }
+
+          $FILENAME = $archive.Name
+          $archivePath = $archive.FullName
+
+          # Get file size
+          $SIZE = $archive.Length
+
+          # Upload to S3
+          aws s3 cp --acl=public-read "$archivePath" "s3://espdldata/dl/eim/$FILENAME"
+
+          # Generate build info
+          New-Item -ItemType Directory -Path "build-info" -Force | Out-Null
+
+          $buildInfo = @{
+            version = $VERSION
+            platform = $PLATFORM
+            filename = $FILENAME
+            size = $SIZE
+          }
+
+          $buildInfo | ConvertTo-Json | Out-File -FilePath "build-info/build-info.json" -Encoding UTF8
+
+          Write-Host "Uploaded $FILENAME ($SIZE bytes)"
+
+      - name: Save build info as artifact
         uses: actions/upload-artifact@v4
         with:
-          name: build-infos-${{ matrix.package_name }}
-          path: build-infos/
+          name: build-info-${{ matrix.idf_version }}-${{ matrix.package_name }}
+          path: build-info/
           retention-days: 7
 
   update-json:
@@ -251,27 +384,61 @@ jobs:
       - name: Download all build infos
         uses: actions/download-artifact@v4
         with:
-          pattern: build-infos-*
+          pattern: build-info-*
           path: ./all-build-infos/
-          merge-multiple: true
 
       - name: Merge and update JSON
         run: |
-          # Collect all new entries
+          echo "=== Debugging artifact structure ==="
+          find all-build-infos -name "*.json" -type f | head -10
+          echo "=== Directory structure ==="
+          ls -la all-build-infos/ || echo "No all-build-infos directory"
+          find all-build-infos -type f | head -20
+
+          # Collect all new entries with more robust file finding
           NEW_ENTRIES="[]"
-          for info_file in all-build-infos/build-infos/*/build-info-*.json; do
+
+          # Find all build-info.json files recursively
+          while IFS= read -r -d '' info_file; do
             if [ -f "$info_file" ]; then
               echo "Processing: $info_file"
-              entry=$(cat "$info_file")
-              NEW_ENTRIES=$(echo "$NEW_ENTRIES" | jq --argjson entry "$entry" '. + [$entry]')
+              echo "File contents:"
+              cat "$info_file"
+              echo "---"
+
+              # Validate JSON before processing
+              if jq empty "$info_file" 2>/dev/null; then
+                entry=$(cat "$info_file")
+                NEW_ENTRIES=$(echo "$NEW_ENTRIES" | jq --argjson entry "$entry" '. + [$entry]')
+                echo "Successfully added entry from $info_file"
+              else
+                echo "WARNING: Invalid JSON in $info_file, skipping"
+              fi
+            else
+              echo "WARNING: File $info_file does not exist"
             fi
-          done
+          done < <(find all-build-infos -name "build-info.json" -type f -print0)
+
+          echo "=== Collected entries ==="
+          echo "NEW_ENTRIES count: $(echo "$NEW_ENTRIES" | jq length)"
+          echo "$NEW_ENTRIES" | jq .
+
+          # Validate we found some entries
+          ENTRIES_COUNT=$(echo "$NEW_ENTRIES" | jq length)
+          if [ "$ENTRIES_COUNT" -eq 0 ]; then
+            echo "ERROR: No build info entries found! This indicates a problem with artifact structure."
+            echo "Expected to find build-info.json files in downloaded artifacts."
+            exit 1
+          fi
 
           # Load current JSON
+          echo "=== Loading current JSON ==="
           CURRENT=$(cat offline_archives.json)
+          echo "Current entries count: $(echo "$CURRENT" | jq length)"
 
           # Remove existing entries that are being replaced (same platform + version)
           # Keep entries for platforms/versions NOT rebuilt
+          echo "=== Merging entries ==="
           UPDATED=$(jq --argjson new "$NEW_ENTRIES" '
             . as $current |
             ($new | map({version, platform})) as $to_replace |
@@ -281,20 +448,35 @@ jobs:
             ))) + $new
           ' offline_archives.json)
 
+          echo "=== Final result ==="
+          echo "Final entries count: $(echo "$UPDATED" | jq length)"
           echo "Final offline_archives.json:"
           echo "$UPDATED" | jq .
 
-          # Validate
+          # Validate final JSON
           echo "$UPDATED" > updated_offline_archives.json
           if ! jq empty updated_offline_archives.json; then
-            echo "Generated JSON is invalid!" >&2
+            echo "ERROR: Generated JSON is invalid!" >&2
+            echo "Content that failed validation:"
+            cat updated_offline_archives.json
             exit 1
           fi
 
+          # Final size check
+          FINAL_COUNT=$(jq length updated_offline_archives.json)
+          if [ "$FINAL_COUNT" -eq 0 ]; then
+            echo "ERROR: Final JSON is empty! This should not happen." >&2
+            exit 1
+          fi
+
+          echo "SUCCESS: Generated valid JSON with $FINAL_COUNT entries"
+
           # Upload
+          echo "=== Uploading to S3 ==="
           aws s3 cp --acl=public-read updated_offline_archives.json s3://espdldata/dl/eim/offline_archives.json
 
           # Invalidate CloudFront
+          echo "=== Invalidating CloudFront ==="
           aws cloudfront create-invalidation \
             --distribution-id ${{ secrets.DL_DISTRIBUTION_ID }} \
             --paths "/dl/eim/offline_archives.json" "/dl/eim/archive_*.zst"

--- a/dl_page/index.html
+++ b/dl_page/index.html
@@ -1,12 +1,13 @@
 <!DOCTYPE html>
 <html lang="en">
-
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="shortcut icon" href="https://www.espressif.com/sites/all/themes/espressif/favicon.ico" type="image/vnd.microsoft.icon">
   <title>ESP-IDF Installation Manager Downloads</title>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/3.3.4/vue.global.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/FileSaver.js/2.0.0/FileSaver.min.js"></script>
   <style>
     :root {
       --primary: #e7352c;
@@ -290,6 +291,67 @@
       padding: 1rem;
     }
 
+    #offline-installer-creator {
+      background: var(--card);
+      border-radius: 12px;
+      padding: 1.5rem;
+      margin-bottom: 1.5rem;
+      box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    }
+
+    #offline-installer-creator h3 {
+      font-size: 1.25rem;
+      font-weight: 600;
+      color: var(--primary);
+      margin-bottom: 1rem;
+    }
+
+    #offline-installer-creator div {
+      margin-bottom: 1rem;
+    }
+
+    #offline-installer-creator label {
+      font-weight: 600;
+      color: var(--secondary);
+      margin-right: 1rem;
+    }
+
+    #offline-installer-creator select {
+      padding: 0.5rem;
+      border-radius: 6px;
+      border: 1px solid #e5e7eb;
+    }
+
+    #download-offline-installer {
+      background: var(--primary);
+      color: white;
+      padding: 0.75rem 1.5rem;
+      border-radius: 6px;
+      text-decoration: none;
+      font-weight: 500;
+      transition: background-color 0.3s ease;
+      border: none;
+      cursor: pointer;
+    }
+
+    #download-offline-installer:hover {
+      background: var(--primary-dark);
+    }
+
+    #progress-bar {
+      width: 100%;
+      background-color: #e5e7eb;
+      border-radius: 6px;
+      margin-top: 1rem;
+    }
+
+    #progress {
+      height: 20px;
+      background-color: var(--primary);
+      border-radius: 6px;
+      transition: width 0.3s ease;
+    }
+
     footer {
       text-align: center;
       padding: 2rem 0;
@@ -315,7 +377,435 @@
     }
   </style>
 </head>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="shortcut icon" href="https://www.espressif.com/sites/all/themes/espressif/favicon.ico" type="image/vnd.microsoft.icon">
+  <title>ESP-IDF Installation Manager Downloads</title>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/3.3.4/vue.global.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/FileSaver.js/2.0.0/FileSaver.min.js"></script>
+  <style>
+    :root {
+      --primary: #e7352c;
+      --primary-dark: #e7210a;
+      --secondary: #6b7280;
+      --background: #f8fafc;
+      --card: #ffffff;
+      --tab-active: #e7352c;
+      --tab-inactive: #9ca3af;
+      --tab-border: #e5e7eb;
+    }
 
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+    }
+
+    body {
+      background: var(--background);
+      min-height: 100vh;
+      color: #1a1a1a;
+    }
+
+    .container {
+      max-width: 1200px;
+      margin: 0 auto;
+      padding: 2rem;
+    }
+
+    header {
+      text-align: center;
+      margin-bottom: 3rem;
+      padding: 2rem 0;
+    }
+
+    .logo-title {
+      font-size: 3rem;
+      font-weight: 800;
+      background: linear-gradient(135deg, var(--primary) 0%, #00a3ff 100%);
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      margin-bottom: 1rem;
+    }
+
+    .subtitle {
+      font-size: 1.125rem;
+      color: var(--secondary);
+      max-width: 600px;
+      margin: 0 auto;
+    }
+
+    .release-version {
+      font-size: 1rem;
+      color: var(--secondary);
+      margin-top: 0.5rem;
+    }
+
+    .tab-container {
+      margin-bottom: 2rem;
+    }
+
+    .tab-buttons {
+      display: flex;
+      justify-content: center;
+      margin-bottom: 0;
+      border-bottom: 2px solid var(--tab-border);
+      background: none;
+    }
+
+    .tab-button {
+      padding: 1rem 2rem;
+      border: none;
+      border-bottom: 3px solid transparent;
+      background: transparent;
+      color: var(--tab-inactive);
+      font-weight: 600;
+      font-size: 1rem;
+      cursor: pointer;
+      transition: all 0.3s ease;
+      position: relative;
+      margin-bottom: -2px;
+    }
+
+    .tab-button.active {
+      color: var(--tab-active);
+      border-bottom-color: var(--tab-active);
+      background: none;
+      box-shadow: none;
+    }
+
+    .tab-button:hover:not(.active) {
+      color: var(--primary-dark);
+      border-bottom-color: #d1d5db;
+    }
+
+    .tab-content {
+      display: none;
+      padding-top: 2rem;
+    }
+
+    .tab-content.active {
+      display: block;
+    }
+
+    .platform-section {
+      margin-bottom: 1.5rem;
+      border-radius: 12px;
+      overflow: hidden;
+      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    }
+
+    .platform-header {
+      background: var(--card);
+      padding: 1.5rem;
+      cursor: pointer;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      transition: background-color 0.3s ease;
+    }
+
+    .platform-header:hover {
+      background: #f1f5f9;
+    }
+
+    .platform-title {
+      font-size: 1.25rem;
+      font-weight: 600;
+      color: var(--primary);
+    }
+
+    .platform-toggle {
+      font-size: 1.5rem;
+      color: var(--secondary);
+      transition: transform 0.3s ease;
+    }
+
+    .platform-toggle.expanded {
+      transform: rotate(90deg);
+    }
+
+    .platform-content {
+      background: var(--card);
+      padding: 0 1.5rem 1.5rem;
+      display: none;
+    }
+
+    .platform-content.expanded {
+      display: block;
+    }
+
+    .installer-group {
+      margin-top: 1rem;
+    }
+
+    .installer-title {
+      font-size: 1.125rem;
+      font-weight: 600;
+      color: var(--secondary);
+      margin-bottom: 1rem;
+      border-bottom: 1px solid #e5e7eb;
+      padding-bottom: 0.5rem;
+    }
+
+    .download-item {
+      background: #f8fafc;
+      border-radius: 8px;
+      padding: 1rem;
+      margin-bottom: 1rem;
+      transition: all 0.3s ease;
+    }
+
+    .download-item:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+    }
+
+    .download-name {
+      font-size: 1rem;
+      font-weight: 600;
+      margin-bottom: 0.5rem;
+    }
+
+    .download-desc {
+      color: var(--secondary);
+      font-size: 0.875rem;
+      margin-bottom: 0.75rem;
+    }
+
+    .download-meta {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+    }
+
+    .download-size {
+      color: var(--secondary);
+      font-size: 0.875rem;
+    }
+
+    .download-buttons {
+      display: flex;
+      gap: 0.5rem;
+      align-items: center;
+    }
+
+    .download-button {
+      background: var(--primary);
+      color: white;
+      padding: 0.5rem 1rem;
+      border-radius: 6px;
+      text-decoration: none;
+      font-weight: 500;
+      transition: background-color 0.3s ease;
+    }
+
+    .download-button:hover {
+      background: var(--primary-dark);
+    }
+
+    .github-button {
+      background: #24292e;
+    }
+
+    .github-button:hover {
+      background: #000000;
+    }
+
+    .github-icon {
+      display: inline-block;
+      vertical-align: middle;
+    }
+
+    .loading {
+      text-align: center;
+      padding: 3rem 0;
+      color: var(--secondary);
+    }
+
+    .loading-spinner {
+      border: 4px solid #f3f3f3;
+      border-top: 4px solid var(--primary);
+      border-radius: 50%;
+      width: 36px;
+      height: 36px;
+      animation: spin 1s linear infinite;
+      margin: 0 auto 1rem;
+    }
+
+    .error {
+      background: #fee2e2;
+      border: 1px solid #fecaca;
+      border-radius: 10px;
+      padding: 1.5rem;
+      text-align: center;
+      color: #dc2626;
+      margin-bottom: 1.5rem;
+    }
+
+    .retry-button {
+      background: var(--primary);
+      color: white;
+      border: none;
+      padding: 0.5rem 1rem;
+      border-radius: 6px;
+      cursor: pointer;
+      font-weight: 500;
+    }
+
+    .warning-message {
+      color: #dc2626;
+      font-weight: 600;
+      margin-bottom: 1rem;
+      background: #fee2e2;
+      border: 1px solid #fecaca;
+      border-radius: 8px;
+      padding: 1rem;
+    }
+
+    #offline-installer-creator {
+      background: var(--card);
+      border-radius: 12px;
+      padding: 2rem;
+      margin-bottom: 1.5rem;
+      box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    #offline-installer-creator h3 {
+      font-size: 1.5rem;
+      font-weight: 600;
+      color: var(--primary);
+      margin-bottom: 1.5rem;
+      text-align: center;
+    }
+
+    .creator-form {
+      display: flex;
+      flex-direction: column;
+      align-items: stretch;
+      gap: 1.5rem;
+      width: 100%;
+      max-width: 500px;
+    }
+
+    .form-row {
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+    }
+
+    .form-row label {
+      font-weight: 600;
+      color: var(--secondary);
+    }
+
+    .radio-button-group {
+      display: flex;
+      border-radius: 6px;
+      overflow: hidden;
+      border: 1px solid #e5e7eb;
+    }
+
+    .radio-button-group input[type="radio"] {
+      display: none;
+    }
+
+    .radio-button-group label {
+      flex: 1;
+      text-align: center;
+      padding: 0.75rem 1rem;
+      cursor: pointer;
+      background: #f9fafb;
+      color: var(--secondary);
+      transition: all 0.2s ease-in-out;
+      border-right: 1px solid #e5e7eb;
+    }
+
+    .radio-button-group label:last-child {
+      border-right: none;
+    }
+
+    .radio-button-group input[type="radio"]:checked + label {
+      background: var(--primary);
+      color: white !important;
+      font-weight: 600;
+    }
+
+    #offline-installer-creator select {
+      padding: 0.75rem;
+      border-radius: 6px;
+      border: 1px solid #e5e7eb;
+      width: 100%;
+      font-size: 1rem;
+    }
+
+    #download-offline-installer {
+      background: var(--primary);
+      color: white;
+      padding: 0.75rem 1.5rem;
+      border-radius: 6px;
+      text-decoration: none;
+      font-weight: 500;
+      transition: background-color 0.3s ease;
+      border: none;
+      cursor: pointer;
+      font-size: 1.1rem;
+      width: 100%;
+    }
+
+    #download-offline-installer:hover {
+      background: var(--primary-dark);
+    }
+
+    #progress-bar {
+      width: 100%;
+      background-color: #e5e7eb;
+      border-radius: 6px;
+      margin-top: 1rem;
+      overflow: hidden;
+    }
+
+    #progress {
+      height: 20px;
+      background-color: var(--primary);
+      border-radius: 6px;
+      transition: width 0.3s ease;
+      width: 0%;
+    }
+
+    footer {
+      text-align: center;
+      padding: 2rem 0;
+      color: var(--secondary);
+    }
+
+    footer a {
+      color: var(--primary);
+      text-decoration: none;
+    }
+
+    footer a:hover {
+      text-decoration: underline;
+    }
+
+    @keyframes spin {
+      0% {
+        transform: rotate(0deg);
+      }
+      100% {
+        transform: rotate(360deg);
+      }
+    }
+  </style>
+</head>
 <body>
   <div id="app" class="container">
     <header>
@@ -381,6 +871,33 @@
                 ⚠️ Warning: Offline installer is large. Only download if you have poor internet or need to install on multiple machines.
               </div>
 
+              <div id="offline-installer-creator">
+                <h3>Offline Installer Creator</h3>
+                <div class="creator-form">
+                  <div class="form-row">
+                    <label>Installer Type</label>
+                    <div class="radio-button-group">
+                      <input type="radio" id="gui-installer" name="installer-type" value="gui" checked>
+                      <label for="gui-installer">GUI</label>
+                      <input type="radio" id="cli-installer" name="installer-type" value="cli">
+                      <label for="cli-installer">CLI</label>
+                    </div>
+                  </div>
+                  <div class="form-row">
+                    <label for="platform">Platform</label>
+                    <select id="platform"></select>
+                  </div>
+                  <div class="form-row">
+                    <label for="idf-version">IDF Version</label>
+                    <select id="idf-version"></select>
+                  </div>
+                  <button id="download-offline-installer">Download</button>
+                  <div id="progress-bar" style="display: none;">
+                    <div id="progress"></div>
+                  </div>
+                </div>
+              </div>
+
               <offline-installer-section
                 v-if="offlineInstallers.length"
                 :offline-installers="offlineInstallers"
@@ -422,7 +939,7 @@
   </div>
 
   <script>
-    const { createApp, ref, onMounted, computed } = Vue;
+    const { createApp, ref, onMounted, computed, nextTick } = Vue;
 
     const GithubIconButton = {
       props: ['href'],
@@ -882,9 +1399,133 @@
           detectPlatform();
         };
 
+        function updateVersionDropdown() {
+          const idfVersionSelect = document.getElementById('idf-version');
+          const platformSelect = document.getElementById('platform');
+          const selectedPlatform = platformSelect.value;
+
+          idfVersionSelect.innerHTML = '';
+
+          const versions = [...new Set(
+            offlineArchiveData.value
+              .filter(item => item.platform === selectedPlatform)
+              .map(item => item.version)
+          )];
+
+          versions.sort().reverse();
+
+          versions.forEach(version => {
+            const option = document.createElement('option');
+            option.value = version;
+            option.textContent = version;
+            idfVersionSelect.appendChild(option);
+          });
+        }
+
+        function populateOfflineCreator() {
+          const platformSelect = document.getElementById('platform');
+
+          const platforms = [...new Set(offlineArchiveData.value.map(item => item.platform))];
+          platforms.forEach(platform => {
+            const option = document.createElement('option');
+            option.value = platform;
+            option.textContent = platform;
+            platformSelect.appendChild(option);
+          });
+
+          const userAgent = navigator.userAgent.toLowerCase();
+          const availablePlatforms = Array.from(platformSelect.options).map(o => o.value);
+          let selectedPlatform = null;
+
+          if (userAgent.includes('win')) {
+            if (availablePlatforms.includes('windows-x64')) {
+              selectedPlatform = 'windows-x64';
+            }
+          } else if (userAgent.includes('linux')) {
+            if (userAgent.includes('aarch64') && availablePlatforms.includes('linux-aarch64')) {
+              selectedPlatform = 'linux-aarch64';
+            } else if (availablePlatforms.includes('linux-x64')) {
+              selectedPlatform = 'linux-x64';
+            }
+          } else if (userAgent.includes('mac')) {
+            const hasAarch64 = availablePlatforms.includes('macos-aarch64');
+            const hasX64 = availablePlatforms.includes('macos-x64');
+            if (hasAarch64 && hasX64) {
+              selectedPlatform = 'macos-aarch64';
+            } else if (hasAarch64) {
+              selectedPlatform = 'macos-aarch64';
+            } else if (hasX64) {
+              selectedPlatform = 'macos-x64';
+            }
+          }
+
+          if (selectedPlatform) {
+            platformSelect.value = selectedPlatform;
+          }
+
+          platformSelect.addEventListener('change', updateVersionDropdown);
+
+          updateVersionDropdown();
+        }
+
         onMounted(() => {
           initializeTabFromUrl();
-          fetchRelease();
+          fetchRelease().then(() => {
+            nextTick(() => {
+              populateOfflineCreator();
+              document.getElementById('download-offline-installer').addEventListener('click', async () => {
+                const installerType = document.querySelector('input[name="installer-type"]:checked').value;
+                const idfVersion = document.getElementById('idf-version').value;
+                const platform = document.getElementById('platform').value;
+
+                const archive = offlineArchiveData.value.find(item => item.version === idfVersion && item.platform === platform);
+                if (!archive) {
+                  alert('Selected archive not found.');
+                  return;
+                }
+
+                const installerAsset = releaseData.value.assets.find(asset => {
+                  const name = asset.name.toLowerCase();
+                  return name.includes(`eim-${installerType}`) && name.includes(platform);
+                });
+
+                if (!installerAsset) {
+                  alert('Selected installer not found.');
+                  return;
+                }
+
+                const archiveUrl = `https://dl.espressif.com/dl/eim/${archive.filename}`;
+                const installerUrl = installerAsset.browser_download_url;
+
+                const progressBar = document.getElementById('progress');
+                const progressBarContainer = document.getElementById('progress-bar');
+                progressBarContainer.style.display = 'block';
+
+                try {
+                  const zip = new JSZip();
+
+                  const [installerResponse, archiveResponse] = await Promise.all([
+                    fetch(installerUrl),
+                    fetch(archiveUrl)
+                  ]);
+
+                  zip.file(installerAsset.name, installerResponse.blob());
+                  zip.file(archive.filename, archiveResponse.blob());
+
+                  const content = await zip.generateAsync({ type: 'blob' }, (metadata) => {
+                    progressBar.style.width = metadata.percent.toFixed(2) + '%';
+                  });
+
+                  saveAs(content, `esp-idf-offline-installer-${idfVersion}-${platform}.zip`);
+                } catch (error) {
+                  console.error('Error creating zip file:', error);
+                  alert('Failed to create zip file.');
+                } finally {
+                  progressBarContainer.style.display = 'none';
+                }
+              });
+            });
+          });
         });
 
         return {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1524,6 +1524,7 @@ dependencies = [
  "dirs 6.0.0",
  "flate2",
  "fork",
+ "fs_extra",
  "git2",
  "idf-env",
  "indicatif",
@@ -1877,6 +1878,12 @@ checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "funty"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -11,7 +11,7 @@ default-run = "eim"
 default = ["gui", "cli", "vendored-openssl"]
 gui = ["dep:tauri", "dep:tauri-build", "dep:tauri-plugin-shell", "dep:tauri-plugin-dialog", "dep:tauri-plugin-log", "dep:num_cpus", "dep:tauri-plugin-store", "dep:tauri-plugin-opener"]
 cli = ["dep:clap", "dep:dialoguer", "dep:indicatif", "dep:console", "dep:log4rs", "vendored-openssl"]
-offline = ["cli"]
+offline = ["cli", "dep:fs_extra"]
 userustpython = ["dep:rustpython-vm", "dep:rustpython-stdlib"]
 vendored-openssl = ["openssl-sys/vendored", "reqwest/native-tls-vendored"]
 
@@ -63,7 +63,7 @@ zstd = "0.13.3"
 chrono = { version = "0.4.42", default-features = false, features = ["serde", "clock"] }
 once_cell = "1.21.3"
 idf-env = { git = "https://github.com/espressif/idf-env", rev="fd69ab4f550ef35647bb32d1584caa6623cbfc4e" }
-
+fs_extra = { version = "1.3.0", optional = true }
 
 # GUI-related dependencies (optional)
 tauri = { version = "2.7.0", features = [], optional = true }
@@ -86,6 +86,7 @@ log4rs = { version = "1.3.0", optional = true }
 rustpython-vm = { git = "https://github.com/Hahihula/RustPython.git", branch = "test-rust-build", features = ["freeze-stdlib"], optional = true }
 rustpython-stdlib = { git = "https://github.com/Hahihula/RustPython.git", branch = "test-rust-build", features = ["ssl-vendor"], optional = true }
 os_info = "3.12.0"
+
 
 
 

--- a/src-tauri/src/offline_installer_builder.rs
+++ b/src-tauri/src/offline_installer_builder.rs
@@ -368,16 +368,30 @@ struct Args {
     /// Each version will create its own .zst archive file
     #[arg(long)]
     build_all_versions: bool,
+
+    /// List all supported IDF versions in machine-readable format and exit
+    /// Output format: one version per line
+    #[arg(long)]
+    list_versions: bool,
 }
 
 #[tokio::main]
 async fn main() {
     let args = Args::parse();
+    if args.list_versions {
+        let versions = idf_im_lib::idf_versions::get_idf_names().await;
+        for version in versions {
+            println!("{}", version);
+        }
+        return;
+    }
 
     // Setup logging
     if let Err(e) = setup_logging(args.verbose) {
         error!("Failed to initialize logging: {e}");
     }
+
+
 
     if args.create_from_config.is_some() {
         info!(

--- a/src-tauri/src/offline_installer_builder.rs
+++ b/src-tauri/src/offline_installer_builder.rs
@@ -358,6 +358,16 @@ struct Args {
     /// If not specified, uses all supported versions for POSIX systems, single version for Windows
     #[arg(long, value_delimiter = ',')]
     wheel_python_versions: Option<Vec<String>>,
+
+    /// Override IDF version (e.g., "v5.1.2", "v5.0.4")
+    /// If specified, only this version will be processed instead of versions from config
+    #[arg(long)]
+    idf_version_override: Option<String>,
+
+    /// Build separate archives for all supported IDF versions
+    /// Each version will create its own .zst archive file
+    #[arg(long)]
+    build_all_versions: bool,
 }
 
 #[tokio::main]
@@ -417,71 +427,31 @@ async fn main() {
 
         info!("Will download wheels for Python versions: {:?}", wheel_python_versions);
 
-        // Download prerequisities and python
-        match std::env::consts::OS {
-            "windows" => {
-                // scoop package manager is used to install dependencies on Windows
-                let scoop_path = archive_dir.path().join("scoop");
-                ensure_path(scoop_path.to_str().unwrap());
-                let scoop_list = vec![
-                    ("https://github.com/ScoopInstaller/Scoop/archive/master.zip", "scoop-master.zip"),
-                    ("https://github.com/ScoopInstaller/Main/archive/master.zip","main-master.zip"),
-                    ("https://github.com/git-for-windows/git/releases/download/v2.50.1.windows.1/PortableGit-2.50.1-64-bit.7z.exe", "PortableGit-2.50.1-64-bit.7z.exe"),
-                    // ("https://www.python.org/ftp/python/3.10.11/python-3.10.11-amd64.exe", "python-3.10.11-amd64.exe"),
-                    ("https://www.python.org/ftp/python/3.11.9/python-3.11.9-amd64.exe", "python-3.11.9-amd64.exe"),
-                    ("https://raw.githubusercontent.com/ScoopInstaller/Main/master/scripts/python/install-pep-514.reg", "install-pep-514.reg"),
-                    ("https://raw.githubusercontent.com/ScoopInstaller/Main/master/scripts/python/uninstall-pep-514.reg", "uninstall-pep-514.reg"),
-                    ("https://www.7-zip.org/a/7z2501-x64.msi", "7z2501-x64.msi"),
-                    ("https://raw.githubusercontent.com/ScoopInstaller/Binary/master/dark/dark-3.14.1.zip","dark-3.14.1.zip")
-                ];
-                for (link, name) in scoop_list {
-                    info!("Downloading Scoop from: {}", link);
-                    match download_file_and_rename(link, scoop_path.to_str().unwrap(), None, Some(name)).await {
-                        Ok(_) => {
-                            info!("Scoop downloaded successfully from: {}", link);
-                        }
-                        Err(err) => {
-                            error!("Failed to download Scoop from {} : {}", link, err);
-                            return;
-                        }
-                    }
-                }
-                let scoop_install_script = include_str!("../powershell_scripts/install_scoop_offline.ps1");
-                fs::write(
-                    scoop_path.join("install_scoop_offline.ps1"),
-                    scoop_install_script,
-                )
-                .expect("Failed to write install_scoop_offline.ps1 script");
-                info!("Scoop install script written to: {:?}", scoop_path.join("install_scoop_offline.ps1"));
-            }
-            "linux" | "macos" => {
-                info!("Detected Unix-like OS, ...");
-                warn!("prerequisites installation is not implemented for Unix-like OSes yet, please install them manually.");
-            }
-            _ => {
-                error!("Unsupported OS: {}", std::env::consts::OS);
-                return;
-            }
-        }
         let versions = idf_im_lib::idf_versions::get_idf_names().await;
-        let version_list = settings
-            .idf_versions
-            .clone()
-            .unwrap_or(vec![versions.first().unwrap().clone()]);
+        let version_list = if let Some(override_version) = args.idf_version_override {
+            info!("Using IDF version override: {}", override_version);
+            vec![override_version]
+        } else if args.build_all_versions {
+            info!("Building separate archives for all supported versions: {:?}", versions);
+            versions.clone() // We'll iterate over all
+        } else {
+            settings
+                .idf_versions
+                .clone()
+                .unwrap_or(vec![versions.first().unwrap().clone()])
+        };
 
         settings.idf_versions = Some(version_list.clone());
-        // check is uv is installed TODO: maybe download uv in case it's missing
-        match execute_command(
-            "uv",
-            &["--version"],
-        ) {
+
+        // Check if uv is installed
+        match execute_command("uv", &["--version"]) {
             Ok(output) => {
-              if output.status.success() {
-                info!("UV is installed: {:?}", output);
-              } else {
-                error!("UV is not installed or not found: {:?}", output);
-                return;
-              }
+                if output.status.success() {
+                    info!("UV is installed: {:?}", output);
+                } else {
+                    error!("UV is not installed or not found: {:?}", output);
+                    return;
+                }
             }
             Err(err) => {
                 error!("UV is not installed or not found: {}. Please install it and try again.", err);
@@ -489,22 +459,73 @@ async fn main() {
             }
         }
 
+        // DOWNLOAD SHARED PREREQUISITES ONCE (Windows only)
+        let shared_prereq_dir: Option<TempDir> = if std::env::consts::OS == "windows" {
+            let temp_shared = TempDir::new().expect("Failed to create shared prereq temp dir");
+            let scoop_path = temp_shared.path().join("scoop");
+            ensure_path(scoop_path.to_str().unwrap()).expect("Failed to create scoop dir");
+
+            let scoop_list = vec![
+                ("https://github.com/ScoopInstaller/Scoop/archive/master.zip", "scoop-master.zip"),
+                ("https://github.com/ScoopInstaller/Main/archive/master.zip", "main-master.zip"),
+                ("https://github.com/git-for-windows/git/releases/download/v2.50.1.windows.1/PortableGit-2.50.1-64-bit.7z.exe", "PortableGit-2.50.1-64-bit.7z.exe"),
+                ("https://www.python.org/ftp/python/3.11.9/python-3.11.9-amd64.exe", "python-3.11.9-amd64.exe"),
+                ("https://raw.githubusercontent.com/ScoopInstaller/Main/master/scripts/python/install-pep-514.reg", "install-pep-514.reg"),
+                ("https://raw.githubusercontent.com/ScoopInstaller/Main/master/scripts/python/uninstall-pep-514.reg", "uninstall-pep-514.reg"),
+                ("https://www.7-zip.org/a/7z2501-x64.msi", "7z2501-x64.msi"),
+                ("https://raw.githubusercontent.com/ScoopInstaller/Binary/master/dark/dark-3.14.1.zip", "dark-3.14.1.zip"),
+            ];
+
+            for (link, name) in scoop_list {
+                info!("Downloading Scoop prereq: {} as {}", link, name);
+                match download_file_and_rename(link, scoop_path.to_str().unwrap(), None, Some(name)).await {
+                    Ok(_) => info!("Downloaded: {}", name),
+                    Err(err) => {
+                        error!("Failed to download {}: {}", name, err);
+                        return;
+                    }
+                }
+            }
+
+            let scoop_install_script = include_str!("../powershell_scripts/install_scoop_offline.ps1");
+            fs::write(scoop_path.join("install_scoop_offline.ps1"), scoop_install_script)
+                .expect("Failed to write install_scoop_offline.ps1 script");
+
+            info!("Shared Windows prerequisites downloaded to: {:?}", temp_shared.path());
+            Some(temp_shared)
+        } else if std::env::consts::OS == "linux" || std::env::consts::OS == "macos" {
+            info!("Detected Unix-like OS, prerequisites installation not implemented — skipping.");
+            None
+        } else {
+            error!("Unsupported OS: {}", std::env::consts::OS);
+            return;
+        };
+
+        // ITERATE OVER EACH VERSION AND BUILD SEPARATE ARCHIVE
         for idf_version in version_list {
+            info!("=== Processing ESP-IDF version: {} ===", idf_version);
+
+            // Create a fresh temp dir for this version
+            let archive_dir = TempDir::new().expect("Failed to create version-specific temp dir");
             let version_path = archive_dir.path().join(&idf_version);
-            ensure_path(version_path.to_str().unwrap())
-                .expect("Failed to ensure path for IDF version");
-            info!(
-                "Preparing installation data for ESP-IDF version: {} to folder {:?}",
-                idf_version,
-                version_path.display()
-            );
+            ensure_path(version_path.to_str().unwrap()).expect("Failed to ensure version path");
 
-            // download idf
+            // 👇 COPY SHARED PREREQUISITES (if any)
+            if let Some(ref shared_dir) = shared_prereq_dir {
+                let dest_scoop = archive_dir.path().join("scoop");
+                info!("Copying shared prerequisites to: {:?}", dest_scoop);
+                fs_extra::dir::copy(
+                    shared_dir.path().join("scoop"),
+                    &dest_scoop,
+                    &fs_extra::dir::CopyOptions::new().overwrite(true).copy_inside(true),
+                )
+                .expect("Failed to copy shared prerequisites");
+            }
+
+            // Download ESP-IDF for this version
             let (tx, rx) = mpsc::channel();
-
             let handle = thread::spawn(move || {
                 let mut progress_bar = create_progress_bar();
-
                 loop {
                     match rx.recv() {
                         Ok(ProgressMessage::Finish) => {
@@ -527,12 +548,11 @@ async fn main() {
                             println!("submodule: {}", name);
                             progress_bar = create_progress_bar();
                         }
-                        Err(_) => {
-                            break;
-                        }
+                        Err(_) => break,
                     }
                 }
             });
+
             let idf_path = version_path.join("esp-idf");
             match idf_im_lib::get_esp_idf(
                 idf_path.to_str().unwrap(),
@@ -542,79 +562,60 @@ async fn main() {
                 true,
                 tx,
             ) {
-                Ok(_) => {
-                    info!("ESP-IDF version {} downloaded successfully.", idf_version);
-                }
+                Ok(_) => info!("ESP-IDF version {} downloaded successfully.", idf_version),
                 Err(err) => {
-                    error!("Failed to download ESP-IDF version: {}", idf_version);
+                    error!("Failed to download ESP-IDF version {}: {}", idf_version, err);
+                    continue; // Skip to next version
                 }
             }
+            handle.join().unwrap(); // Wait for progress bar thread to finish
+
+            // Read tools.json
             let tools_json_file = idf_path
-                .clone()
-                .join(
-                    settings
-                        .clone()
-                        .tools_json_file
-                        .clone()
-                        .unwrap_or(Settings::default().tools_json_file.unwrap()),
-                )
+                .join(settings.tools_json_file.clone().unwrap_or_else(|| Settings::default().tools_json_file.unwrap()))
                 .to_str()
-                .expect("Failed to convert tools json file path to string")
+                .expect("Failed to convert tools json path")
                 .to_string();
 
-            debug!("Tools json file: {}", tools_json_file);
             let tools = match idf_im_lib::idf_tools::read_and_parse_tools_file(&tools_json_file) {
                 Ok(tools) => tools,
                 Err(err) => {
-                error!("Failed to read tools json file: {}", err);
-                    return;
+                    error!("Failed to read tools json file: {}", err);
+                    continue;
                 }
             };
+
             let download_links = get_list_of_tools_to_download(
                 tools.clone(),
                 settings.clone().target.unwrap_or(vec!["all".to_string()]),
                 settings.mirror.as_deref(),
             );
+
             let tool_path = archive_dir.path().join("dist");
-            ensure_path(tool_path.to_str().unwrap()).expect("Failed to ensure path for tools");
+            ensure_path(tool_path.to_str().unwrap()).expect("Failed to ensure tools path");
+
             for (tool_name, (version, download_link)) in download_links.iter() {
-                info!(
-                    "Preparing tool: {} version: {} download link: {:?}",
-                    tool_name, version, download_link
-                );
+                info!("Preparing tool: {} version: {} from: {}", tool_name, version, download_link.url);
                 match download_file(&download_link.url, tool_path.to_str().unwrap(), None).await {
                     Ok(_) => {
-                        let file_path = Path::new(&download_link.url);
-                        let filename = file_path.file_name().unwrap().to_str().unwrap();
-
+                        let filename = Path::new(&download_link.url).file_name().unwrap().to_str().unwrap();
                         let full_file_path = tool_path.join(filename);
-                        if verify_file_checksum(
-                            &download_link.sha256,
-                            full_file_path.to_str().unwrap(),
-                        )
-                        .unwrap()
-                        {
-                        info!(
-                            "Tool {} version {} downloaded successfully.",
-                            tool_name, version
-                        );
+
+                        if verify_file_checksum(&download_link.sha256, full_file_path.to_str().unwrap()).unwrap() {
+                            info!("Tool {} version {} downloaded and verified.", tool_name, version);
                         } else {
-                            error!(
-                                "Checksum verification failed for tool {} version {}.",
-                                tool_name, version
-                            );
-                            panic!(
-                                "Checksum verification failed for tool {} version {}.",
-                                tool_name, version
-                            );
+                            error!("Checksum failed for tool {} version {}.", tool_name, version);
+                            continue;
                         }
                     }
                     Err(err) => {
                         error!("Failed to download tool {}: {}", tool_name, err);
+                        continue;
                     }
                 }
             }
-            // download constrain file
+
+            // Download constraints file
             let constrains_idf_version = match parse_cmake_version(idf_path.to_str().unwrap()) {
                 Ok((maj, min)) => format!("v{}.{}", maj, min),
                 Err(e) => {
@@ -622,110 +623,92 @@ async fn main() {
                     idf_version.to_string()
                 }
             };
-            let constraint_file =
-                match download_constraints_file(&archive_dir.path(), &constrains_idf_version).await {
-                    Ok(constraint_file) => {
-                        info!("Downloaded constraints file: {}", constraint_file.display());
-                        Some(constraint_file)
-                    }
-                    Err(e) => {
-                        warn!("Failed to download constraints file: {}", e);
-                        None
-                    }
-                };
-            if constraint_file.is_none() {
-                error!(
-                    "Failed to download constraints file for IDF version {}",
-                    idf_version
-                );
-                return;
-            } else {
-                info!(
-                    "Constraints file downloaded successfully for IDF version {}",
-                    idf_version
-                );
-            }
 
-            // Merge requirements files
+            let constraint_file = match download_constraints_file(&archive_dir.path(), &constrains_idf_version).await {
+                Ok(file) => {
+                    info!("Downloaded constraints: {}", file.display());
+                    file
+                }
+                Err(e) => {
+                    error!("Failed to download constraints for {}: {}", idf_version, e);
+                    continue;
+                }
+            };
+
+            // Merge requirements
             let requirements_dir = idf_path.join("tools").join("requirements");
             if let Err(e) = merge_requirements_files(&requirements_dir) {
-                error!("Failed to merge requirements files: {}", e);
-                return;
+                error!("Failed to merge requirements: {}", e);
+                continue;
             }
 
-            // Download wheels for multiple Python versions
             let requirements_file = requirements_dir.join("requirements.merged.txt");
-            let constraint_file = constraint_file.unwrap();
 
             let wheel_versions: Vec<&str> = wheel_python_versions.iter().map(|s| s.as_str()).collect();
-
             if let Err(e) = download_wheels_for_python_versions(
                 archive_dir.path(),
                 &requirements_file,
                 &constraint_file,
                 &wheel_versions,
             ).await {
-                error!("Failed to download wheels: {}", e);
-                return;
+                error!("Failed to download wheels for {}: {}", idf_version, e);
+                continue;
             }
+
+            // Save settings for this version
+            let mut version_settings = settings.clone();
+            version_settings.idf_versions = Some(vec![idf_version.clone()]);
+            version_settings.config_file_save_path = Some(archive_dir.path().join("config.toml"));
+            version_settings.idf_path = None;
+
+            if let Err(e) = version_settings.save() {
+                error!("Failed to save settings for {}: {}", idf_version, e);
+                continue;
+            }
+
+            // CREATE INDIVIDUAL ARCHIVE PER VERSION
+            let output_path = PathBuf::from(format!("archive_{}.zst", idf_version));
+            let mut output_file = match File::create(&output_path) {
+                Ok(f) => f,
+                Err(e) => {
+                    error!("Failed to create output file {}: {}", output_path.display(), e);
+                    continue;
+                }
+            };
+
+            // Tar + Zstd compress
+            let mut tar = TarBuilder::new(Vec::new());
+            if let Err(e) = tar.append_dir_all(".", archive_dir.path()) {
+                error!("Failed to create tar for {}: {}", idf_version, e);
+                continue;
+            }
+
+            let tar_data = match tar.into_inner() {
+                Ok(data) => data,
+                Err(e) => {
+                    error!("Failed to finalize tar for {}: {}", idf_version, e);
+                    continue;
+                }
+            };
+
+            let compressed_data = match encode_all(&tar_data[..], 3) {
+                Ok(data) => data,
+                Err(e) => {
+                    error!("Failed to compress with zstd for {}: {}", idf_version, e);
+                    continue;
+                }
+            };
+
+            if let Err(e) = output_file.write_all(&compressed_data) {
+                error!("Failed to write compressed data for {}: {}", idf_version, e);
+                continue;
+            }
+
+            info!("✅ Archive for {} saved to: {:?}", idf_version, output_path);
         }
 
-        settings.config_file_save_path = Some(archive_dir.path().join("config.toml"));
-        settings.idf_path = None;
-
-        match settings.save() {
-          Ok(_) => {
-            info!("Settings saved successfully.");
-          }
-          Err(e) => {
-            error!("Failed to save settings: {}", e);
-            return;
-          }
-        }
-        // Create a .zst file in the current directory
-        let output_path = PathBuf::from(format!(
-            "archive_{}.zst", //TODO: read path from param
-            settings
-                .idf_versions
-                .unwrap_or(vec!["default".to_string()])
-                .join("_")
-        ));
-        let mut output_file = match File::create(&output_path) {
-            Ok(f) => f,
-            Err(e) => {
-                error!("Failed to create output zst file: {}", e);
-                return;
-            }
-        };
-
-        // Compress the archive_dir into a .zst file
-        let mut tar = TarBuilder::new(Vec::new());
-        if let Err(e) = tar.append_dir_all(".", archive_dir.path()) {
-            error!("Failed to create tar archive: {}", e);
-            return;
-        }
-        let tar_data = match tar.into_inner() {
-            Ok(data) => data,
-            Err(e) => {
-                error!("Failed to finalize tar archive: {}", e);
-                return;
-            }
-        };
-        // Compression level 3 is almost instant, just IDF  results in 2.2GB archive, level 19 took 8 minutes resulting in 2.1G archive
-        let compressed_data = match encode_all(&tar_data[..], 3) {
-            Ok(data) => data,
-            Err(e) => {
-                error!("Failed to compress with zstd: {}", e);
-                return;
-            }
-        };
-        if let Err(e) = output_file.write_all(&compressed_data) {
-            error!("Failed to write compressed data: {}", e);
-            return;
-        }
-
-        info!("Compressed archive saved to {:?}", output_path);
-        return;
+        info!("🎉 All requested versions processed.");
+        return; // Exit after creating archives
     } else if let Some(archive_path) = args.archive {
         // Extract installation data from archive
         info!("Extracting installation data from archive: {:?}", archive_path);


### PR DESCRIPTION
on release the pipeline should purge all existing offline installers from s3 and build offline archives for all IDF versions
manual run enables now to specify single version or all.