### PR TITLE
EIM-391 gui now correctly interprets the -v param

### DIFF
--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -567,7 +567,12 @@ pub async fn run_cli(cli: Cli) -> anyhow::Result<()> {
         Commands::Gui(_install_args) => {
             #[cfg(not(feature = "gui"))]
             unimplemented!("GUI not present in this type of build");
-            gui::run();
+            let log_level = match cli.verbose {
+                0 => LevelFilter::Info,
+                1 => LevelFilter::Debug,
+                _ => LevelFilter::Trace,
+            };
+            gui::run(Some(log_level));
             Ok(())
         }
         Commands::InstallDrivers => {

--- a/src-tauri/src/gui/mod.rs
+++ b/src-tauri/src/gui/mod.rs
@@ -180,7 +180,7 @@ fn is_process_running(pid: u32) -> bool {
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
-pub fn run() {
+pub fn run(leg_level_override: Option<log::LevelFilter>) {
     // this is here because macos bundled .app does not inherit path
     #[cfg(target_os = "macos")]
     {
@@ -207,9 +207,9 @@ pub fn run() {
                         file_name: Some("eim_gui_log".to_string()),
                     },
                 ))
-                .level(log::LevelFilter::Info)
-                .level_for("idf_im_lib", log::LevelFilter::Info)
-                .level_for("eim_lib", log::LevelFilter::Info)
+                .level(leg_level_override.unwrap_or(log::LevelFilter::Info))
+                .level_for("idf_im_lib", leg_level_override.unwrap_or(log::LevelFilter::Info))
+                .level_for("eim_lib", leg_level_override.unwrap_or(log::LevelFilter::Info))
                 .build(),
         )
         .plugin(tauri_plugin_dialog::init())

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -137,7 +137,7 @@ async fn main() {
     #[cfg(not(feature = "cli"))]
     {
         set_locale(&None);
-        gui::run();
+        gui::run(None);
     }
     // both GUI and CLI features are enabled
     #[cfg(target_os = "windows")]


### PR DESCRIPTION
now when running the gui like ` eim -vvv gui ` the log levels will be set to trace (or accorging to the number of 'v's 
then running directly as the gui without the terminal, behaviour should stay the same as now.