### PR TITLE
EIM-350 unify which version of python gets installed as part of install prerequisities on windows

### DIFF
--- a/src-tauri/src/cli/prompts.rs
+++ b/src-tauri/src/cli/prompts.rs
@@ -145,7 +145,7 @@ pub fn check_and_install_python(
             };
 
             if res.map_err(|e| e.to_string())? {
-                system_dependencies::install_prerequisites(vec!["python313".to_string()])
+                system_dependencies::install_prerequisites(vec![idf_im_lib::system_dependencies::PYTHON_NAME_TO_INSTALL.to_string()])
                     .map_err(|e| e.to_string())?;
                 let scp = system_dependencies::get_scoop_path();
                 let usable_python = match scp {

--- a/src-tauri/src/gui/commands/prequisites.rs
+++ b/src-tauri/src/gui/commands/prequisites.rs
@@ -132,7 +132,7 @@ pub fn python_sanity_check(app_handle: AppHandle, python: Option<&str>) -> bool 
 /// Installs Python
 #[tauri::command]
 pub fn python_install(app_handle: AppHandle) -> bool {
-    match idf_im_lib::system_dependencies::install_prerequisites(vec!["python".to_string()]) {
+    match idf_im_lib::system_dependencies::install_prerequisites(vec![idf_im_lib::system_dependencies::PYTHON_NAME_TO_INSTALL.to_string()]) {
         Ok(_) => true,
         Err(err) => {
             let error_msg = t!("gui.system_dependencies.error_installing_python", error = err.to_string()).to_string();

--- a/src-tauri/src/lib/system_dependencies.rs
+++ b/src-tauri/src/lib/system_dependencies.rs
@@ -5,6 +5,8 @@ use log::{debug, trace, warn};
 
 use crate::{command_executor, utils::find_by_name_and_extension};
 
+pub const PYTHON_NAME_TO_INSTALL: &str = "python313";
+
 /// Determines the package manager installed on the system.
 ///
 /// This function attempts to identify the package manager by executing each


### PR DESCRIPTION

now it should be fixed on 3.13 with constatnt in the common library so it should never diverge again