### PR TITLE
reset settings after finished installation

### DIFF
--- a/src-tauri/src/gui/app_state.rs
+++ b/src-tauri/src/gui/app_state.rs
@@ -17,9 +17,9 @@ pub struct WizardData {
 /// Application state that is managed by Tauri and accessible across commands
 #[derive(Default, Serialize, Deserialize)]
 pub struct AppState {
-    wizard_data: Mutex<WizardData>,
-    settings: Mutex<Settings>,
-    is_installing: Mutex<bool>,
+    pub wizard_data: Mutex<WizardData>,
+    pub settings: Mutex<Settings>,
+    pub is_installing: Mutex<bool>,
 }
 
 /// Gets the current settings from the app state

--- a/src-tauri/src/gui/commands/settings.rs
+++ b/src-tauri/src/gui/commands/settings.rs
@@ -1,5 +1,5 @@
 use tauri::{AppHandle, Manager};
-use idf_im_lib::{settings,to_absolute_path, utils::is_valid_idf_directory};
+use idf_im_lib::{settings::{self, Settings},to_absolute_path, utils::is_valid_idf_directory};
 use crate::gui::{
   app_state::{self, get_locked_settings, get_settings_non_blocking, update_settings, AppState},
   ui::send_message,
@@ -369,4 +369,18 @@ pub async fn is_path_empty_or_nonexistent_command(app_handle: AppHandle, path: S
 #[tauri::command]
 pub async fn is_path_idf_directory(_app_handle: AppHandle, path: String) -> bool {
    is_valid_idf_directory(&path)
+}
+
+/// Resets the settings to their default values
+#[tauri::command]
+pub fn reset_settings_to_default(app_handle: AppHandle) -> Result<(), String> {
+    let app_state = app_handle.state::<AppState>();
+    let mut settings = app_state.settings.lock().map_err(|_| {
+        "Failed to obtain lock on AppState. Please retry the last action later.".to_string()
+    })?;
+
+    *settings = Settings::default();
+    log::info!("Settings reset to default values");
+
+    Ok(())
 }

--- a/src-tauri/src/gui/mod.rs
+++ b/src-tauri/src/gui/mod.rs
@@ -274,6 +274,7 @@ pub fn run() {
             get_features_list_all_versions,
             set_selected_features_per_version,
             get_selected_features_per_version,
+            reset_settings_to_default,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src/components/wizard_steps/Complete.vue
+++ b/src/components/wizard_steps/Complete.vue
@@ -128,6 +128,9 @@ export default {
   },
   mounted() {
     this.get_os();
+  },
+  beforeUnmount() {
+    const _ = invoke("reset_settings_to_default", {});
   }
 }
 </script>


### PR DESCRIPTION
now the setting chosen by user during the expert installation should not persist to other installations