### PR TITLE
EIM-570: Fix for venv detection

### DIFF
--- a/src-tauri/src/lib/python_utils.rs
+++ b/src-tauri/src/lib/python_utils.rs
@@ -592,14 +592,14 @@ pub async fn install_python_env(
                 let python_executable_path = PathBuf::from(scoop_shims_path).join("python3.exe");
                 match python_executable_path.try_exists() {
                     Ok(true) => python_executable_path.to_string_lossy().into_owned(),
-                    Ok(false) => "python3.exe".to_string(),
+                    Ok(false) => detect_default_python().to_string(),
                     Err(e) => {
                         warn!("Failed to check if Python executable exists: {}", e);
-                        "python3.exe".to_string()
+                        detect_default_python().to_string()
                     }
                 }
               } else {
-                "python3.exe".to_string()
+                detect_default_python().to_string()
               }
             },
             _ => "python3".to_string(),


### PR DESCRIPTION
## Summary

Fixes installation failure when creating the Python virtual environment on Windows. The venv step now uses the same Python detection as the pre-install sanity check, so setups with only `python` (or `python.exe`) on PATH are supported.

## What we found

- Installation was failing at **Python venv creation** with an empty error message (`failed to create venv:`).
- The **sanity check** already detects both `python` and `python3` on Windows via `detect_default_python()`.
- The **venv creation** path used different logic: it preferred Scoop’s `python3.exe` or fell back to the literal `"python3.exe"`, and never tried `python`/`python.exe`. So when only `python` was on PATH, venv creation could fail even after the sanity check passed.

## What we fixed

- In `install_python_env()` (`src-tauri/src/lib/python_utils.rs`), on Windows we now use `detect_default_python()` for the fallback when:
  - Scoop is not used, or
  - Scoop is used but `python3.exe` is not present (or the path check fails).

Venv creation and the sanity check now share the same Python resolution on Windows (`python` then `python3`).

## How to test

**On Windows:**

1. **Scenario A – Only `python` on PATH**  
   - Ensure `python --version` works and `python3` is not available (or rename/unlink `python3` for the test).  
   - Run a new ESP-IDF installation (GUI or CLI, e.g. `eim wizard` or Expert Installation).  
   - Installation should complete and create the venv under the tools path (e.g. `C:\Espressif\tools\python\<version>\venv`).

2. **Scenario B – Both `python` and `python3` on PATH**  
   - Run a new installation.  
   - Venv should be created successfully (unchanged behavior when `python3` is available).

3. **Scenario C – Scoop Python**  
   - With Scoop and `python3` installed via Scoop, run a new installation.  
   - Venv should still be created using Scoop’s Python when available.

**Non-Windows:** No behavior change; still uses `python3` as before.

Closes #510.
