### PR TITLE
EIM-541: Fix for venv python alias in export

### DIFF
--- a/src-tauri/bash_scripts/activate_idf_template.sh
+++ b/src-tauri/bash_scripts/activate_idf_template.sh
@@ -127,17 +127,17 @@ else
     fi
 fi
 
-alias idf.py="{{idf_python_env_path_escaped}}/bin/python3 {{idf_path_escaped}}/tools/idf.py"
+alias idf.py="{{idf_python_env_path_escaped}}/bin/python {{idf_path_escaped}}/tools/idf.py"
 
-alias esptool.py="{{idf_python_env_path_escaped}}/bin/python3 {{idf_path_escaped}}/components/esptool_py/esptool/esptool.py"
+alias esptool.py="{{idf_python_env_path_escaped}}/bin/python {{idf_path_escaped}}/components/esptool_py/esptool/esptool.py"
 
-alias espefuse.py="{{idf_python_env_path_escaped}}/bin/python3 {{idf_path_escaped}}/components/esptool_py/esptool/espefuse.py"
+alias espefuse.py="{{idf_python_env_path_escaped}}/bin/python {{idf_path_escaped}}/components/esptool_py/esptool/espefuse.py"
 
-alias espsecure.py="{{idf_python_env_path_escaped}}/bin/python3 {{idf_path_escaped}}/components/esptool_py/esptool/espsecure.py"
+alias espsecure.py="{{idf_python_env_path_escaped}}/bin/python {{idf_path_escaped}}/components/esptool_py/esptool/espsecure.py"
 
-alias otatool.py="{{idf_python_env_path_escaped}}/bin/python3 {{idf_path_escaped}}/components/app_update/otatool.py"
+alias otatool.py="{{idf_python_env_path_escaped}}/bin/python {{idf_path_escaped}}/components/app_update/otatool.py"
 
-alias parttool.py="{{idf_python_env_path_escaped}}/bin/python3 {{idf_path_escaped}}/components/partition_table/parttool.py"
+alias parttool.py="{{idf_python_env_path_escaped}}/bin/python {{idf_path_escaped}}/components/partition_table/parttool.py"
 
 
 # Main execution


### PR DESCRIPTION
User reported bug #475 where the alias in activation scripts was pointing to python3 causing a mismatch with ide and cli.

For testing please use the original reported bug