### PR TITLE
(WIP) Add PR and run link to version output for PR builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,6 +15,10 @@ on:
       - created
   workflow_dispatch:
 
+env:
+  EIM_PR_LINK: ${{ github.event_name == 'pull_request' && format('https://github.com/{0}/pull/{1}', github.repository, github.event.pull_request.number) || '' }}
+  EIM_RUN_URL: ${{ format('{0}/{1}/actions/runs/{2}', github.server_url, github.repository, github.run_id) }}
+
 jobs:
   setup:
     name: Setup and Check merged PRs (schedule only)

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -24,7 +24,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         (Some(pr), None) => format!("{} (PR: {})", pkg_version, pr),
         (None, _) => pkg_version,
     };
-    println!("cargo:rustc-env=CARGO_PKG_VERSION={}", version_string);
+    println!("cargo:rustc-env=EIM_VERSION_STRING={}", version_string);
     println!("cargo:rerun-if-env-changed=EIM_PR_LINK");
     println!("cargo:rerun-if-env-changed=EIM_RUN_URL");
     #[cfg(feature = "gui")]

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -15,6 +15,18 @@ async fn main() -> Result<(), Box<dyn Error>> {
             println!("cargo:rustc-env=CACHED_IDF_VERSIONS={{}}");
         }
     }
+    // Version string: add PR link and run link when EIM_PR_LINK is set (CI PR builds only)
+    let pkg_version = std::env::var("CARGO_PKG_VERSION").unwrap();
+    let pr_link = std::env::var("EIM_PR_LINK").ok().filter(|s| !s.is_empty());
+    let run_url = std::env::var("EIM_RUN_URL").ok().filter(|s| !s.is_empty());
+    let version_string = match (pr_link, run_url) {
+        (Some(pr), Some(run)) => format!("{} (PR: {}, Run: {})", pkg_version, pr, run),
+        (Some(pr), None) => format!("{} (PR: {})", pkg_version, pr),
+        (None, _) => pkg_version,
+    };
+    println!("cargo:rustc-env=CARGO_PKG_VERSION={}", version_string);
+    println!("cargo:rerun-if-env-changed=EIM_PR_LINK");
+    println!("cargo:rerun-if-env-changed=EIM_RUN_URL");
     #[cfg(feature = "gui")]
     {
     tauri_build::build()

--- a/src-tauri/src/cli/cli_args.rs
+++ b/src-tauri/src/cli/cli_args.rs
@@ -4,7 +4,7 @@ use clap_complete::aot::Shell;
 use idf_im_lib::to_absolute_path;
 use std::path::PathBuf;
 
-const VERSION: &str = env!("CARGO_PKG_VERSION");
+const VERSION: &str = env!("EIM_VERSION_STRING");
 
 fn custom_styles() -> Styles {
     Styles::styled()

--- a/src-tauri/src/cli/helpers.rs
+++ b/src-tauri/src/cli/helpers.rs
@@ -123,7 +123,7 @@ pub fn update_progress_bar_number(pb: &ProgressBar, value: u64) {
     pb.set_position(value);
 }
 
-const EIM_VERSION: &str = env!("CARGO_PKG_VERSION");
+const EIM_VERSION: &str = env!("EIM_VERSION_STRING");
 
 pub async fn track_cli_event(event_name: &str, additional_data: Option<serde_json::Value>) {
   let system_info = idf_im_lib::telemetry::get_system_info();

--- a/src-tauri/src/gui/commands/utils_commands.rs
+++ b/src-tauri/src/gui/commands/utils_commands.rs
@@ -14,7 +14,7 @@ use sysinfo::System;
 
 use crate::gui::ui::send_message;
 
-const EIM_VERSION: &str = env!("CARGO_PKG_VERSION");
+const EIM_VERSION: &str = env!("EIM_VERSION_STRING");
 
 #[tauri::command]
 pub async fn fetch_json_from_url(url: String) -> Result<Value, String> {


### PR DESCRIPTION
## Summary

When testing binaries from a PR, it can be hard to know exactly which PR and which CI run produced that build. This PR adds the PR link and the GitHub Actions run link to the version string for **PR builds only**, so `eim --version` (and the GUI version) show where the binary came from. Release builds are unchanged.

**JIRA:** [EIM-494](https://jira.espressif.com:8443/browse/EIM-494)

<img width="1054" height="94" alt="image" src="https://github.com/user-attachments/assets/765df516-cd16-44a3-9758-256b84fa1e53" />


## Why

- **QA and dev** can quickly identify the source of a binary when reporting or debugging issues.
- Running `eim --version` (CLI) or checking the version in the GUI shows the PR URL and the Actions run URL that produced that build.
- **Release builds are not affected**: `EIM_PR_LINK` is only set on `pull_request` events, so released binaries still show the plain version (e.g. `0.7.1`).

## What changed

- **`.github/workflows/build.yaml`**
  - Set workflow-level `EIM_PR_LINK` (PR URL) for `pull_request` events.
  - Set `EIM_RUN_URL` (GitHub Actions run URL) for all runs so PR builds can include it.

- **`src-tauri/build.rs`**
  - Before compile, build a version string from `CARGO_PKG_VERSION` and, when `EIM_PR_LINK` is set, append the PR link and (when available) the run link.
  - Emit `CARGO_PKG_VERSION` so the existing code (CLI and GUI) shows this string without any changes in `cli_args.rs`, `helpers.rs`, or `utils_commands.rs`.

## Example output

**PR build:**
```
eim 0.7.1 (PR: https://github.com/espressif/idf-im-ui/pull/123, Run: https://github.com/espressif/idf-im-ui/actions/runs/456789)
```

**Release build:** unchanged
```
eim 0.7.1
```

Made with [Cursor](https://cursor.com)