### PR TITLE
EIM-433-offline-installer-pipeline-enhancement

### DIFF
--- a/.github/workflows/build_offline_installer_archives.yaml
+++ b/.github/workflows/build_offline_installer_archives.yaml
@@ -13,6 +13,11 @@ on:
         required: false
         type: string
         description: "Specific IDF version to build (e.g., v5.1.2). If empty, builds all versions."
+      debug:
+        required: false
+        type: boolean
+        default: false
+        description: "Debug mode: Uploads to debug folder, skips JSON update, skips purge."
     secrets:
       AWS_ACCESS_KEY_ID:
         required: true
@@ -36,15 +41,27 @@ on:
         required: false
         type: boolean
         default: false
+      debug:
+        description: "Debug mode: Uploads to debug folder, skips JSON update, skips purge."
+        required: false
+        type: boolean
+        default: false
+
+concurrency:
+  group: offline-installer-build
+  cancel-in-progress: false
+
+permissions:
+  contents: read
 
 jobs:
-  # Get versions first
   get-versions:
     name: Get IDF Versions to Build
     runs-on: ubuntu-latest
     outputs:
       versions: ${{ steps.get-versions.outputs.versions }}
       should_purge: ${{ steps.get-versions.outputs.should_purge }}
+      debug: ${{ steps.get-versions.outputs.debug }}
     steps:
       - name: Checkout (for scripts if needed)
         uses: actions/checkout@v4
@@ -61,33 +78,36 @@ jobs:
       - name: Make binary executable
         run: chmod +x ./offline_installer_builder
 
-      - name: Install UV (Python package manager)
-        run: cargo install --git https://github.com/astral-sh/uv uv
+      - name: Install UV
+        uses: astral-sh/setup-uv@v2
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
 
       - name: Get IDF versions
         id: get-versions
         run: |
+          echo "debug=${{ inputs.debug }}" >> $GITHUB_OUTPUT
+
+          if [ "${{ inputs.debug }}" = "true" ]; then
+            echo "should_purge=false" >> $GITHUB_OUTPUT
+          else
+            SHOULD_PURGE=$([ "${{ github.event_name }}" = "release" ] || [ "${{ inputs.purge_all }}" = "true" ] && echo "true" || echo "false")
+            echo "should_purge=$SHOULD_PURGE" >> $GITHUB_OUTPUT
+          fi
+
           if [ -n "${{ inputs.idf_version }}" ]; then
-            # Single version specified
             VERSIONS='["${{ inputs.idf_version }}"]'
           else
-            # Get all available versions from the builder
             echo "Getting available IDF versions..."
             VERSIONS_OUTPUT=$(./offline_installer_builder --list-versions)
             echo "Available versions:"
             echo "$VERSIONS_OUTPUT"
-
-            # Convert to JSON array
             VERSIONS=$(echo "$VERSIONS_OUTPUT" | jq -R -s -c 'split("\n") | map(select(length > 0))')
           fi
 
           echo "versions=$VERSIONS" >> $GITHUB_OUTPUT
 
-          # Determine if we should purge
-          SHOULD_PURGE=$([ "${{ github.event_name }}" = "release" ] || [ "${{ inputs.purge_all }}" = "true" ] && echo "true" || echo "false")
-          echo "should_purge=$SHOULD_PURGE" >> $GITHUB_OUTPUT
-
-  # Build job with simpler matrix
   build-and-upload:
     name: Build & Upload (${{ matrix.package_name }}, ${{ matrix.idf_version }})
     needs: get-versions
@@ -101,7 +121,6 @@ jobs:
         package_name: [linux-x64, linux-aarch64, windows-x64, macos-aarch64, macos-x64]
         idf_version: ${{ fromJson(needs.get-versions.outputs.versions) }}
         exclude:
-          # Only run matching OS/package combinations
           - os: ubuntu-latest
             package_name: linux-aarch64
           - os: ubuntu-latest
@@ -160,8 +179,8 @@ jobs:
         if: runner.os != 'Windows'
         run: chmod +x ./offline_installer_builder
 
