### PR TITLE
Fix windows version selection

### DIFF
--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -160,13 +160,6 @@ pub async fn run_cli(cli: Cli) -> anyhow::Result<()> {
                   if install_args.install_all_prerequisites.is_none() { // if cli argument is not set
                     settings.install_all_prerequisites = Some(true); // The non-interactive install will always install all prerequisites
                   }
-                  if install_args.idf_versions.is_none() {
-                    settings.idf_versions = match get_latest_idf_version(false).await {
-                      Ok(Some(version)) => Some(vec![version.name]),
-                      Ok(None) => None,
-                      Err(_) => None,
-                    };
-                  }
                   debug!("Settings after adjustments: {:?}", settings);
                   let time = std::time::SystemTime::now();
                   if !do_not_track {

--- a/src-tauri/src/cli/prompts.rs
+++ b/src-tauri/src/cli/prompts.rs
@@ -25,9 +25,11 @@ pub async fn select_idf_version(
 ) -> Result<Vec<String>, String> {
     let mut avalible_versions = if target == "all" {
         //todo process vector of targets
-        idf_im_lib::idf_versions::get_idf_names(true).await
+        // in non-interactive mode, we want to skip pre-releases
+        idf_im_lib::idf_versions::get_idf_names(!non_interactive).await
     } else {
-        idf_im_lib::idf_versions::get_idf_name_by_target(&target.to_string().to_lowercase(),true).await
+        // in non-interactive mode, we want to skip pre-releases
+        idf_im_lib::idf_versions::get_idf_name_by_target(&target.to_string().to_lowercase(),!non_interactive).await
     };
     avalible_versions.push("master".to_string());
     if non_interactive {


### PR DESCRIPTION
the logic of skipping the pre-release version introduced the error that the value from config was ignored (which in case of windows means the whole gui selection was ignored too as the selection is pased using the config internaly)

Tested the builded binaries on windows. Confirmed that it solves the issue.