### PR TITLE
fix: Prevent mirror override when config file is loaded (Windows GUI)

### DIFF
--- a/src-tauri/src/cli/prompts.rs
+++ b/src-tauri/src/cli/prompts.rs
@@ -222,7 +222,9 @@ where
         let selected = generic_select(wizard_key, &display)?;
         let url = selected.split(" (").next().unwrap_or(&selected).to_string();
         set_value(config, url);
-    } else if needs_value {
+    } else if needs_value && config.config_file.is_none() {
+        // Only auto-select based on latency if no config file was loaded
+        // This prevents overriding user's mirror selection from GUI/config file
         let entries = calculate_mirrors_latency(candidates).await;
         if let Some(entry) = entries.first() {
             if entry.latency.is_some() {


### PR DESCRIPTION
## Summary

Fixes an issue where the user's explicitly selected IDF mirror gets overridden by latency-based auto-selection during Windows Expert Installation.

This fixes the first part of the user issue #382 

## Problem

On Windows, GUI installation spawns a CLI subprocess with `-c config.toml`. The `select_single_mirror` function was checking:

} else if needs_value {  // needs_value = current.is_none() || config.is_default(field_name)

When the user selects GitHub (which is also the default mirror), `is_default("idf_mirror")` returns `true`, triggering latency-based auto-selection that overrides the user's choice with a faster mirror (e.g., JihuLab).

## Fix
Added a guard to only auto-select based on latency when no config file was loaded:
`} else if needs_value && config.config_file.is_none() {`

This ensures settings loaded from a config file are respected, while preserving auto-selection for fresh CLI runs.


## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