-      - name: Install UV (Python package manager)
-        run: cargo install --git https://github.com/astral-sh/uv uv
+      - name: Install UV
+        uses: astral-sh/setup-uv@v2
 
       - name: Set up AWS CLI
         uses: aws-actions/configure-aws-credentials@v4
@@ -171,41 +190,14 @@ jobs:
           aws-region: ap-east-1
 
       - name: Download current offline_archives.json
-        if: runner.os != 'Windows'
+        if: needs.get-versions.outputs.should_purge == 'true'
         id: download_json
         shell: bash
         run: |
           aws s3 cp s3://espdldata/dl/eim/offline_archives.json ./offline_archives.json 2>/dev/null || echo "[]" > ./offline_archives.json
           if ! jq -e 'type == "array"' ./offline_archives.json >/dev/null 2>&1; then
-            echo "Invalid JSON, resetting to empty array"
             echo "[]" > ./offline_archives.json
           fi
-          echo "Current offline_archives.json:"
-          cat ./offline_archives.json
-
-      - name: Download current offline_archives.json (Windows)
-        if: runner.os == 'Windows'
-        id: download_json_windows
-        shell: pwsh
-        run: |
-          try {
-            aws s3 cp s3://espdldata/dl/eim/offline_archives.json ./offline_archives.json
-          } catch {
-            Set-Content -Path "./offline_archives.json" -Value "[]"
-          }
-
-          try {
-            $json = Get-Content "./offline_archives.json" | ConvertFrom-Json
-            if (-not ($json -is [array])) {
-              throw "Not an array"
-            }
-          } catch {
-            Write-Host "Invalid JSON, resetting to empty array"
-            Set-Content -Path "./offline_archives.json" -Value "[]"
-          }
-
-          Write-Host "Current offline_archives.json:"
-          Get-Content "./offline_archives.json"
 
       - name: Purge existing archives for this version (if requested) - Unix
         if: needs.get-versions.outputs.should_purge == 'true' && runner.os != 'Windows'
@@ -213,25 +205,13 @@ jobs:
         continue-on-error: true
         run: |
           echo "Purging existing archives for version ${{ matrix.idf_version }} from S3..."
-
-          # Only purge archives for THIS specific version and platform
-          set +e  # Don't exit on error
+          set +e
           aws s3 ls s3://espdldata/dl/eim/ | grep "archive_${{ matrix.idf_version }}_${{ matrix.package_name }}\.zst" | awk '{print $4}' | while read filename; do
             if [ -n "$filename" ]; then
-              echo "Deleting s3://espdldata/dl/eim/$filename"
-              if ! aws s3 rm "s3://espdldata/dl/eim/$filename"; then
-                echo "::warning::Failed to delete $filename, continuing..."
-              fi
+              aws s3 rm "s3://espdldata/dl/eim/$filename" || true
             fi
           done
-
-          # Check if grep found anything (if pipe failed, there were no matches)
-          if [ ${PIPESTATUS[1]} -ne 0 ]; then
-            echo "::warning::No existing archives found for ${{ matrix.idf_version }}_${{ matrix.package_name }}, or grep failed"
-          fi
-
-          echo "Purge step completed (errors ignored)"
-          exit 0  # Always exit successfully
+          exit 0
 
       - name: Purge existing archives for this version (if requested) - Windows
         if: needs.get-versions.outputs.should_purge == 'true' && runner.os == 'Windows'
@@ -239,152 +219,127 @@ jobs:
         continue-on-error: true
         run: |
           Write-Host "Purging existing archives for version ${{ matrix.idf_version }} from S3..."
