### PR TITLE
EIM-348 rearranged version selector UI

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -2,6 +2,7 @@
   --background-color: #f0f0f0;
   --text-color: #333333;
   --primary-color: #f0f0f0;
+  --n-primary-color-suppl: #ecf5fe;
   --secondary-color: #5AC8FA;
   --espressif-red-color: #E8362D;
   --border-color: #d1d1d1;

--- a/src/components/wizard_steps/VersionItem.vue
+++ b/src/components/wizard_steps/VersionItem.vue
@@ -1,0 +1,146 @@
+<template>
+  <div
+    class="version-item"
+    :class="[{ 'selected': selected }, type]"
+    :data-id="`version-item-${version.name}`"
+    @click="toggle"
+  >
+    <div class="version-content" :data-id="`version-content-${version.name}`">
+      <div class="version-header" :data-id="`version-header-${version.name}`">
+        <span class="version-name" :data-id="`version-name-${version.name}`">{{ version.name }}</span>
+        <div class="version-tags">
+          <n-tag
+            v-if="version.latest"
+            type="error"
+            size="small"
+            :data-id="`version-latest-tag-${version.name}`"
+          >
+            {{ t('versionSelect.tags.latest') }}
+          </n-tag>
+          <n-tag
+            v-if="version.pre_release"
+            type="warning"
+            size="small"
+            :data-id="`version-prerelease-tag-${version.name}`"
+          >
+            {{ t('versionSelect.tags.preRelease') }}
+          </n-tag>
+          <n-tag
+            v-if="version.is_master"
+            type="error"
+            size="small"
+            :data-id="`version-unstable-tag-${version.name}`"
+          >
+            {{ t('versionSelect.tags.unstable') }}
+          </n-tag>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { NTag } from 'naive-ui';
+import { useI18n } from 'vue-i18n';
+
+export default {
+  name: 'VersionItem',
+  components: { NTag },
+  props: {
+    version: Object,
+    selected: Boolean,
+    type: String,
+  },
+  setup() {
+    const { t } = useI18n();
+    return { t };
+  },
+  methods: {
+    toggle() {
+      this.$emit('toggle', this.version.name);
+    },
+  },
+};
+</script>
+
+<style scoped>
+.version-item {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  padding: 16px;
+  border: 2px solid var(--n-border-color);
+  border-radius: 10px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  background-color: var(--n-card-color);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.version-item:hover {
+  border-color: var(--n-primary-color);
+  background-color: var(--n-primary-color-hover);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+.version-item.selected {
+  border-color: var(--n-primary-color);
+  background-color: var(--n-primary-color-suppl);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+.version-item.prerelease {
+  border-style: dashed;
+}
+
+.version-item.development {
+  border-color: var(--espressif-red-color);
+  border-style: dashed;
+}
+
+.version-item.development:hover {
+  border-color: var(--espressif-red-color);
+  background-color: rgba(208, 48, 80, 0.05);
+}
+
+.version-item.development.selected {
+  background-color: rgba(208, 48, 80, 0.1);
+}
+
+.version-content {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  flex: 1;
+  text-align: center;
+}
+
+.version-header {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+}
+
+.version-name {
+  font-weight: 600;
+  font-size: 15px;
+  color: var(--n-text-color);
+}
+
+.version-tags {
+  display: flex;
+  gap: 4px;
+}
+
+.version-description {
+  font-size: 12px;
+  color: var(--n-text-color-3);
+}
+
+.development-warning {
+  color: var(--espressif-red-color);
+  font-style: italic;
+}
+</style>

--- a/src/components/wizard_steps/VersionSection.vue
+++ b/src/components/wizard_steps/VersionSection.vue
@@ -1,0 +1,100 @@
+<template>
+  <div class="version-section" :data-id="`${type}-versions-section`">
+    <div class="section-header" :data-id="`${type}-section-header`">
+      <h2 class="section-title">{{ title }}</h2>
+    </div>
+    <p v-if="description && type != 'prerelease' && type != 'development'" class="section-description" :data-id="`${type}-section-description`">
+      {{ description }}
+    </p>
+    <n-alert
+      v-if="type === 'prerelease' || type === 'development'"
+      :type="type === 'development' ? 'warning' : 'info'"
+      :show-icon="true"
+      class="section-alert"
+      :class="{ warning: type === 'development' }"
+      :data-id="`${type}-alert`"
+    >
+      <template v-if="type === 'development'" #header>
+        {{ t('versionSelect.sections.development.warningTitle') }}
+      </template>
+      {{ description }}
+    </n-alert>
+    <div class="versions-grid" :data-id="`${type}-versions-grid`">
+      <version-item
+        v-for="version in versions"
+        :key="version.name"
+        :version="version"
+        :selected="selected.includes(version.name)"
+        :type="type"
+        @toggle="$emit('toggle', $event)"
+      />
+    </div>
+  </div>
+</template>
+
+<script>
+import { NAlert } from 'naive-ui';
+import { useI18n } from 'vue-i18n';
+import VersionItem from './VersionItem.vue';
+
+export default {
+  name: 'VersionSection',
+  components: { NAlert, VersionItem },
+  props: {
+    title: String,
+    description: String,
+    versions: Array,
+    selected: Array,
+    type: String,
+  },
+  setup() {
+    const { t } = useI18n();
+    return { t };
+  },
+};
+</script>
+
+<style scoped>
+.version-section {
+  margin-bottom: 32px;
+}
+
+.version-section:last-of-type {
+  margin-bottom: 24px;
+}
+
+.section-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 8px;
+}
+
+.section-title {
+  font-size: 18px;
+  font-weight: 600;
+  margin: 0;
+  color: var(--n-text-color);
+}
+
+.section-description {
+  color: var(--n-text-color-3);
+  font-size: 13px;
+  margin-bottom: 16px;
+  padding-left: 30px;
+}
+
+.section-alert {
+  margin-bottom: 16px;
+}
+
+.section-alert.warning {
+  border-left: 4px solid #f0a020;
+}
+
+.versions-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  gap: 12px;
+}
+</style>

--- a/src/components/wizard_steps/VersionSelect.vue
+++ b/src/components/wizard_steps/VersionSelect.vue
@@ -5,38 +5,66 @@
 
     <n-card class="selection-card" data-id="version-selection-card">
       <n-spin :show="loading" data-id="version-loading-spinner">
-        <div class="versions-grid" data-id="versions-grid">
-          <div v-for="version in versions" :key="version.name" class="version-item"
-            :class="{ 'selected': selected_versions.includes(version.name) }" :data-id="`version-item-${version.name}`"
-            @click="clickOnVersion">
-            <div class="version-content" :data-id="`version-content-${version.name}`">
-              <div class="version-header" :data-id="`version-header-${version.name}`">
-                <span class="version-name" :data-id="`version-name-${version.name}`">{{ version.name }}</span>
-                <n-tag v-if="version.latest" type="error" size="small"
-                  :data-id="`version-latest-tag-${version.name}`">{{ t('versionSelect.tags.latest') }}</n-tag>
-                <n-tag v-if="version.lts" type="success" size="small"
-                  :data-id="`version-lts-tag-${version.name}`">{{ t('versionSelect.tags.lts') }}</n-tag>
-              </div>
-              <span v-if="version.description" class="version-description"
-                :data-id="`version-description-${version.name}`">
-                {{ version.description }}
-              </span>
-            </div>
-          </div>
-        </div>
-        <div class="selected-versions-summary" v-if="selected_versions.length > 0">
-          {{ t('versionSelect.selectedVersions') }}
+        <!-- Stable Versions Section -->
+        <version-section
+          v-if="stableVersions.length > 0"
+          :title="t('versionSelect.sections.stable.title')"
+          :description="t('versionSelect.sections.stable.description')"
+          :versions="stableVersions"
+          :selected="selected_versions"
+          @toggle="toggleVersion"
+        />
+
+        <!-- Pre-release Versions Section -->
+        <version-section
+          v-if="preReleaseVersions.length > 0"
+          :title="t('versionSelect.sections.preRelease.title')"
+          :description="t('versionSelect.sections.preRelease.description')"
+          :versions="preReleaseVersions"
+          :selected="selected_versions"
+          @toggle="toggleVersion"
+          type="prerelease"
+        />
+
+        <!-- Development (Master) Section -->
+        <version-section
+          v-if="masterVersion"
+          :title="t('versionSelect.sections.development.title')"
+          :description="t('versionSelect.sections.development.description')"
+          :versions="[masterVersion]"
+          :selected="selected_versions"
+          @toggle="toggleVersion"
+          type="development"
+        />
+
+        <!-- Selected Versions Summary -->
+        <div class="selected-versions-summary" v-if="selected_versions.length > 0" data-id="selected-summary">
+          <span class="summary-label">{{ t('versionSelect.selectedVersions') }}</span>
           <div class="selected-tags" data-id="selected-tags">
-            <n-tag v-for="version in selected_versions" :key="version" closable round size="medium"
-              :data-id="`selected-tag-${version}`" @close="deselectVersion(version)">
+            <n-tag
+              v-for="version in selected_versions"
+              :key="version"
+              closable
+              round
+              size="medium"
+              :type="getTagType(version)"
+              :data-id="`selected-tag-${version}`"
+              @close="deselectVersion(version)"
+            >
               {{ version }}
             </n-tag>
           </div>
         </div>
 
+        <!-- Action Footer -->
         <div class="action-footer" data-id="version-action-footer">
-          <n-button @click="processVersions" type="error" size="large" :disabled="!hasSelectedVersions"
-            data-id="continue-installation-button">
+          <n-button
+            @click="processVersions"
+            type="primary"
+            size="large"
+            :disabled="!hasSelectedVersions"
+            data-id="continue-installation-button"
+          >
             {{ t('versionSelect.continueInstallation') }}
           </n-button>
         </div>
@@ -46,208 +74,134 @@
 </template>
 
 <script>
-import { ref, version } from "vue";
+import { ref } from "vue";
 import { useI18n } from 'vue-i18n';
 import { invoke } from "@tauri-apps/api/core";
-import { NButton, NSpin, NCard, NCheckbox, NTag } from 'naive-ui'
-import loading from "naive-ui/es/_internal/loading";
+import { NButton, NSpin, NCard, NCheckbox, NTag, NAlert } from 'naive-ui';
+import VersionSection from './VersionSection.vue';
 
 export default {
   name: 'VersionSelect',
   props: {
     nextstep: Function
   },
-  components: { NButton, NSpin, NCard, NCheckbox, NTag },
+  components: {
+    NButton, NSpin, NCard, NCheckbox, NTag, NAlert,
+    VersionSection,
+  },
   setup() {
-    const { t } = useI18n()
-    return { t }
+    const { t } = useI18n();
+    return { t };
   },
   data: () => ({
     loading: true,
     versions: [],
     selected_versions: []
   }),
-  methods: {
-    get_available_versions: async function () {
-      const versions = await invoke("get_idf_versions", {includeUnstable: true});
-      this.versions = versions;
-      this.loading = false;
-    },
-    async processVersions() {
-      await invoke("set_versions", { versions: this.selectedVersions });
-      this.nextstep();
-    },
-    deselectVersion(versionName) {
-      this.selected_versions.splice(this.selected_versions.indexOf(versionName), 1);
-    },
-    clickOnVersion(event) {
-      let version_name = event.currentTarget.textContent.trim();
-      console.log('target clicked', version_name);
-      if (this.selected_versions.includes(version_name)) {
-        this.selected_versions.splice(this.selected_versions.indexOf(version_name), 1);
-      } else {
-        this.selected_versions.push(version_name);
-      }
-      console.log('selected versions', this.selected_versions);
-    }
-  },
   computed: {
+    stableVersions() {
+      return this.versions.filter(v => v.category === 'stable' && !v.is_master);
+    },
+    preReleaseVersions() {
+      return this.versions.filter(v => v.category === 'pre_release' && !v.is_master);
+    },
+    masterVersion() {
+      return this.versions.find(v => v.is_master);
+    },
     hasSelectedVersions() {
       return this.selected_versions.length > 0;
     },
-    selectedVersions() {
-      return this.selected_versions
+  },
+  methods: {
+    async getAvailableVersions() {
+      try {
+        const versions = await invoke("get_idf_versions", { includeUnstable: true });
+        this.versions = versions;
+        this.selected_versions = versions.filter(v => v.selected).map(v => v.name);
+      } catch (error) {
+        console.error('Error fetching versions:', error);
+      } finally {
+        this.loading = false;
+      }
+    },
+    async processVersions() {
+      await invoke("set_versions", { versions: this.selected_versions });
+      this.nextstep();
+    },
+    toggleVersion(versionName) {
+      const index = this.selected_versions.indexOf(versionName);
+      if (index > -1) {
+        this.selected_versions.splice(index, 1);
+      } else {
+        this.selected_versions.push(versionName);
+      }
+    },
+    deselectVersion(versionName) {
+      const index = this.selected_versions.indexOf(versionName);
+      if (index > -1) {
+        this.selected_versions.splice(index, 1);
+      }
+    },
+    getTagType(versionName) {
+      if (versionName === 'master') return 'error';
+      const version = this.versions.find(v => v.name === versionName);
+      if (version?.pre_release) return 'warning';
+      return 'success';
     }
   },
   mounted() {
-    this.get_available_versions();
+    this.getAvailableVersions();
   }
-}
+};
 </script>
 
 <style scoped>
 .version-select {
-  padding: 2rem;
-  max-width: 800px;
+  padding: 24px;
+  max-width: 900px;
   margin: 0 auto;
 }
 
 .title {
-  font-size: 27px;
-  font-family: 'Trueno-bold', sans-serif;
-  color: #374151;
-  margin-bottom: 0.5rem;
+  font-size: 28px;
+  font-weight: 600;
+  margin-bottom: 8px;
+  color: var(--n-text-color);
 }
 
 .description {
-  color: #6b7280;
-  margin-bottom: 2rem;
+  color: var(--n-text-color-3);
+  margin-bottom: 24px;
+  font-size: 14px;
 }
 
 .selection-card {
-  background: white;
-  padding: 1rem;
-}
-
-.versions-grid {
-  display: flex;
-  /* Use flexbox */
-  flex-wrap: wrap;
-  /* Allow items to wrap to the next line */
-  gap: 12px;
-  margin-bottom: 2rem;
-}
-
-.version-item {
-  width: 125px;
-  height: 40px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0.5rem;
-  border: 1px solid #e5e7eb;
-  border-radius: 0.5rem;
-  cursor: pointer;
-  transition: all 0.2s ease;
-}
-
-.version-item:hover {
-  border-color: #1290d8;
-}
-
-.version-item.selected {
-  background-color: #1290d8;
-  border-color: #1290d8;
-  color: white
-}
-
-.version-content {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-}
-
-.version-header {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-}
-
-.version-name {
-  font-weight: 500;
-  color: #374151;
-}
-
-.version-item.selected .version-name {
-  color: white;
-}
-
-.version-description {
-  font-size: 0.875rem;
-  color: #6b7280;
-}
-
-.version-meta {
-  display: flex;
-  justify-content: space-between;
-  font-size: 0.75rem;
-  color: #6b7280;
-}
-
-.summary-section {
-  margin: 2rem 0;
-  padding: 1rem;
-  background-color: #f9fafb;
-  border-radius: 0.5rem;
-}
-
-.summary-content {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-}
-
-.summary-label {
-  font-weight: 500;
-  color: #374151;
-}
-
-.selected-tags {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-}
-
-.action-footer {
-  display: flex;
-  justify-content: center;
-  margin-top: 2rem;
-  padding-top: 1rem;
-}
-
-.n-card {
-  border: none;
-  border-top: 1px solid #e5e7eb;
-
+  border-radius: 12px;
 }
 
 .selected-versions-summary {
-  font-family: 'Trueno-light';
-  display: flex;
-  font-size: 21px;
-  line-height: 23px;
-  vertical-align: baseline;
+  margin-top: 24px;
+  padding: 16px;
+  background-color: var(--n-color-embedded);
+  border-radius: 10px;
+}
+
+.summary-label {
+  display: block;
+  font-weight: 500;
+  margin-bottom: 12px;
+  color: var(--n-text-color);
 }
 
 .selected-tags {
-  margin-left: 1rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
 }
 
-.n-tag {
-  color: #1290d8;
-  border-color: #1290d8;
-  border-radius: 3px;
-
+.action-footer {
+  margin-top: 24px;
+  display: flex;
+  justify-content: flex-end;
 }
 </style>
-

--- a/src/locales/cn.json
+++ b/src/locales/cn.json
@@ -431,10 +431,29 @@
   "versionSelect": {
     "title": "选择 ESP-IDF 版本",
     "description": "选择要安装的 ESP-IDF SDK 版本：",
+    "sections": {
+      "stable": {
+        "title": "稳定版",
+        "description": "推荐用于大多数项目的生产就绪版本。这些版本经过充分测试，适用于商业和生产环境。"
+      },
+      "preRelease": {
+        "title": "预发布版本",
+        "description": "预发布版本包含最新功能和尚未正式发布的错误修复。如果您需要使用最新的改进，请选择这些版本，但请注意，它们可能不如正式发布版本稳定。"
+      },
+      "development": {
+        "title": "开发分支",
+        "warningTitle": "⚠️ 仅限高级用户使用",
+        "description": "主分支（master）包含最新的开发代码，稳定性极低。仅当您是 ESP-IDF 开发者、需要测试未发布功能，或必须使用最新更改时，才应安装此分支。该分支可能存在破坏性变更，不适用于生产环境。"
+      }
+    },
     "tags": {
       "latest": "最新",
-      "lts": "长期支持版本"
+      "lts": "长期支持版本",
+      "preRelease": "预发布版",
+      "unstable": "不稳定版"
     },
+    "supportedTargets": "支持的目标平台",
+    "masterDescription": "最新开发代码——可能包含破坏性变更",
     "selectedVersions": "已选版本：",
     "continueInstallation": "继续安装"
   },

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -431,10 +431,29 @@
   "versionSelect": {
     "title": "Select ESP-IDF Versions",
     "description": "Choose which ESP-IDF SDK versions to install:",
+    "sections": {
+      "stable": {
+        "title": "Stable Releases",
+        "description": "Production-ready versions recommended for most projects. These versions are thoroughly tested and suitable for commercial and production environments."
+      },
+      "preRelease": {
+        "title": "Pre-Release Versions",
+        "description": "If a required feature is not yet available in a stable release, but you do not want to use the master branch, it is possible to check out a pre-release version or a release branch."
+      },
+      "development": {
+        "title": "Master Branch",
+        "warningTitle": "⚠️ For Advanced Users Only",
+        "description": "For prototyping, experimentation or for developing new ESP-IDF features, use the latest version (master branch). The latest version in the master branch has all the latest features and has passed automated testing, but has not been completely manually tested (\"bleeding edge\")."
+      }
+    },
     "tags": {
       "latest": "Latest",
-      "lts": "LTS"
+      "lts": "LTS",
+      "preRelease": "Pre-release",
+      "unstable": "Unstable"
     },
+    "supportedTargets": "Supported targets",
+    "masterDescription": "Latest development code - may contain breaking changes",
     "selectedVersions": "Selected versions:",
     "continueInstallation": "Continue Installation"
   },


### PR DESCRIPTION
Based on feedback from developer relation team we rearanged the UI of the version selector so it more clearly inform user about the versions avalible and about differences between release branches and tags.
<img width="1166" height="1252" alt="image" src="https://github.com/user-attachments/assets/09c34470-c65f-4b70-ba52-db078806f47e" />
