### PR TITLE
EIM-499: Add workflow to automate PR link comments on Jira

### DIFF
--- a/.github/workflows/jira-pr-comment.yml
+++ b/.github/workflows/jira-pr-comment.yml
@@ -53,11 +53,24 @@ jobs:
           echo "Adding comment to Jira issue: $ISSUE_KEY"
           echo "PR URL: $PR_URL"
 
+          # Handle JIRA_PASS format - it may have "token:" prefix (per espressif/sync-jira-actions convention)
+          # If prefixed with "token:", use Bearer token auth; otherwise use Basic Auth
+          if [[ "$JIRA_PASS" == token:* ]]; then
+            # Strip "token:" prefix and use Bearer token authentication
+            TOKEN="${JIRA_PASS#token:}"
+            AUTH_HEADER="Authorization: Bearer $TOKEN"
+            echo "Using Bearer token authentication"
+          else
+            # Use Basic Auth with username:password
+            AUTH_HEADER="Authorization: Basic $(echo -n "$JIRA_USER:$JIRA_PASS" | base64)"
+            echo "Using Basic authentication"
+          fi
+
           # Make the API call and capture the response
           HTTP_RESPONSE=$(curl -s -w "\n%{http_code}" \
             -X POST \
             -H "Content-Type: application/json" \
-            -u "$JIRA_USER:$JIRA_PASS" \
+            -H "$AUTH_HEADER" \
             -d "{\"body\": \"PR: $PR_URL\"}" \
             "$JIRA_URL/rest/api/2/issue/$ISSUE_KEY/comment")
 


### PR DESCRIPTION
## Summary

- Adds a new GitHub Actions workflow that automatically posts PR links as comments on Jira tickets
- Extracts the Jira issue key from PR titles (format: `EIM-12345: description`)
- Uses the existing Jira secrets (`JIRA_USER`, `JIRA_PASS`, `JIRA_URL`) already configured in the repo

## How it works

1. Triggers on `pull_request: opened` and `pull_request: reopened` events
2. Parses the PR title using regex `^(EIM-[0-9]+):` to extract the issue key
3. Calls Jira REST API to add a comment: `PR: <pr_url>`

## Error Handling

The workflow is designed to **never fail the PR check**:

| Scenario | Behavior |
|----------|----------|
| No issue key in PR title | Skips silently, workflow succeeds |
| Invalid/wrong issue key | Logs warning, workflow succeeds |
| Jira API error | Logs warning, workflow succeeds |

## Test plan

- [ ] Verify this PR itself triggers the workflow and adds a comment to EIM-499
- [ ] Test with a PR that has no Jira key in title - should skip gracefully
- [ ] Test with an invalid Jira key - should warn but not fail

Made with [Cursor](https://cursor.com)