### PR TITLE
add linux support in homebrew ci (EIM-586)

### DIFF
--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -67,9 +67,9 @@ jobs:
           linux_x64_sha=$(sha256sum eim-cli-linux-x64.zip | cut -d' ' -f1)
 
           # Linux ARM64 CLI
-          linux_arm64_url=$(echo "$ASSETS" | jq -r '.[] | select(.name == "eim-cli-linux-arm64.zip") | .browser_download_url')
-          wget -q "$linux_arm64_url" -O eim-cli-linux-arm64.zip
-          linux_arm64_sha=$(sha256sum eim-cli-linux-arm64.zip | cut -d' ' -f1)
+          linux_arm64_url=$(echo "$ASSETS" | jq -r '.[] | select(.name == "eim-cli-linux-aarch64.zip") | .browser_download_url')
+          wget -q "$linux_arm64_url" -O eim-cli-linux-aarch64.zip
+          linux_arm64_sha=$(sha256sum eim-cli-linux-aarch64.zip | cut -d' ' -f1)
 
           echo "macos_x64_url=$macos_x64_url" >> $GITHUB_OUTPUT
           echo "macos_x64_sha=$macos_x64_sha" >> $GITHUB_OUTPUT


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

See: #536

I found the current .rb Formula is entirely within the CI config
adding Linux support requires tiny changes and maintenance.

BTW: `generate_completions_from_executable(bin/"eim", "completions")` works for all shells includes bash, zsh, fish

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->
Closes: #536

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

Tested on Bluefin
Kernel 6.17.12-300.fc43.x86_64
Homebrew 5.0.16-47-g0707ee7

<details>

```
~ 
❯ brew edit espressif/eim/eim
Editing /var/home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/espressif/homebrew-eim/Formula/eim.rb

~ 
❯ brew install espressif/eim/eim
==> Auto-updating Homebrew...
Adjust how often this is run with `$HOMEBREW_AUTO_UPDATE_SECS` or disable with
`$HOMEBREW_NO_AUTO_UPDATE=1`. Hide these hints with `$HOMEBREW_NO_ENV_HINTS=1` (see `man brew`).
==> Fetching downloads for: eim
✔︎ Bottle Manifest keyutils (1.6.3)                                                                                                                          Downloaded    3.5KB/  3.5KB
✔︎ Bottle Manifest krb5 (1.22.2)                                                                                                                             Downloaded   16.3KB/ 16.3KB
✔︎ Bottle Manifest libtirpc (1.3.7)                                                                                                                          Downloaded   13.5KB/ 13.5KB
✔︎ Bottle Manifest libnsl (2.0.1)                                                                                                                            Downloaded    4.6KB/  4.6KB
✔︎ Bottle Manifest python@3.12 (3.12.13)                                                                                                                     Downloaded   28.5KB/ 28.5KB
✔︎ Bottle libnsl (2.0.1)                                                                                                                                     Downloaded   46.2KB/ 46.2KB
✔︎ Bottle keyutils (1.6.3)                                                                                                                                   Downloaded  113.1KB/113.1KB
✔︎ Bottle krb5 (1.22.2)                                                                                                                                      Downloaded    1.7MB/  1.7MB
✔︎ Bottle libtirpc (1.3.7)                                                                                                                                   Downloaded  295.2KB/295.2KB
✔︎ Bottle python@3.12 (3.12.13)                                                                                                                              Downloaded   20.3MB/ 20.3MB
✔︎ Formula eim (0.8.5)                                                                                                                                       Verified     12.3MB/ 12.3MB
==> Installing eim from espressif/eim
==> Installing dependencies for espressif/eim/eim: keyutils, krb5, libtirpc, libnsl and python@3.12
==> Installing espressif/eim/eim dependency: keyutils
==> Pouring keyutils--1.6.3.x86_64_linux.bottle.tar.gz
🍺  /home/linuxbrew/.linuxbrew/Cellar/keyutils/1.6.3: 66 files, 483.2KB
==> Installing espressif/eim/eim dependency: krb5
==> Pouring krb5--1.22.2.x86_64_linux.bottle.tar.gz
🍺  /home/linuxbrew/.linuxbrew/Cellar/krb5/1.22.2: 164 files, 5.5MB
==> Installing espressif/eim/eim dependency: libtirpc
==> Pouring libtirpc--1.3.7.x86_64_linux.bottle.tar.gz
🍺  /home/linuxbrew/.linuxbrew/Cellar/libtirpc/1.3.7: 86 files, 1MB
==> Installing espressif/eim/eim dependency: libnsl
==> Pouring libnsl--2.0.1.x86_64_linux.bottle.1.tar.gz
🍺  /home/linuxbrew/.linuxbrew/Cellar/libnsl/2.0.1: 18 files, 178.1KB
==> Installing espressif/eim/eim dependency: python@3.12
==> Pouring python@3.12--3.12.13.x86_64_linux.bottle.tar.gz
🍺  /home/linuxbrew/.linuxbrew/Cellar/python@3.12/3.12.13: 3,217 files, 75.7MB
==> Installing espressif/eim/eim
==> Caveats
ESP-IDF Installation Manager (EIM) has been installed.

Python 3.12 was installed as a dependency (ESP-IDF requires Python 3.9-3.13).
Python 3.14+ is not yet supported.

Shell completions have been installed.
They will be available in new terminal sessions.
If they don't work immediately, restart your shell:
  exec $SHELL

Run 'eim' to install ESP-IDF.
==> Summary
🍺  /home/linuxbrew/.linuxbrew/Cellar/eim/0.8.5: 7 files, 34.5MB, built in 8 seconds
==> Running `brew cleanup eim`...
Disable this behaviour by setting `HOMEBREW_NO_INSTALL_CLEANUP=1`.
Hide these hints with `HOMEBREW_NO_ENV_HINTS=1` (see `man brew`).
==> Caveats
Bash completion has been installed to:
  /home/linuxbrew/.linuxbrew/etc/bash_completion.d
==> eim
ESP-IDF Installation Manager (EIM) has been installed.

Python 3.12 was installed as a dependency (ESP-IDF requires Python 3.9-3.13).
Python 3.14+ is not yet supported.

Shell completions have been installed.
They will be available in new terminal sessions.
If they don't work immediately, restart your shell:
  exec $SHELL

Run 'eim' to install ESP-IDF.

~ 
❯ eim --version
eim 0.8.5
```

</details>

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
