### PR TITLE
Add activation_script_path_override to CLI config TOML example (EIM-549)

### DIFF
--- a/docs/src/cli_configuration.md
+++ b/docs/src/cli_configuration.md
@@ -69,6 +69,7 @@ idf_path = "/Users/testusername/.espressif/v5.5/esp-idf"
 esp_idf_json_path = "/Users/testusername/.espressif/tools"
 tool_download_folder_name = "/Users/testusername/.espressif/dist"
 tool_install_folder_name = "/Users/testusername/.espressif/tools"
+activation_script_path_override = "/Users/testusername/.espressif/tools"
 python_env_folder_name = "python_env"
 cleanup = true
 target = ["all"]


### PR DESCRIPTION
## Description
This change add the `activation_script_path_override` as part of the example config.toml file in the cli configuration documentation.

## Related

This PR is related to issue #474 

## Testing

Tested in a regular Win11 environment as documented in the issue #474 

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