-
           try {
-            # Only purge archives for THIS specific version and platform
             $archives = aws s3 ls s3://espdldata/dl/eim/ | Where-Object { $_.Split()[-1] -match "archive_${{ matrix.idf_version }}_${{ matrix.package_name }}\.zst" }
-
-            if (-not $archives) {
-              Write-Host "::warning::No existing archives found for ${{ matrix.idf_version }}_${{ matrix.package_name }}"
-            }
-
+            if (-not $archives) { Write-Host "::warning::No existing archives found" }
             foreach ($archive in $archives) {
               $filename = $archive.Split()[-1]
-              if ($filename) {
-                Write-Host "Deleting s3://espdldata/dl/eim/$filename"
-                try {
-                  aws s3 rm "s3://espdldata/dl/eim/$filename"
-                } catch {
-                  Write-Host "::warning::Failed to delete $filename, continuing..."
-                }
-              }
+              if ($filename) { aws s3 rm "s3://espdldata/dl/eim/$filename" || true }
             }
-          } catch {
-            Write-Host "::warning::Purge step encountered an error: $_"
-          }
-
-          Write-Host "Purge step completed (errors ignored)"
-          exit 0  # Always exit successfully
+          } catch { Write-Host "::warning::Purge step encountered an error: $_" }
+          exit 0
 
       - name: Build archive for specific version
         id: build
+        shell: bash
         run: |
-          # Determine binary name
           if [ "${{ runner.os }}" = "Windows" ]; then
             BINARY="./offline_installer_builder.exe"
           else
             BINARY="./offline_installer_builder"
           fi
-
           echo "Building specific version: ${{ matrix.idf_version }}"
-
-          # Build only this specific version
-          $BINARY -c default --idf-version-override ${{ matrix.idf_version }}
-
-          # Rename the built file to include platform
           PLATFORM="${{ matrix.package_name }}"
+          VERSION="${{ matrix.idf_version }}"
           mkdir -p built_archives
+          LOG_FILE="built_archives/archive_v${VERSION}_${PLATFORM}.log"
+
+          set -o pipefail
+          $BINARY -c default --idf-version-override ${{ matrix.idf_version }} 2>&1 | tee "$LOG_FILE"
 
           for file in archive_v*.zst; do
             if [ ! -f "$file" ]; then continue; fi
-
-            # Extract version: archive_v5.1.2.zst → 5.1.2
-            VERSION=$(echo "$file" | sed -E 's/archive_v(.*)\.zst/\1/')
             NEW_NAME="archive_v${VERSION}_${PLATFORM}.zst"
-
-            echo "Renaming $file → $NEW_NAME"
             mv "$file" "built_archives/$NEW_NAME"
           done
-
-          # List built files
-          echo "Built archives:"
-          ls -la built_archives/
-
-          # Fail if nothing built
-          if [ ! "$(ls -A built_archives/ 2>/dev/null)" ]; then
+          if [ ! "$(ls -A built_archives/*.zst 2>/dev/null)" ]; then
             echo "ERROR: No archives built!" >&2
             exit 1
           fi
-        shell: bash
 
-      - name: Upload archive to S3 and generate build info - Unix
+      - name: Upload archive and log to S3 - Unix
         if: runner.os != 'Windows'
         id: upload_unix
         shell: bash
+        env:
+          S3_PREFIX: ${{ needs.get-versions.outputs.debug == 'true' && 'debug/' || '' }}
         run: |
           PLATFORM="${{ matrix.package_name }}"
           VERSION="${{ matrix.idf_version }}"
