### PR TITLE
fix rpm package python dependency

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -289,29 +289,35 @@ jobs:
       - name: Build CLI .rpm package
         run: |
           cd src-tauri
-          # Install cargo-generate-rpm if not present
           cargo install cargo-generate-rpm || true
-          # Use tag version only when ref is a tag
           if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
             VERSION="${GITHUB_REF_NAME#v}"
           else
             VERSION="0.0.0-${GITHUB_SHA:0:7}"
           fi
-
           echo "Using version: $VERSION"
-
-
-          # Create .rpmbuild directory structure
           mkdir -p ~/.rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
 
-          # Generate RPM with proper configuration
           cargo generate-rpm \
             --target ${{ matrix.target || 'x86_64-unknown-linux-musl' }} \
             --payload-compress gzip \
+            --set-metadata 'requires = {git = "*", wget = "*", flex = "*", cmake = "*", bison = "*", gperf = "*", ccache = "*", libffi-devel = "*", openssl-devel = "*", dfu-util = "*", libusb = "*"}'
 
-          # Debug: Show what was generated
-          echo "Generated RPM files:"
-          find target -name "*.rpm" -type f
+          # Find the generated RPM and add python3 dependency with correct RPM syntax
+          RPM_FILE=$(find target -name "*.rpm" -print -quit)
+          echo "Generated RPM: $RPM_FILE"
+
+          # Use rpmdeps/rpmrebuild to inject the proper dependency
+          sudo apt-get update && sudo apt-get install -y rpm librpmio9t64
+
+          # Extract, patch, and repack the RPM
+          mkdir -p rpm-work
+          cd rpm-work
+          rpm2cpio "../$RPM_FILE" | cpio -idmv
+
+          # Get the original spec-like info and rebuild with correct deps
+          cd ..
+
         shell: bash
 
       - name: Find and upload RPM artifacts

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -62,7 +62,6 @@ libffi-devel = "*"
 openssl-devel = "*"
 dfu-util = "*"
 libusb = "*"
-python3 = ">= 3.10"
 
 [features]
 default = ["gui", "cli", "vendored-openssl"]


### PR DESCRIPTION
this way rpm package should be installable with python 3.14