### PR TITLE
EIM-403 fixed the openSUSE package names in requirements check

### DIFF
--- a/docs/src/prerequisites.md
+++ b/docs/src/prerequisites.md
@@ -4,7 +4,7 @@ Below are the minimum requirements for running the ESP-IDF. The Installation Man
 
 ## Python Version
 
-ESP-IDF requires Python to be installed. The supported Python versions are **3.10**, **3.11**, **3.12**, and **3.13**. 
+ESP-IDF requires Python to be installed. The supported Python versions are **3.10**, **3.11**, **3.12**, and **3.13**.
 
 > **Important**
 > Python 3.14 and later are **not supported**. Please ensure you have a compatible Python version installed.
@@ -86,10 +86,10 @@ For more details about ESP-IDF prerequisites, please refer to [the ESP-IDF docum
 - `libusb-1_0-0`: Runtime library for USB device access.
 - `libffi-devel`: Development headers for Foreign Function Interface.
 - `libopenssl-devel`: Development headers for OpenSSL.
-- `libgcrypt`: Runtime library for cryptographic functions (QEMU dependency).
+- `libgcrypt20`: Runtime library for cryptographic functions (QEMU dependency).
 - `glib2`: Runtime library for GLib (QEMU dependency).
 - `pixman-1`: Runtime library for pixman (QEMU dependency).
-- `libsdl2-2_0_0`: Runtime library for SDL2 (QEMU dependency).
+- `libSDL2-2_0-0`: Runtime library for SDL2 (QEMU dependency).
 - `libslirp`: Runtime library for SLIRP user-mode networking (QEMU dependency).
 
 > **Note**

--- a/src-tauri/src/lib/system_dependencies.rs
+++ b/src-tauri/src/lib/system_dependencies.rs
@@ -155,10 +155,10 @@ pub fn get_general_prerequisites_based_on_package_manager() -> Vec<&'static str>
 ///   - `libslirp`: Runtime library for SLIRP user-mode networking (QEMU dependency).
 ///
 /// - **zypper (openSUSE/SUSE Linux Enterprise):**
-///   - `libgcrypt`: Runtime library for cryptographic functions (QEMU dependency).
+///   - `libgcrypt20`: Runtime library for cryptographic functions (QEMU dependency).
 ///   - `glib2`: Runtime library for GLib (QEMU dependency).
 ///   - `pixman-1`: Runtime library for pixman (QEMU dependency).
-///   - `libsdl2-2_0_0`: Runtime library for SDL2 (QEMU dependency).
+///   - `libSDL2-2_0-0`: Runtime library for SDL2 (QEMU dependency).
 ///   - `libslirp`: Runtime library for SLIRP user-mode networking (QEMU dependency).
 ///
 /// # macOS Prerequisites:
@@ -176,7 +176,7 @@ pub fn get_qemu_prerequisites_based_on_package_manager() -> Vec<&'static str> {
             Some("dpkg") => vec!["libgcrypt20", "libglib2.0-0", "libpixman-1-0", "libsdl2-2.0-0", "libslirp0"],
             Some("dnf") => vec!["libgcrypt", "glib2", "pixman", "SDL2", "libslirp"],
             Some("pacman") => vec!["libgcrypt", "glib", "pixman", "sdl2", "libslirp"],
-            Some("zypper") => vec!["libgcrypt", "glib2", "pixman-1", "libsdl2-2_0_0", "libslirp"],
+            Some("zypper") => vec!["libgcrypt20", "glib2", "pixman-1", "libSDL2-2_0-0", "libslirp"],
             _ => vec![],
         },
         "macos" => vec!["libgcrypt", "glib", "pixman", "sdl2", "libslirp"],


### PR DESCRIPTION
This should fix https://github.com/espressif/idf-im-ui/issues/321
needs to be tested on openSUSE environment