### PR TITLE
EIM-535 enabled selecting idf based on idf path

### DIFF
--- a/src-tauri/src/lib/idf_config.rs
+++ b/src-tauri/src/lib/idf_config.rs
@@ -202,11 +202,12 @@ impl IdfConfig {
     /// Selects an IDF installation in the configuration.
     ///
     /// This function searches for an installation matching the given identifier
-    /// (either by ID or name) and sets it as the selected installation.
+    /// (by ID, name, or path) and sets it as the selected installation.
+    /// Path matching supports expansion of ~ and converts to absolute paths for comparison.
     ///
     /// # Arguments
     ///
-    /// * `identifier` - A string slice that holds the ID or name of the installation to select.
+    /// * `identifier` - A string slice that holds the ID, name, or path of the installation to select.
     ///
     /// # Returns
     ///
@@ -217,7 +218,13 @@ impl IdfConfig {
         if let Some(installation) = self
             .idf_installed
             .iter()
-            .find(|install| install.id == identifier || install.name == identifier)
+            .find(|install| {
+                install.id == identifier
+                    || install.name == identifier
+                    || { let normalized_identifier = crate::utils::normalize_path_for_comparison(identifier);
+                     normalized_identifier.is_some() && normalized_identifier == crate::utils::normalize_path_for_comparison(&install.path)
+                }
+            })
         {
             self.idf_selected_id = installation.id.clone();
             true

--- a/src-tauri/src/lib/utils.rs
+++ b/src-tauri/src/lib/utils.rs
@@ -306,6 +306,23 @@ fn filter_subpaths(paths: Vec<String>) -> Vec<String> {
     filtered
 }
 
+/// Normalizes a path for comparison by expanding ~, converting to absolute, and removing trailing slashes.
+///
+/// This function is useful for comparing paths that may differ in formatting but point to the same location.
+/// Returns None if the path cannot be canonicalized.
+///
+/// # Parameters
+///
+/// - `path`: A string slice representing the path to normalize.
+///
+/// # Return Value
+///
+/// - `Option<String>`: The normalized path as a string, or None if canonicalization fails.
+pub fn normalize_path_for_comparison(path: &str) -> Option<String> {
+    let expanded = crate::expand_tilde(Path::new(path));
+    expanded.canonicalize().ok().map(|p| p.to_string_lossy().trim_end_matches('/').trim_end_matches('\\').to_string())
+}
+
 /// Removes a directory and all its contents recursively.
 ///
 /// This function attempts to remove a directory and all its contents, including subdirectories and files.

--- a/src-tauri/src/lib/version_manager.rs
+++ b/src-tauri/src/lib/version_manager.rs
@@ -333,7 +333,13 @@ pub fn find_esp_idf_folders(path: &str) -> Vec<String> {
 
 pub fn run_command_in_context(identifier: &str, command: &str) -> anyhow::Result<ExitStatus> {
     let installation = match list_installed_versions() {
-        Ok(versions) => versions.into_iter().find(|v| v.id == identifier || v.name == identifier || v.path == identifier),
+        Ok(versions) => versions.into_iter().find(|v| {
+            v.id == identifier
+                || v.name == identifier
+                || { let normalized_identifier = crate::utils::normalize_path_for_comparison(identifier);
+                     normalized_identifier.is_some() && normalized_identifier == crate::utils::normalize_path_for_comparison(&v.path)
+                }
+        }),
         Err(e) => {
             return Err(anyhow!("Failed to list installed versions: {}", e));
         }


### PR DESCRIPTION
currently eim select command consumed only id or name of the idf or interactive selection, now it also accepts idf path. This will enable us to call it easily from export.sh script