### PR TITLE
EIM-580: the eim install comand now does not run if the idf is already installed

### DIFF
--- a/src-tauri/locales/app.yml
+++ b/src-tauri/locales/app.yml
@@ -414,8 +414,8 @@ install.ready:
   en: Now you can start using IDF tools
   cn: 现在可以开始使用 IDF 工具了
 install.already_installed:
-  en: "The IDF at path '{path}' is already installed. If you need to reinstall or fix it, please use the 'fix' command."
-  cn: "路径 '{path}' 处的 IDF 已安装。如果您需要重新安装或修复它，请使用 'fix' 命令。"
+  en: "The IDF at path '%{path}' is already installed. If you need to reinstall or fix it, please use the 'fix' command."
+  cn: "路径 '%{path}' 处的 IDF 已安装。如果您需要重新安装或修复它，请使用 'fix' 命令。"
 install.use_fix_command:
   en: "To fix the installation, run: eim fix --path <path>"
   cn: "要修复安装，请运行: eim fix --path <path>"

--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -156,7 +156,7 @@ pub async fn run_cli(cli: Cli) -> anyhow::Result<()> {
                 install_args.config.clone(),
                 install_args.clone().into_iter(),
             );
-            info!("Returned settings: {:?}", settings);
+            debug!("Returned settings: {:?}", settings);
             match settings {
                 Ok(mut settings) => {
                   debug!("Settings before adjustments: {:?}", settings);
@@ -169,17 +169,17 @@ pub async fn run_cli(cli: Cli) -> anyhow::Result<()> {
                       match idf_im_lib::version_manager::list_installed_versions() {
                           Ok(versions) => {
                             debug!("Checking provided path against installed versions. Provided path: '{}'", path.display());
-                              let provided_path = idf_im_lib::utils::normalize_path_for_comparison(&path.to_string_lossy());
-                              for version in versions {
-                                  let version_path = idf_im_lib::utils::normalize_path_for_comparison(&version.path);
-                                  debug!("Normalized version_path for '{}': {:?}", version.path, version_path);
-                                  if let (Some(p), Some(v)) = (&provided_path, &version_path) {
-                                      if p == v {
-                                          info!("{}", t!("install.already_installed", path = path.display()));
-                                          return Ok(());
-                                      }
-                                  }
+                            if let Some(provided_path) = idf_im_lib::utils::normalize_path_for_comparison(&path.to_string_lossy()) {
+                              if versions.iter().any(|version| {
+                                let version_path = idf_im_lib::utils::normalize_path_for_comparison(&version.path);
+                                debug!("Normalized version_path for '{}': {:?}", version.path, version_path);
+                                version_path.map_or(false, |p| p == provided_path)
+                              }) {
+                                info!("{}", t!("install.already_installed", path = path.display()));
+                                info!("{}", t!("install.use_fix_command"));
+                                return Ok(());
                               }
+                            }
                           }
                           Err(err) => {
                               debug!("Could not list installed versions: {}", err);


### PR DESCRIPTION
this is another improvement needed for the final instal.sh replacement