### PR TITLE
IEP-1711: Disable DMA-BUF renderer Nvidia issue

### DIFF
--- a/src-tauri/src/gui/mod.rs
+++ b/src-tauri/src/gui/mod.rs
@@ -240,22 +240,18 @@ pub fn run(log_level_override: Option<log::LevelFilter>) {
 
     let _ = setup_gui_logging(log_level_override);
 
-    // Workaround for WebKitGTK DMA-BUF renderer crash on Nvidia + Wayland (#421).
-    // The GBM buffer allocation fails when using the DMA-BUF renderer with
-    // Nvidia's proprietary driver on Wayland, causing the app to crash.
+    // Workaround for WebKitGTK DMA-BUF renderer issues on Nvidia (#421, #523).
+    // GBM buffer allocation fails when using the DMA-BUF renderer with
+    // Nvidia's proprietary driver, causing a blank window or crash.
+    // This affects both Wayland and X11 sessions.
     #[cfg(target_os = "linux")]
     {
         if env::var_os("WEBKIT_DISABLE_DMABUF_RENDERER").is_none() {
-            let is_wayland = env::var("XDG_SESSION_TYPE")
-                .map(|v| v.eq_ignore_ascii_case("wayland"))
-                .unwrap_or(false)
-                || env::var_os("WAYLAND_DISPLAY").is_some();
-
             let has_nvidia = Path::new("/proc/driver/nvidia/version").exists();
 
-            if is_wayland && has_nvidia {
+            if has_nvidia {
                 env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
-                info!("Nvidia + Wayland detected: disabled WebKitGTK DMA-BUF renderer (WEBKIT_DISABLE_DMABUF_RENDERER=1)");
+                info!("Nvidia detected: disabled WebKitGTK DMA-BUF renderer (WEBKIT_DISABLE_DMABUF_RENDERER=1)");
             }
         }
     }


### PR DESCRIPTION
Closes #523

### Summary

The existing workaround from #428 disabled WebKitGTK's DMA-BUF renderer only when **Nvidia + Wayland** was detected. Issue #523 reports the identical GBM buffer allocation failure (`Failed to create GBM buffer of size 1200x1000: Invalid argument`) on **Nvidia + X11** (Fedora 43, XFCE 4.20.6, Nvidia GTX 3060, driver 590.48.01). The reporter confirmed that setting `WEBKIT_DISABLE_DMABUF_RENDERER=1` resolves the blank window.

The root cause is Nvidia's proprietary DMA-BUF/GBM implementation, which is not specific to Wayland. This PR removes the Wayland-only restriction so the workaround applies to all Nvidia systems on Linux.

### Changes

**`src-tauri/src/gui/mod.rs`**

- Removed the Wayland session detection (`XDG_SESSION_TYPE`, `WAYLAND_DISPLAY` checks).
- Simplified the condition from `is_wayland && has_nvidia` to just `has_nvidia`.
- Updated comments to reference both #421 and #523 and clarify that both Wayland and X11 are affected.
- The existing user-override guard (`WEBKIT_DISABLE_DMABUF_RENDERER` already set) is preserved, so users can still opt out.

### Testing

- Since this is a Linux + Nvidia-specific runtime workaround, it cannot be verified on macOS or Windows.
- The `#[cfg(target_os = "linux")]` guard ensures the block is compiled out on other platforms -- zero cost.
- On non-Nvidia Linux systems, `/proc/driver/nvidia/version` does not exist, so the workaround is skipped entirely.
- On Nvidia Linux systems (Wayland or X11), `WEBKIT_DISABLE_DMABUF_RENDERER=1` is set before WebKitGTK initialisation, preventing the GBM buffer failure.
