### PR TITLE
EIM-191 added gui test execution to the build pipeline

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -726,6 +726,7 @@ jobs:
           restore-keys: ${{ runner.os }}-cargo-
 
       - name: Run GUI Tests
+        if: runner.os != 'Windows'
         run: |
           cd src-tauri
           cargo test --no-fail-fast --no-default-features --features cli,gui --bin eim 2>&1 | tee gui-bin-result.txt
@@ -733,6 +734,7 @@ jobs:
         continue-on-error: true
 
       - name: Format GUI test results
+        if: runner.os != 'Windows'
         uses: hahihula/rust-test-results-formatter@v1
         with:
           results-file: "./src-tauri/gui-bin-result.txt"


### PR DESCRIPTION
currently only the lib part of the tests was executed in the CI
this adds the rust GUI tests 