### PR TITLE
EIM-449: skipped mirrors checking in offline mode

### DIFF
--- a/src-tauri/src/cli/wizard.rs
+++ b/src-tauri/src/cli/wizard.rs
@@ -409,8 +409,10 @@ pub async fn run_wizzard_run(mut config: Settings) -> Result<(), String> {
     // select target & idf version
     config = select_targets_and_versions(config).await?;
 
-    // mirrors select
-    config = select_mirrors(config).await?;
+    // mirrors select (skip in offline mode - mirrors aren't used)
+    if !offline_mode {
+        config = select_mirrors(config).await?;
+    }
 
     config = select_installation_path(config)?;
 


### PR DESCRIPTION
## Description

Skip mirror latency checks when using offline installation mode `--use-local-archive` in the CLI.
For GUI the behavior is fine since the checks start as soon as the app starts and incase of offline installation they will not affect or block the installation even if they timeout.


## Related

[EIM-449](https://jira.espressif.com:8443/browse/EIM-449)

## Testing

Try offline mode with cli the mirrors will not be pinged.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.