### PR TITLE
EIM-368 implement block navigation while installation is running

### DIFF
--- a/src/components/wizard_steps/InstalationProgress.vue
+++ b/src/components/wizard_steps/InstalationProgress.vue
@@ -190,6 +190,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { NButton, NSpin, NCard, NTag, NTabs, NTabPane, NTable, NCollapse, NCollapseItem, NAlert, NProgress } from 'naive-ui'
 import { listen } from '@tauri-apps/api/event'
 import { useWizardStore } from '../../store'
+import { navigationState } from '../../router';
 import { useI18n } from 'vue-i18n'
 
 export default {
@@ -213,6 +214,13 @@ export default {
   setup() {
     const { t } = useI18n()
     return { t }
+  },
+
+  watch: {
+    installation_running(newValue) {
+      // Update the shared navigation state
+      navigationState.setInstallationRunning(newValue);
+    }
   },
 
   data() {
@@ -805,6 +813,7 @@ export default {
     this.startListening();
     this.measureContainer();
     window.addEventListener('resize', this.measureContainer);
+    navigationState.setInstallationRunning(this.installation_running);
 
     if (this.is_fix_mode && this.$route.query.mode === 'fix') {
       this.installation_running = true;
@@ -826,6 +835,7 @@ export default {
   },
 
   beforeUnmount() {
+    navigationState.setInstallationRunning(false);
     this.cleanup();
   },
 }

--- a/src/router.js
+++ b/src/router.js
@@ -8,6 +8,13 @@ import InstallationProgress from "./components/wizard_steps/InstalationProgress.
 import SimpleInstallatioProgressWrapper from "./components/SimpleInstallatioProgressWrapper.vue";
 import WizardStep from "./components/WizardStep.vue";
 
+export const navigationState = {
+  installationRunning: false,
+  setInstallationRunning(value) {
+    this.installationRunning = value;
+  }
+};
+
 const routes = [
   {
     path: "/",
@@ -77,8 +84,11 @@ const router = createRouter({
 
 // Navigation guard to check prerequisites or handle navigation logic
 router.beforeEach(async (to, from, next) => {
-  // You can add logic here to check if the app should skip welcome screen
-  // based on saved preferences
+  // Prevent navigation if installation is running
+  if (navigationState.installationRunning) {
+    next(false); // Block navigation
+    return;
+  }
   next();
 });
 


### PR DESCRIPTION
now navigation (even the top logo) should be blocked while installation is running