### PR TITLE
Removed the duplicate 'Produce Selector' from gui

### DIFF
--- a/src/components/wizard_steps/TargetSelect.vue
+++ b/src/components/wizard_steps/TargetSelect.vue
@@ -2,9 +2,7 @@
   <div class="target-select" data-id="target-select">
     <h1 class="title" data-id="target-select-title">{{ t('targetSelect.title') }}</h1>
     <p class="description" data-id="target-select-description">{{ t('targetSelect.description') }}</p>
-    <p class="description" data-id="target-select-description-second-line">{{ t('targetSelect.productSelectorMessage') }} <a
-        href="https://products.espressif.com/#/product-comparison?names=ESP32-S2,ESP32-C3,ESP32-S3,ESP32-C6&type=SoC"
-        target="_blank">{{ t('targetSelect.productSelector') }}</a></p>
+
     <div class="selection_header">
       {{ t('targetSelect.targetChips') }}
       <span @click="clickOnAll">
@@ -37,6 +35,10 @@
         </div>
       </n-spin>
     </n-card>
+    <hr></hr>
+    <p class="description" data-id="target-select-description-second-line">{{ t('targetSelect.productSelectorMessage') }} <a
+        href="https://products.espressif.com/#/product-comparison?names=ESP32-S2,ESP32-C3,ESP32-S3,ESP32-C6&type=SoC"
+        target="_blank">{{ t('targetSelect.productSelector') }}</a></p>
   </div>
 </template>
 


### PR DESCRIPTION
there was text duplication in GUI
<img width="643" height="222" alt="image" src="https://github.com/user-attachments/assets/84a23b6f-e5b9-4011-a2a6-6b7b9eea1b26" />

... is now removed
<img width="1006" height="646" alt="image" src="https://github.com/user-attachments/assets/acffdfd2-5d17-4615-b997-70207e623159" />
.. and the link is moved below the form