### PR TITLE
EIM-576: if cloning idf fails the error is now corectly propagated to the user

### DIFF
--- a/src-tauri/src/lib/git_tools.rs
+++ b/src-tauri/src/lib/git_tools.rs
@@ -468,6 +468,7 @@ pub fn clone_repository(
         Err(e) => {
             let _ = tx.send(ProgressMessage::Finish);
             error!("Failed to checkout reference: {}", e);
+            return Err(anyhow!("Failed to checkout reference: {}", e).into());
         }
     }
 
@@ -479,10 +480,15 @@ pub fn clone_repository(
         info!("Recurse submodules is TRUE");
         match update_submodules_shallow(&repo, tx.clone()) {
             Ok(_) => info!("Submodules updated successfully"),
-            Err(e) => error!("Submodule update failed: {}", e),
+            Err(e) => {
+                let _ = tx.send(ProgressMessage::Finish);
+                error!("Submodule update failed: {}", e);
+                return Err(anyhow!("Submodule update failed: {}", e).into());
+            }
         }
     }
 
+    let _ = tx.send(ProgressMessage::Finish);
     Ok(dest_path)
 }
 


### PR DESCRIPTION
Curently, if the clonning of idf failed (like when we were missing token in case of private repository), we printed:
Idf clonned sucessfully
and failed in next step on missing tools.json file.
That should be now fixed and user should get real error reason.