-
-          # Should have exactly one file
           archive=$(ls built_archives/*.zst | head -1)
-
-          if [ ! -f "$archive" ]; then
-            echo "ERROR: No archive found!" >&2
-            exit 1
-          fi
+          if [ ! -f "$archive" ]; then echo "ERROR: No archive found!" >&2; exit 1; fi
 
           FILENAME=$(basename "$archive")
+          # Prepend prefix for JSON file logic
+          JSON_FILENAME="${S3_PREFIX}${FILENAME}"
 
-          # Get file size
           if [ "${{ runner.os }}" = "macOS" ]; then
             SIZE=$(stat -f %z "$archive")
           else
             SIZE=$(stat -c %s "$archive")
           fi
 
-          # Upload to S3
-          aws s3 cp --acl=public-read --content-type="application/zstd" "$archive" "s3://espdldata/dl/eim/$FILENAME"
+          echo "Uploading to S3 prefix: ${S3_PREFIX}"
 
-          # Generate build info
+          # Upload Archive
+          aws s3 cp --acl=public-read --content-type="application/zstd" "$archive" "s3://espdldata/dl/eim/${S3_PREFIX}${FILENAME}"
+
+          # Upload Log
+          LOG_FILE="${archive%.zst}.log"
+          if [ -f "$LOG_FILE" ]; then
+            LOG_FILENAME=$(basename "$LOG_FILE")
+            aws s3 cp --acl=public-read --content-type="text/plain" "$LOG_FILE" "s3://espdldata/dl/eim/${S3_PREFIX}${LOG_FILENAME}"
+          fi
+
+          # Generate build-info.json with the correct path (including prefix)
           mkdir -p build-info
           jq -n \
             --arg version "$VERSION" \
             --arg platform "$PLATFORM" \
-            --arg filename "$FILENAME" \
+            --arg filename "$JSON_FILENAME" \
             --argjson size $SIZE \
             '{"version": $version, "platform": $platform, "filename": $filename, "size": $size}' \
             > "build-info/build-info.json"
 
-          echo "Uploaded $FILENAME ($SIZE bytes)"
-
-      - name: Upload archive to S3 and generate build info - Windows
+      - name: Upload archive and log to S3 - Windows
         if: runner.os == 'Windows'
         id: upload_windows
         shell: pwsh
+        env:
+          S3_PREFIX: ${{ needs.get-versions.outputs.debug == 'true' && 'debug/' || '' }}
         run: |
           $PLATFORM = "${{ matrix.package_name }}"
           $VERSION = "${{ matrix.idf_version }}"
-
-          # Should have exactly one file
           $archive = Get-ChildItem "built_archives/*.zst" | Select-Object -First 1
-
-          if (-not $archive) {
-            Write-Error "ERROR: No archive found!"
-            exit 1
-          }
+          if (-not $archive) { Write-Error "ERROR: No archive found!"; exit 1 }
 
           $FILENAME = $archive.Name
           $archivePath = $archive.FullName
-
-          # Get file size
           $SIZE = $archive.Length
+          $Prefix = "${{ env.S3_PREFIX }}"
 
-          # Upload to S3
-          aws s3 cp --acl=public-read --content-type="application/zstd" "$archivePath" "s3://espdldata/dl/eim/$FILENAME"
+          # Prepend prefix for JSON file logic
+          $JsonFilename = "$Prefix$FILENAME"
 
-          # Generate build info
+          # Upload Archive
+          aws s3 cp --acl=public-read --content-type="application/zstd" "$archivePath" "s3://espdldata/dl/eim/$Prefix$FILENAME"
+
+          # Upload Log
+          $LogFile = "$($archive.DirectoryName)\$($archive.BaseName).log"
+          if (Test-Path $LogFile) {
+             $LogFilename = Split-Path $LogFile -Leaf
+             aws s3 cp --acl=public-read --content-type="text/plain" "$LogFile" "s3://espdldata/dl/eim/$Prefix$LogFilename"
+          }
+
+          # Generate build-info.json with the correct path
           New-Item -ItemType Directory -Path "build-info" -Force | Out-Null
-
           $buildInfo = @{
             version = $VERSION
             platform = $PLATFORM
-            filename = $FILENAME
+            filename = $JsonFilename
             size = $SIZE
           }
-
           $buildInfo | ConvertTo-Json | Out-File -FilePath "build-info/build-info.json" -Encoding UTF8
-
-          Write-Host "Uploaded $FILENAME ($SIZE bytes)"
 
       - name: Save build info as artifact
         uses: actions/upload-artifact@v4
@@ -396,6 +351,7 @@ jobs:
   update-json:
     name: Update offline_archives.json
     needs: [get-versions, build-and-upload]
+    if: needs.get-versions.outputs.debug != 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Set up AWS CLI
@@ -415,44 +371,19 @@ jobs:
       - name: Purge old archives (if release)
         if: needs.get-versions.outputs.should_purge == 'true'
         run: |
-          echo "=== Purging archives older than 24 hours ==="
-
-          # Get current timestamp (24 hours ago in epoch seconds)
           CUTOFF_TIME=$(date -d '24 hours ago' +%s)
-          echo "Cutoff time: $(date -d @$CUTOFF_TIME)"
-
-          # List all archive files in S3 with their modification times
-          echo "Scanning S3 for old archive files..."
-          OLD_FILES=()
-
           aws s3api list-objects-v2 \
             --bucket espdldata \
             --prefix dl/eim/archive_ \
             --query 'Contents[?ends_with(Key, `.zst`)].[Key,LastModified]' \
             --output text | while read -r key last_modified; do
-
-            # Convert S3 timestamp to epoch
             FILE_TIME=$(date -d "$last_modified" +%s)
-
             if [ $FILE_TIME -lt $CUTOFF_TIME ]; then
-              echo "Marking for deletion: $key (modified: $last_modified)"
-              # Extract just the filename for JSON filtering
-              FILENAME=$(basename "$key")
-              echo "$FILENAME" >> old_files.txt
-
-              # Delete from S3
-              echo "Deleting s3://espdldata/$key"
               aws s3 rm "s3://espdldata/$key"
-            else
-              echo "Keeping: $key (modified: $last_modified)"
+              basename "$key" >> old_files.txt
             fi
           done
-
-          # Create empty file if none found
           touch old_files.txt
-
-          echo "=== Files marked for JSON removal ==="
-          cat old_files.txt || echo "No files to remove"
 
       - name: Download all build infos
         uses: actions/download-artifact@v4
@@ -462,71 +393,21 @@ jobs:
 
       - name: Merge and update JSON
         run: |
-          echo "=== Debugging artifact structure ==="
-          find all-build-infos -name "*.json" -type f | head -10
-          echo "=== Directory structure ==="
-          ls -la all-build-infos/ || echo "No all-build-infos directory"
-          find all-build-infos -type f | head -20
-
-          # Collect all new entries with more robust file finding
           NEW_ENTRIES="[]"
-
-          # Find all build-info.json files recursively
           while IFS= read -r -d '' info_file; do
-            if [ -f "$info_file" ]; then
-              echo "Processing: $info_file"
-              echo "File contents:"
-              cat "$info_file"
-              echo "---"
-
-              # Validate JSON before processing
-              if jq empty "$info_file" 2>/dev/null; then
-                entry=$(cat "$info_file")
-                NEW_ENTRIES=$(echo "$NEW_ENTRIES" | jq --argjson entry "$entry" '. + [$entry]')
-                echo "Successfully added entry from $info_file"
-              else
-                echo "WARNING: Invalid JSON in $info_file, skipping"
-              fi
-            else
-              echo "WARNING: File $info_file does not exist"
+            if [ -f "$info_file" ] && jq empty "$info_file" 2>/dev/null; then
+              entry=$(cat "$info_file")
+              NEW_ENTRIES=$(echo "$NEW_ENTRIES" | jq --argjson entry "$entry" '. + [$entry]')
             fi
           done < <(find all-build-infos -name "build-info.json" -type f -print0)
 
-          echo "=== Collected entries ==="
-          echo "NEW_ENTRIES count: $(echo "$NEW_ENTRIES" | jq length)"
-          echo "$NEW_ENTRIES" | jq .
-
-          # Validate we found some entries
-          ENTRIES_COUNT=$(echo "$NEW_ENTRIES" | jq length)
-          if [ "$ENTRIES_COUNT" -eq 0 ]; then
-            echo "ERROR: No build info entries found! This indicates a problem with artifact structure."
-            echo "Expected to find build-info.json files in downloaded artifacts."
-            exit 1
-          fi
-
-          # Load current JSON
-          echo "=== Loading current JSON ==="
           CURRENT=$(cat offline_archives.json)
-          echo "Current entries count: $(echo "$CURRENT" | jq length)"
 
-          # Remove old files from JSON if they were purged
           if [ -f old_files.txt ] && [ -s old_files.txt ]; then
-            echo "=== Removing purged files from JSON ==="
-            # Read old files into a JSON array
             OLD_FILENAMES=$(jq -R -s -c 'split("\n") | map(select(length > 0))' old_files.txt)
-            echo "Files to remove from JSON:"
-            echo "$OLD_FILENAMES" | jq .
-
-            # Filter out entries with filenames in the old_filenames list
-            CURRENT=$(echo "$CURRENT" | jq --argjson old "$OLD_FILENAMES" '
-              map(select(.filename as $f | ($old | index($f)) | not))
-            ')
-            echo "After purge filter, entries count: $(echo "$CURRENT" | jq length)"
+            CURRENT=$(echo "$CURRENT" | jq --argjson old "$OLD_FILENAMES" 'map(select(.filename as $f | ($old | index($f)) | not))')
           fi
 
-          # Remove existing entries that are being replaced (same platform + version)
-          # Keep entries for platforms/versions NOT rebuilt
-          echo "=== Merging entries ==="
           UPDATED=$(echo "$CURRENT" | jq --argjson new "$NEW_ENTRIES" '
             . as $current |
             ($new | map({version, platform})) as $to_replace |
@@ -536,48 +417,18 @@ jobs:
             ))) + $new
           ')
 
-          echo "=== Final result ==="
-          echo "Final entries count: $(echo "$UPDATED" | jq length)"
-          echo "Final offline_archives.json:"
-          echo "$UPDATED" | jq .
-
-          # Validate final JSON
           echo "$UPDATED" > updated_offline_archives.json
-          if ! jq empty updated_offline_archives.json; then
-            echo "ERROR: Generated JSON is invalid!" >&2
-            echo "Content that failed validation:"
-            cat updated_offline_archives.json
-            exit 1
-          fi
+          if ! jq empty updated_offline_archives.json; then echo "ERROR: JSON Invalid"; exit 1; fi
 
-          # Final size check
-          FINAL_COUNT=$(jq length updated_offline_archives.json)
-          if [ "$FINAL_COUNT" -eq 0 ]; then
-            echo "ERROR: Final JSON is empty! This should not happen." >&2
-            exit 1
-          fi
-
-          echo "SUCCESS: Generated valid JSON with $FINAL_COUNT entries"
-
-          # Upload
-          echo "=== Uploading to S3 ==="
           aws s3 cp --acl=public-read updated_offline_archives.json s3://espdldata/dl/eim/offline_archives.json
 
-          # Invalidate CloudFront
-          echo "=== Invalidating CloudFront ==="
           aws cloudfront create-invalidation \
             --distribution-id ${{ secrets.DL_DISTRIBUTION_ID }} \
             --paths "/dl/eim/offline_archives.json" "/dl/eim/archive_*.zst"
 
-      - name: Upload final JSON as artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: final-offline-archives-json
-          path: updated_offline_archives.json
-
   autotest:
     name: Autotest Offline Archives Installation
-    needs: [build-and-upload, update-json]
+    needs: [build-and-upload]
     if: always() && needs.build-and-upload.result == 'success'
     uses: ./.github/workflows/test_offline.yml
     with:

--- a/.github/workflows/test_offline.yml
+++ b/.github/workflows/test_offline.yml
@@ -93,8 +93,6 @@ jobs:
         run: |
           mkdir -p ./artifacts
           curl -fsSL -o ./artifacts/offline_archives.json https://dl.espressif.com/dl/eim/offline_archives.json
-          echo "Downloaded $(wc -c < ./artifacts/offline_archives.json) bytes"
-          ls -la ./artifacts/
 
       - name: Download latest EIM CLI binary (non-Windows)
         if: matrix.os != 'windows-latest' && inputs.eim_cli_run_id == 'release'
@@ -102,14 +100,11 @@ jobs:
           latest_release=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/espressif/idf-im-ui/releases/latest)
           eim_cli_url=$(echo "$latest_release" | jq -r '.assets[] | select(.name | test("eim-cli-${{matrix.package_name}}.zip")) | .browser_download_url')
           curl -L -o ./artifacts/eim-cli.zip "$eim_cli_url"
-
-          ls -la ./artifacts/
           unzip ./artifacts/eim-cli.zip -d ./artifacts/
 
       - name: Check artifact and make it executable (non-Windows)
         if: matrix.os != 'windows-latest'
         run: |
-          ls -la ./artifacts/
           chmod +x artifacts/eim
 
       - name: Install dependencies and node.js (Ubuntu)
@@ -132,12 +127,9 @@ jobs:
         run: |
           python3 --version
           SETUP_PYTHON=$(which python3)
-          echo "Setup python is at: $SETUP_PYTHON"
           mkdir -p $HOME/.local/bin
           ln -sf $SETUP_PYTHON $HOME/.local/bin/python3
           export PATH="$HOME/.local/bin:$PATH"
-          python3 --version
-          which python3          
           export LOG_TO_FILE="true"
           export EIM_CLI_PATH="../artifacts/eim"
           export BUILD_INFO_PATH="../artifacts"
@@ -152,8 +144,6 @@ jobs:
         run: |
           New-Item -ItemType Directory -Force -Path "./artifacts" | Out-Null
           Invoke-WebRequest -Uri 'https://dl.espressif.com/dl/eim/offline_archives.json' -OutFile './artifacts/offline_archives.json' -UseBasicParsing
-          Write-Host "Downloaded $(Get-Item ./artifacts/offline_archives.json).Length bytes"
-          ls ./artifacts/
 
       - name: Download latest EIM CLI binary (Windows)
         if: matrix.os == 'windows-latest' && inputs.eim_cli_run_id == 'release'
@@ -161,8 +151,6 @@ jobs:
           $latest_release = Invoke-RestMethod -Uri "https://api.github.com/repos/espressif/idf-im-ui/releases/latest"
           $eim_cli_url = $latest_release.assets | Where-Object { $_.name -like "eim-cli-${{ matrix.package_name }}.exe" } | Select-Object -ExpandProperty browser_download_url
           Invoke-WebRequest -Uri $eim_cli_url -OutFile ".\artifacts\eim.exe"
-
-          ls ./artifacts/
 
       - name: Run IDF offline installation (Windows)
         if: matrix.os == 'windows-latest'
@@ -180,19 +168,21 @@ jobs:
       - name: Copy EIM Log files (ubuntu)
         if: matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-24.04-arm'
         run: |
-          cp ~/.local/share/eim/logs/*.log ./tests/
+          cp ~/.local/share/eim/logs/*.log ./tests/ 2>/dev/null || true
         continue-on-error: true
 
       - name: Copy EIM Log files (MacOS)
         if: matrix.os == 'macos-latest' || matrix.os == 'macos-15-intel'
         run: |
-          cp ~/Library/Application\ Support/eim/logs/*.log ./tests/
+          cp ~/Library/Application\ Support/eim/logs/*.log ./tests/ 2>/dev/null || true
         continue-on-error: true
 
       - name: Copy EIM Log files (Windows)
         if: matrix.os == 'windows-latest'
         run: |
-          Move-Item -Path "$env:LOCALAPPDATA\eim\logs\*" -Destination ".\tests\" -Force
+          if (Test-Path "$env:LOCALAPPDATA\eim\logs\") {
+             Move-Item -Path "$env:LOCALAPPDATA\eim\logs\*" -Destination ".\tests\" -Force -ErrorAction SilentlyContinue
+          }
         continue-on-error: true
 
       # Upload test results


### PR DESCRIPTION
this add the `debug` flag to the offline installer pipeline.
if the flag is checked, the archives are builded to different folder on s3 alongside complete build logs for evaluation.
This should allow us to inspect the archive and test them on PR without actually affecting the real offline installer archives exposed to the users on the dl page. 