### PR TITLE
EIM-553: Cancel old commit builds on PR (with no-cancel-pipeline opt-out

### DIFF
--- a/.github/workflows/cancel-old-commit-build-pr.yml
+++ b/.github/workflows/cancel-old-commit-build-pr.yml
@@ -47,9 +47,12 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const ref = context.ref; // e.g. refs/pull/123/merge
             const owner = context.repo.owner;
             const repo = context.repo.repo;
+            const prHeadBranch = context.payload.pull_request.head.ref;
+            const prNumber = context.payload.pull_request.number;
+
+            core.info(`PR #${prNumber}, head branch: ${prHeadBranch}`);
 
             // Find "Unified Build Workflow" (build.yaml)
             const { data: workflows } = await github.rest.actions.listRepoWorkflows({
@@ -68,24 +71,30 @@ jobs:
             const workflowId = buildWorkflow.id;
             const runsToCancel = [];
 
-            for (const status of ['in_progress', 'queued']) {
-              const { data } = await github.rest.actions.listWorkflowRunsForRepo({
+            for (const status of ['in_progress', 'queued', 'waiting', 'pending', 'requested']) {
+              const { data } = await github.rest.actions.listWorkflowRuns({
                 owner,
                 repo,
                 workflow_id: workflowId,
-                ref,
+                branch: prHeadBranch,
+                event: 'pull_request',
                 status,
                 per_page: 100
               });
               runsToCancel.push(...data.workflow_runs);
             }
 
+            // Keep only runs that belong to this PR
+            const prRuns = runsToCancel.filter(r =>
+              r.pull_requests && r.pull_requests.some(pr => pr.number === prNumber)
+            );
+
             // Dedupe by run id and sort by run_number descending (newest first)
-            const byId = new Map(runsToCancel.map(r => [r.id, r]));
+            const byId = new Map(prRuns.map(r => [r.id, r]));
             const sorted = [...byId.values()].sort((a, b) => b.run_number - a.run_number);
 
             if (sorted.length === 0) {
-              core.info('No in-progress or queued build runs to cancel.');
+              core.info('No active build runs to cancel.');
               return;
             }
 
@@ -94,10 +103,18 @@ jobs:
             core.info(`Keeping run #${sorted[0].run_number} (id ${sorted[0].id}); cancelling ${toCancel.length} older run(s).`);
 
             for (const run of toCancel) {
-              await github.rest.actions.cancelWorkflowRun({
-                owner,
-                repo,
-                run_id: run.id
-              });
-              core.info(`Cancelled run #${run.run_number} (id ${run.id}).`);
+              try {
+                await github.rest.actions.cancelWorkflowRun({
+                  owner,
+                  repo,
+                  run_id: run.id
+                });
+                core.info(`Cancelled run #${run.run_number} (id ${run.id}).`);
+              } catch (err) {
+                if (err.status === 409) {
+                  core.info(`Run #${run.run_number} (id ${run.id}) already completed; skipping.`);
+                } else {
+                  throw err;
+                }
+              }
             }


### PR DESCRIPTION
# Cancel old commit builds on PR (with no-cancel-pipeline opt-out)

## Summary

Adds a GitHub Actions workflow that cancels in-progress and queued **Unified Build Workflow** runs for the same PR when a new commit is pushed. Only the latest commit is built, saving CI time and avoiding redundant runs.

## Problem

When multiple commits are pushed to a PR in quick succession, each push triggers a new build. The previous run(s) are often still queued or in progress, so CI spends time building outdated commits. We want the pipeline to focus on the **most recent** commit for that PR.

## Solution

A new workflow **Cancel old commit build (PR)** (`.github/workflows/cancel-old-commit-build-pr.yml`) runs on the same PR events as the main build (`pull_request` to `master`, with the same `paths-ignore`). It:

1. **Reads the head commit message** (via GitHub API so it works for `pull_request`).
2. **If the message contains `no-cancel-pipeline`** (case-insensitive): does nothing, so existing and new runs continue.
3. **Otherwise**: finds in-progress and queued runs of the Unified Build Workflow for this PR ref, keeps the **newest** run (by `run_number`), and **cancels** the rest via the Actions API.

No changes were made to existing workflows (e.g. `build.yaml`).

## Behaviour

| Scenario | Behaviour |
|----------|-----------|
| New push to PR, commit message **does not** contain `no-cancel-pipeline` | Older build runs for that PR are cancelled; only the newest run continues. |
| New push to PR, commit message **contains** `no-cancel-pipeline` | No cancellation; previous and current runs continue (opt-out for special cases). |
| Triggers / paths | Same as main build: `pull_request` (opened, synchronize) to `master`, with the same `paths-ignore`. |

## Opt-out

Include **`no-cancel-pipeline`** anywhere in the commit message (e.g. `fix: something no-cancel-pipeline`) to keep the current and previous runs and not cancel them. Useful when you intentionally want multiple builds to run (e.g. testing different configs or not interrupting a long run).

## Testing

- Open a PR targeting `master`, push several commits in a row: only the latest commit’s build should run; earlier ones should be cancelled (unless a commit message contains `no-cancel-pipeline`).
- Push a commit with `no-cancel-pipeline` in the message: no runs should be cancelled.