### PR TITLE
EIM-560: Jira Build Artifacts Comment Workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1040,6 +1040,16 @@ jobs:
           asset_path: src-tauri/target/release/bundle/dmg/*.dmg
           asset_name: eim-gui-${{ matrix.package_name }}.dmg
 
+  jira-build-artifacts-comment:
+    name: Post build artifacts comment on Jira
+    needs: [build-cli, build-cli-linux, build-gui]
+    if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/jira-build-artifacts-comment.yml
+    with:
+      run_id: ${{ github.run_id }}
+      pr_title: ${{ github.event.pull_request.title }}
+    secrets: inherit
+
   Autotest-CLI:
     name: Autotest CLI
     needs: [build-cli, build-cli-linux]

--- a/.github/workflows/jira-build-artifacts-comment.yml
+++ b/.github/workflows/jira-build-artifacts-comment.yml
@@ -3,7 +3,12 @@
 #
 # When the Unified Build Workflow completes for a PR, this workflow posts or updates
 # a single Jira comment with the latest build artifacts and a link to the CI run.
+# Runs only for pull_request-triggered builds, and runs whether the build succeeded or failed.
 # Uses the same Jira key detection as jira-pr-comment.yml (PR title: EIM-12345: description).
+#
+# Can be triggered in two ways:
+# 1. workflow_run: after Unified Build completes (only works when this file is on default branch).
+# 2. workflow_call: from build.yaml after artifact jobs finish (works on PR branch so you can test before merge).
 #
 # Ensures only one "Build Artifacts (CI)" comment per Jira issue: finds it by marker
 # and updates it, or creates a new comment if none exists.
@@ -11,48 +16,81 @@
 name: Build Artifacts Comment on Jira
 
 run-name: >
-  Build Artifacts on Jira - Run #${{ github.event.workflow_run.run_number }}
+  Build Artifacts on Jira -
+  ${{ github.event_name == 'workflow_run' && format('Run #{0}', github.event.workflow_run.run_number) || format('Run #{0}', github.run_id) }}
 
 on:
   workflow_run:
     workflows: ["Unified Build Workflow"]
+    # completed = run finished (success, failure, or cancelled); we run regardless of result
     types: [completed]
+  workflow_call:
+    inputs:
+      run_id:
+        description: "Workflow run ID (e.g. github.run_id from caller)"
+        required: true
+        type: string
+      pr_title:
+        description: "Pull request title (for Jira key extraction)"
+        required: true
+        type: string
 
 jobs:
   jira-artifacts-comment:
     name: Post or update artifacts comment on Jira
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.event == 'pull_request'
+    # workflow_run: only when the build was triggered by a PR
+    # workflow_call: caller (build.yaml) only calls us for pull_request
+    if: |
+      (github.event_name == 'workflow_run' && github.event.workflow_run.event == 'pull_request') ||
+      github.event_name == 'workflow_call'
     steps:
       - name: Get PR and extract Jira key
         id: pr
         uses: actions/github-script@v7
         with:
           script: |
-            const run = context.payload.workflow_run;
-            const runId = run.id;
-            let prNumber, prTitle;
+            const eventName = context.eventName;
+            let runId, prNumber, prTitle;
 
-            if (run.pull_requests && run.pull_requests.length > 0) {
-              prNumber = run.pull_requests[0].number;
-              prTitle = run.pull_requests[0].title;
+            if (eventName === 'workflow_run') {
+              const run = context.payload.workflow_run;
+              runId = run.id;
+              if (run.pull_requests && run.pull_requests.length > 0) {
+                prNumber = run.pull_requests[0].number;
+                prTitle = run.pull_requests[0].title;
+              } else {
+                const head = `${run.head_repository.owner.login}:${run.head_branch}`;
+                const { data: pulls } = await github.rest.pulls.list({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  state: 'open',
+                  head
+                });
+                if (!pulls.length) {
+                  core.info('No PR found for this run. Skipping.');
+                  core.setOutput('found', 'false');
+                  return;
+                }
+                prNumber = pulls[0].number;
+                prTitle = pulls[0].title;
+              }
             } else {
-              const owner = run.head_repository.owner.login;
-              const repo = run.head_repository.name;
-              const head = `${owner}:${run.head_branch}`;
-              const { data: pulls } = await github.rest.pulls.list({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                state: 'open',
-                head
-              });
-              if (!pulls.length) {
-                core.info('No PR found for this run. Skipping.');
+              // workflow_call: PR info passed as inputs by caller (build.yaml)
+              runId = context.payload.inputs.run_id;
+              prTitle = context.payload.inputs.pr_title;
+              const match = prTitle.match(/^(EIM-[0-9]+):/);
+              if (!match) {
+                core.info('No Jira issue key in PR title. Skipping.');
                 core.setOutput('found', 'false');
                 return;
               }
-              prNumber = pulls[0].number;
-              prTitle = pulls[0].title;
+              core.setOutput('found', 'true');
+              core.setOutput('issue_key', match[1]);
+              core.setOutput('pr_number', ''); // not needed for Jira comment
+              core.setOutput('pr_title', prTitle);
+              core.setOutput('run_id', String(runId));
+              return;
             }
 
             const match = prTitle.match(/^(EIM-[0-9]+):/);
@@ -72,9 +110,11 @@ jobs:
         if: steps.pr.outputs.found == 'true'
         id: artifacts
         uses: actions/github-script@v7
+        env:
+          RUN_ID: ${{ steps.pr.outputs.run_id }}
         with:
           script: |
-            const runId = context.payload.workflow_run.id;
+            const runId = parseInt(process.env.RUN_ID, 10);
             const { data } = await github.rest.actions.listWorkflowRunArtifacts({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -100,7 +140,7 @@ jobs:
           ISSUE_KEY: ${{ steps.pr.outputs.issue_key }}
           RUN_ID: ${{ steps.pr.outputs.run_id }}
           NAMES_JSON: ${{ steps.artifacts.outputs.names_json }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ steps.pr.outputs.run_id }}
         run: |
           set -euo pipefail
           MARKER="Build Artifacts (CI)"

--- a/.github/workflows/jira-build-artifacts-comment.yml
+++ b/.github/workflows/jira-build-artifacts-comment.yml
@@ -1,0 +1,171 @@
+---
+# FILE: .github/workflows/jira-build-artifacts-comment.yml
+#
+# When the Unified Build Workflow completes for a PR, this workflow posts or updates
+# a single Jira comment with the latest build artifacts and a link to the CI run.
+# Uses the same Jira key detection as jira-pr-comment.yml (PR title: EIM-12345: description).
+#
+# Ensures only one "Build Artifacts (CI)" comment per Jira issue: finds it by marker
+# and updates it, or creates a new comment if none exists.
+
+name: Build Artifacts Comment on Jira
+
+run-name: >
+  Build Artifacts on Jira - Run #${{ github.event.workflow_run.run_number }}
+
+on:
+  workflow_run:
+    workflows: ["Unified Build Workflow"]
+    types: [completed]
+
+jobs:
+  jira-artifacts-comment:
+    name: Post or update artifacts comment on Jira
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.event == 'pull_request'
+    steps:
+      - name: Get PR and extract Jira key
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const run = context.payload.workflow_run;
+            const runId = run.id;
+            let prNumber, prTitle;
+
+            if (run.pull_requests && run.pull_requests.length > 0) {
+              prNumber = run.pull_requests[0].number;
+              prTitle = run.pull_requests[0].title;
+            } else {
+              const owner = run.head_repository.owner.login;
+              const repo = run.head_repository.name;
+              const head = `${owner}:${run.head_branch}`;
+              const { data: pulls } = await github.rest.pulls.list({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: 'open',
+                head
+              });
+              if (!pulls.length) {
+                core.info('No PR found for this run. Skipping.');
+                core.setOutput('found', 'false');
+                return;
+              }
+              prNumber = pulls[0].number;
+              prTitle = pulls[0].title;
+            }
+
+            const match = prTitle.match(/^(EIM-[0-9]+):/);
+            if (!match) {
+              core.info('No Jira issue key in PR title. Skipping.');
+              core.setOutput('found', 'false');
+              return;
+            }
+
+            core.setOutput('found', 'true');
+            core.setOutput('issue_key', match[1]);
+            core.setOutput('pr_number', String(prNumber));
+            core.setOutput('pr_title', prTitle);
+            core.setOutput('run_id', String(runId));
+
+      - name: Fetch workflow run artifacts
+        if: steps.pr.outputs.found == 'true'
+        id: artifacts
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runId = context.payload.workflow_run.id;
+            const { data } = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: runId
+            });
+            const names = (data.artifacts || [])
+              .filter(a => !a.expired)
+              .map(a => a.name)
+              .sort();
+            const sizes = (data.artifacts || [])
+              .filter(a => !a.expired)
+              .map(a => ({ name: a.name, size: a.size_in_bytes }));
+            core.setOutput('names_json', JSON.stringify(names));
+            core.setOutput('sizes_json', JSON.stringify(sizes));
+            core.setOutput('count', String(names.length));
+
+      - name: Build comment body and post or update on Jira
+        if: steps.pr.outputs.found == 'true'
+        env:
+          JIRA_USER: ${{ secrets.JIRA_USER }}
+          JIRA_PASS: ${{ secrets.JIRA_PASS }}
+          JIRA_URL: ${{ secrets.JIRA_URL }}
+          ISSUE_KEY: ${{ steps.pr.outputs.issue_key }}
+          RUN_ID: ${{ steps.pr.outputs.run_id }}
+          NAMES_JSON: ${{ steps.artifacts.outputs.names_json }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}
+        run: |
+          set -euo pipefail
+          MARKER="Build Artifacts (CI)"
+
+          # Build plain-text comment body: heading, link, artifact list
+          BODY_LINE1="$MARKER"
+          BODY_LINE2=""
+          BODY_LINE3="Workflow run: $RUN_URL"
+          BODY_LINE4=""
+          BODY_LINE5="Artifacts:"
+          BODY_ARTIFACTS=$(echo "$NAMES_JSON" | jq -r '.[] | "• " + .')
+          COMMENT_BODY="${BODY_LINE1}"$'\n'"${BODY_LINE2}"$'\n'"${BODY_LINE3}"$'\n'"${BODY_LINE4}"$'\n'"${BODY_LINE5}"$'\n'"${BODY_ARTIFACTS}"
+
+          # Auth (same as jira-pr-comment.yml)
+          if [[ "$JIRA_PASS" == token:* ]]; then
+            TOKEN="${JIRA_PASS#token:}"
+            AUTH_HEADER="Authorization: Bearer $TOKEN"
+          else
+            AUTH_HEADER="Authorization: Basic $(echo -n "$JIRA_USER:$JIRA_PASS" | base64)"
+          fi
+
+          # Escape for JSON: replace backslash and double-quote, then wrap in quotes
+          BODY_ESCAPED=$(echo "$COMMENT_BODY" | jq -Rs .)
+
+          # GET existing comments
+          COMMENTS_RESPONSE=$(curl -s -w "\n%{http_code}" \
+            -H "$AUTH_HEADER" \
+            "$JIRA_URL/rest/api/2/issue/$ISSUE_KEY/comment")
+          COMMENTS_HTTP=$(echo "$COMMENTS_RESPONSE" | tail -n 1)
+          COMMENTS_JSON=$(echo "$COMMENTS_RESPONSE" | sed '$d')
+
+          if [[ "$COMMENTS_HTTP" -lt 200 || "$COMMENTS_HTTP" -ge 300 ]]; then
+            echo "::warning::Failed to get Jira comments (HTTP $COMMENTS_HTTP). Skipping."
+            exit 0
+          fi
+
+          # Find comment containing our marker
+          EXISTING_ID=$(echo "$COMMENTS_JSON" | jq -r --arg m "$MARKER" '.comments[] | select(.body | type == "string" and (contains($m))) | .id' | head -n 1)
+
+          if [[ -n "$EXISTING_ID" && "$EXISTING_ID" != "null" ]]; then
+            # Update existing comment
+            UPDATE_RESPONSE=$(curl -s -w "\n%{http_code}" \
+              -X PUT \
+              -H "Content-Type: application/json" \
+              -H "$AUTH_HEADER" \
+              -d "{\"body\": $BODY_ESCAPED}" \
+              "$JIRA_URL/rest/api/2/issue/$ISSUE_KEY/comment/$EXISTING_ID")
+            UPDATE_HTTP=$(echo "$UPDATE_RESPONSE" | tail -n 1)
+            if [[ "$UPDATE_HTTP" -ge 200 && "$UPDATE_HTTP" -lt 300 ]]; then
+              echo "Updated existing Build Artifacts comment on Jira issue $ISSUE_KEY"
+            else
+              echo "::warning::Failed to update Jira comment (HTTP $UPDATE_HTTP)"
+            fi
+          else
+            # Add new comment
+            POST_RESPONSE=$(curl -s -w "\n%{http_code}" \
+              -X POST \
+              -H "Content-Type: application/json" \
+              -H "$AUTH_HEADER" \
+              -d "{\"body\": $BODY_ESCAPED}" \
+              "$JIRA_URL/rest/api/2/issue/$ISSUE_KEY/comment")
+            POST_HTTP=$(echo "$POST_RESPONSE" | tail -n 1)
+            if [[ "$POST_HTTP" -ge 200 && "$POST_HTTP" -lt 300 ]]; then
+              echo "Added Build Artifacts comment to Jira issue $ISSUE_KEY"
+            else
+              echo "::warning::Failed to add Jira comment (HTTP $POST_HTTP). Response: $(echo "$POST_RESPONSE" | sed '$d')"
+            fi
+          fi


### PR DESCRIPTION
# Jira build artifacts comment workflow

## Summary

Adds a GitHub Actions workflow that posts or updates a **single** Jira comment with the latest build artifacts and a link to the CI run whenever the Unified Build Workflow completes for a pull request.

- Reuses the same Jira ticket detection as the existing PR-link workflow: **PR title** must match `EIM-12345: description`.
- Ensures only one “Build Artifacts (CI)” comment per Jira issue: the workflow finds that comment by a marker and **updates** it when new artifacts are available; otherwise it creates a new comment.
- Comment includes a direct link to the **workflow run** (CI build) and a formatted list of **artifact names**.

## Changes

- **New workflow**: `.github/workflows/jira-build-artifacts-comment.yml`
  - **Trigger**: `workflow_run` when “Unified Build Workflow” completes, only for runs triggered by `pull_request`.
  - Resolves the PR from `workflow_run.pull_requests` or, if empty, by querying pulls with the run’s head branch.
  - Extracts Jira key from PR title with regex `^(EIM-[0-9]+):`.
  - Fetches artifact names for the run via GitHub Actions API.
  - Gets existing Jira issue comments, finds the comment containing the marker “Build Artifacts (CI)”, then:
    - **PUT** update that comment with the new body, or
    - **POST** a new comment if none is found.

## Comment format (on Jira)

```
Build Artifacts (CI)

Workflow run: <link to GitHub Actions run>
Artifacts:
• eim-cli-linux-x64-123
• eim-gui-macos-aarch64-123
...
```

Artifact download links are not embedded (they require auth); users open the workflow run link to download artifacts.

## Error handling

- No Jira key in PR title → workflow skips without failing.
- Jira API errors (GET/PUT/POST) → warning is logged; workflow does not fail.
- No PR found for the run → skip with a log message.

## Secrets

No new secrets. Reuses:

- `JIRA_USER`
- `JIRA_PASS`
- `JIRA_URL`

## Testing suggestions

1. Open a PR whose title starts with `EIM-XXXX: ...`.
2. Wait for the Unified Build Workflow to complete (or trigger it).
3. Check the Jira issue for a “Build Artifacts (CI)” comment with the run link and artifact list.
4. Push another commit and re-run the build; the same Jira comment should be **updated** with the new run/artifacts instead of creating a second comment.
