### PR TITLE
feat: Add codepell check

### DIFF
--- a/.github/workflows/pre_check.yml
+++ b/.github/workflows/pre_check.yml
@@ -1,0 +1,47 @@
+name: Spell Check (typos)
+
+# Triggers on pull requests and pushes to master or main branches
+on:
+  pull_request:
+  push:
+    branches: [master, main]
+
+jobs:
+  typos:
+    runs-on: ubuntu-latest
+    steps:
+      # Fetches full Git history to enable branch comparison
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # Identifies changed files using git diff
+      - name: Get modified files
+        id: modified_files
+        run: |
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            BASE_BRANCH="${{ github.base_ref }}"
+            git fetch origin $BASE_BRANCH --depth=1
+            MODIFIED_FILES="$(git diff --name-only origin/$BASE_BRANCH...HEAD || echo "")"
+          else
+            MODIFIED_FILES="$(git diff --name-only HEAD~1 HEAD || echo "")"
+          fi
+
+          if [ -n "$MODIFIED_FILES" ]; then
+            echo "Modified files to check:"
+            echo "$MODIFIED_FILES"
+            echo "files=$(echo "$MODIFIED_FILES" | tr '\n' ' ')" >> $GITHUB_OUTPUT
+            echo "has_files=true" >> $GITHUB_OUTPUT
+          else
+            echo "No modified files to check."
+            echo "has_files=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Run typos on modified files
+        if: steps.modified_files.outputs.has_files == 'true'
+        uses: crate-ci/typos@v1
+        with:
+          config: .typos.toml
+          files: ${{ steps.modified_files.outputs.files }}
+

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,17 @@
+[files]
+extend-exclude = [
+  "*.lock",
+  "*.rs",
+  "*.vue",
+  "*.js",
+  "*.json",
+  "*.ps1",
+  "man",
+  "build",
+  "src-tauri/locales/app.yml",
+]
+
+[default.extend-words]
+bu = "bu"
+inout = "inout"
+NEmpty = "NEmpty"

--- a/docs/src/expert_installation.md
+++ b/docs/src/expert_installation.md
@@ -2,7 +2,7 @@
 
 Expert installation is a wizard that guides you through the installation process step by step, enabling you to customize installation settings as needed.
 
-## Prerequisities Check
+## Prerequisites Check
 
 The installer will first verify that all prerequisites are met.
 

--- a/docs/src/simple_installation.md
+++ b/docs/src/simple_installation.md
@@ -2,7 +2,7 @@
 
 The easy installation is a streamlined process with default settings, ideal for most users who want to quickly get started with ESP-IDF development. You can choose this option from the main installation screen, which also offers expert installation, loading a configuration file, or offline installation.
 
-Once you select simplified installation, the process will check prerequisities and path avalibility ant wait for user confirmation.
+Once you select simplified installation, the process will check prerequisites and path availability, then wait for user confirmation.
 
 ![Easy Installation Ready](./screenshots/easy_install_ready.png)
 


### PR DESCRIPTION
This PR adds a `codespell` job to the workflow checks, preventing possible typos from being committed. 
The following file types and paths are excluded from the check:

-  `*.lock`
- `*.rs`
- `*.vue`
- `*.js`
- `*.json`
- `*.ps1`
- files in `build` and `man` folders
- src-tauri/locales/app.yml