### PR TITLE
Eim-435: added bat and fish activation

### DIFF
--- a/docs/src/after_installing.md
+++ b/docs/src/after_installing.md
@@ -6,7 +6,12 @@ On Windows, the installer creates a desktop icon labeled **IDF\_PowerShell**. Cl
 
 ## macOS & Linux
 
-In the installation directory you selected, there will be a `.sh` script that, when sourced, activates the ESP-IDF environment in your current shell. If you've installed multiple versions of ESP-IDF, there will be a separate script for each version.
+In the installation directory you selected, there will be activation scripts for both **Bash** and **Fish** shells:
+
+- **Bash**: `activate_idf_{version}.sh` - works in Sh, Bash, Dash and Zsh
+- **Fish**: `activate_idf_{version}.fish` - for Fish shell users
+
+If you've installed multiple versions of ESP-IDF, there will be separate scripts for each version.
 
 > **Note**
 > The script must be sourced and not executed\!

--- a/docs/src/cli_commands.md
+++ b/docs/src/cli_commands.md
@@ -71,6 +71,7 @@ Options:
 - `--cleanup`: If set to true, the installer will remove temporary tool archive files after installation. Default is false. This is useful for headless, CI, and Docker environments where the installation artifacts are not needed after installation and can significantly reduce the final image size.
 - `--use-local-archive <PATH_TO_ARCHIVE>`: Use a local archive for offline installation. The installer will use the provided archive instead of downloading from the internet. The archive should be a `.zst` file. **Do not unpack the .zst archive.** This option is not compatible with online installation options like `--idf-versions`, `--mirror`, etc. At this time, offline installation only supports Python 3.11 to 3.14 on Linux and macOS.
 - `--activation-script-path-override`: Optional override for activation script path. This allows specifying a custom path for the activation script to be saved to instead of the default one.
+- `--create-bat-activation-script`: Optional flag to create a CMD batch activation script in addition to PowerShell profile. This is for backward compatibility only - PowerShell is recommended and batch support will be abandoned in a future release.
 - `--idf-tools <IDF_TOOLS>`: Comma separated list of tools to be installed with ESP-IDF. When installing multiple versions, these tools are applied to all versions. For per-version tool configuration, use a configuration file with the `idf_tools_per_version` option.
 
 ### Wizard Command

--- a/docs/src/cli_configuration.md
+++ b/docs/src/cli_configuration.md
@@ -70,6 +70,7 @@ esp_idf_json_path = "/Users/testusername/.espressif/tools"
 tool_download_folder_name = "/Users/testusername/.espressif/dist"
 tool_install_folder_name = "/Users/testusername/.espressif/tools"
 activation_script_path_override = "/Users/testusername/.espressif/tools"
+create_bat_activation_script = false
 python_env_folder_name = "python_env"
 cleanup = true
 target = ["all"]

--- a/docs/src/faq.md
+++ b/docs/src/faq.md
@@ -159,6 +159,26 @@ For GitHub Actions, use the [install-esp-idf-action](https://github.com/espressi
 
 If you downloaded the CLI-only version (e.g., `eim-cli-*.exe`) and double-clicked the executable, this behavior is expected. CLI releases must be run from a terminal/command prompt rather than double-clicking. When you double-click the executable, it opens a terminal window briefly, displays help information, and then closes immediately, which may appear as if the installer crashed. Instead, open PowerShell or Command Prompt, navigate to the file location, and run it with `.\eim-cli-*.exe --help`.
 
+### What shells are supported for activation scripts?
+
+On Linux and macOS, EIM creates activation scripts for both **Bash** and **Fish** shells:
+- **Bash**: `activate_idf_{version}.sh` - works in Sh, Bash, Dash and Zsh
+- **Fish**: `activate_idf_{version}.fish` - for Fish shell users
+
+On Windows, EIM creates a **PowerShell** profile script (`Microsoft.{version}.PowerShell_profile.ps1`). Additionally, you can optionally create a CMD batch file by setting `create_bat_activation_script = true` in your configuration.
+
+### Should I use CMD (Command Prompt) batch files?
+
+**No.** We strongly recommend using **PowerShell** instead of CMD (Command Prompt) on Windows. The batch file (`.bat`) support exists only for backward compatibility and will be abandoned in a future release.
+
+Reasons to use PowerShell:
+- Better environment variable handling
+- More modern syntax and features
+- Active development and support
+- Required for many modern tools
+
+To use PowerShell, simply run the generated PowerShell profile script - it is created automatically during installation.
+
 ## More Questions?
 
 If you have additional questions, you can:

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -711,28 +711,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "chrono-tz"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93698b29de5e97ad0ae26447b344c482a7284c737d9ddc5f9e52b74a336671bb"
-dependencies = [
- "chrono",
- "chrono-tz-build",
- "phf 0.11.3",
-]
-
-[[package]]
-name = "chrono-tz-build"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c088aee841df9c3041febbb73934cfc39708749bf96dc827e3359cd39ef11b1"
-dependencies = [
- "parse-zoneinfo",
- "phf 0.11.3",
- "phf_codegen 0.11.3",
-]
-
-[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1226,12 +1204,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "deunicode"
-version = "1.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abd57806937c9cc163efc8ea3910e00a62e2aeb0b8119f1793a978088f8f6b04"
-
-[[package]]
 name = "dialoguer"
 version = "0.11.0"
 source = "git+https://github.com/Hahihula/dialoguer.git?branch=folder-select#d675b3f5a6a22ceec46b1c24a81b599526131d9d"
@@ -1453,7 +1425,6 @@ dependencies = [
  "tauri-plugin-shell",
  "tauri-plugin-store",
  "tempfile",
- "tera",
  "thiserror 2.0.18",
  "tokio",
  "toml 0.9.12+spec-1.1.0",
@@ -3001,17 +2972,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "globwalk"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
-dependencies = [
- "bitflags 2.11.0",
- "ignore",
- "walkdir",
-]
-
-[[package]]
 name = "gobject-sys"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3286,15 +3246,6 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
-
-[[package]]
-name = "humansize"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7"
-dependencies = [
- "libm",
-]
 
 [[package]]
 name = "hyper"
@@ -5022,15 +4973,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parse-zoneinfo"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f2a05b18d44e2957b88f96ba460715e295bc1d7510468a2f3d3b44535d26c24"
-dependencies = [
- "regex",
-]
-
-[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5953,7 +5895,7 @@ version = "3.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fda2551fdfaf6cc5ee283adc15e157047b92ae6535cf80f6d4962d05717dc332"
 dependencies = [
- "globwalk 0.8.1",
+ "globwalk",
  "once_cell",
  "regex",
  "rust-i18n-macro",
@@ -5986,7 +5928,7 @@ checksum = "940ed4f52bba4c0152056d771e563b7133ad9607d4384af016a134b58d758f19"
 dependencies = [
  "arc-swap",
  "base62",
- "globwalk 0.8.1",
+ "globwalk",
  "itertools",
  "lazy_static",
  "normpath",
@@ -6965,16 +6907,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
-name = "slug"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "882a80f72ee45de3cc9a5afeb2da0331d58df69e4e7d8eeb5d3c7784ae67e724"
-dependencies = [
- "deunicode",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7718,28 +7650,6 @@ dependencies = [
  "futf",
  "mac",
  "utf-8",
-]
-
-[[package]]
-name = "tera"
-version = "1.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8004bca281f2d32df3bacd59bc67b312cb4c70cea46cbd79dbe8ac5ed206722"
-dependencies = [
- "chrono",
- "chrono-tz",
- "globwalk 0.9.1",
- "humansize",
- "lazy_static",
- "percent-encoding",
- "pest",
- "pest_derive",
- "rand 0.8.5",
- "regex",
- "serde",
- "serde_json",
- "slug",
- "unicode-segmentation",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -104,7 +104,6 @@ gix = { version = "0.80", default-features = false, features = [
 sha2 = "0.10.8"
 log = "0.4.21"
 dirs = "6.0.0"
-tera = "1.20.0"
 config = "0.15.13"
 toml = "0.9.8"
 uuid = {version="1.10.0", features = ["v4"] }

--- a/src-tauri/bash_scripts/activate_idf_template.fish
+++ b/src-tauri/bash_scripts/activate_idf_template.fish
@@ -1,0 +1,161 @@
+# Store env var pairs as semicolon-separated string for later parsing
+set -g FISH_ENV_VAR_PAIRS "{{fish_env_var_pairs}}"
+
+# --- Capture absolute eim path early (before PATH changes) ---
+set -g _EIM_BIN (command -v eim 2>/dev/null; or true)
+
+function parse_cmake_version
+    set cmake_file "{{idf_path_escaped}}/tools/cmake/version.cmake"
+
+    # Check if file exists
+    if not test -f "$cmake_file"
+        echo "Error: CMake version file not found at: $cmake_file" >&2
+        return 1
+    end
+
+    set major ""
+    set minor ""
+
+    # Read the file and extract version numbers
+    while read -l line
+        # Trim leading whitespace
+        set line (string trim --left "$line")
+
+        # Check for version lines
+        if string match -q "set(IDF_VERSION_MAJOR *" "$line"
+            set -l matches (string match -r 'set\(IDF_VERSION_MAJOR\s+(\d+)' "$line")
+            and set major $matches[2]
+        else if string match -q "set(IDF_VERSION_MINOR *" "$line"
+            set -l matches (string match -r 'set\(IDF_VERSION_MINOR\s+(\d+)' "$line")
+            and set minor $matches[2]
+        end
+    end < "$cmake_file"
+
+    # Check if both versions were found
+    if test -z "$major" -o -z "$minor"
+        echo "Error: Could not find both major and minor version numbers" >&2
+        return 1
+    end
+
+    # Return the version
+    echo "$major.$minor"
+    return 0
+end
+
+set IDF_VERSION (parse_cmake_version)
+
+# Store env var pairs as a list (parse the semicolon-separated string)
+set -g ENV_VAR_PAIRS (string split ";" "$FISH_ENV_VAR_PAIRS")
+
+# Function to print environment variables
+function print_env_variables
+    printf '%s\n' "PATH={{addition_to_path}}"
+    printf '%s\n' "SYSTEM_PATH={{current_system_path}}"
+    printf '%s\n' "ESP_IDF_VERSION=$IDF_VERSION"
+
+    # Process environment variables
+    for pair in $ENV_VAR_PAIRS
+        if test -n "$pair"
+            set -l key (string split -m 1 ":" "$pair")[1]
+            set -l value (string split -m 1 ":" "$pair")[2]
+            printf '%s=%s\n' "$key" "$value"
+        end
+    end
+end
+
+function add_env_variable
+    set -gx ESP_IDF_VERSION "$IDF_VERSION"
+    printf '%s\n' "Added environment variable ESP_IDF_VERSION = $ESP_IDF_VERSION"
+
+    # Process environment variables
+    for pair in $ENV_VAR_PAIRS
+        if test -n "$pair"
+            set -l key (string split -m 1 ":" "$pair")[1]
+            set -l value (string split -m 1 ":" "$pair")[2]
+            set -gx $key "$value"
+            printf '%s\n' "Added environment variable $key = $value"
+        end
+    end
+end
+
+# Function to add a directory to the system PATH
+function add_to_path
+    # Fish PATH is a list; split colon-separated paths into individual entries
+    set -l new_paths (string split ":" "{{addition_to_path}}")
+    set -gx PATH $new_paths $PATH
+    printf '%s\n' "Added proper directory to PATH"
+end
+
+# Function to activate Python virtual environment
+function activate_venv
+    set -l venv_path $argv[1]
+    if test -f "$venv_path/bin/activate.fish"
+        source "$venv_path/bin/activate.fish"
+        printf '%s\n' "Activated virtual environment at $venv_path"
+    else if test -f "$venv_path/bin/activate"
+        # Fallback to bash-style activate
+        source "$venv_path/bin/activate"
+        printf '%s\n' "Activated virtual environment at $venv_path (bash-style)"
+    else
+        printf '%s\n' "Virtual environment not found at $venv_path"
+        return 1
+    end
+end
+
+# Check if the script is being sourced
+if not status is-interactive
+    if test (count $argv) -ge 1; and test "$argv[1]" = "-e"
+        print_env_variables
+        exit 0
+    else
+        echo "This script should be sourced, not executed."
+        echo "If you want to print environment variables, run it with the -e parameter."
+        exit 1
+    end
+end
+
+# Define functions for IDF tools
+function idf.py
+    {{python_bin_path}} {{idf_path_escaped}}/tools/idf.py $argv
+end
+
+function esptool.py
+    {{python_bin_path}} {{idf_path_escaped}}/components/esptool_py/esptool/esptool.py $argv
+end
+
+function espefuse.py
+    {{python_bin_path}} {{idf_path_escaped}}/components/esptool_py/esptool/espefuse.py $argv
+end
+
+function espsecure.py
+    {{python_bin_path}} {{idf_path_escaped}}/components/esptool_py/esptool/espsecure.py $argv
+end
+
+function otatool.py
+    {{python_bin_path}} {{idf_path_escaped}}/components/app_update/otatool.py $argv
+end
+
+function parttool.py
+    {{python_bin_path}} {{idf_path_escaped}}/components/partition_table/parttool.py $argv
+end
+
+# Main execution
+add_env_variable
+add_to_path
+
+# Activate virtual environment (use IDF_PYTHON_ENV_PATH if set, otherwise default)
+set -l venv_default "{{idf_python_env_path_escaped}}"
+if set -q IDF_PYTHON_ENV_PATH; and test -n "$IDF_PYTHON_ENV_PATH"
+    activate_venv "$IDF_PYTHON_ENV_PATH"
+else
+    activate_venv "$venv_default"
+end
+
+printf '%s\n' "Environment setup complete for the current shell session."
+printf '%s\n' "These changes will be lost when you close this terminal."
+printf '%s\n' "You are now using IDF version $IDF_VERSION."
+
+# Sync selection with eim_idf.json for IDEs (silent on failure)
+if test -n "$_EIM_BIN"; and test -x "$_EIM_BIN"
+    $_EIM_BIN select "{{idf_version}}" >/dev/null 2>&1; and printf '%s\n' "eim select {{idf_version}}"
+end

--- a/src-tauri/powershell_scripts/idf_tools_profile_template.bat
+++ b/src-tauri/powershell_scripts/idf_tools_profile_template.bat
@@ -1,0 +1,76 @@
+@echo off
+
+REM Capture eim path early (before PATH changes)
+set _EimBinPath=
+for /f "delims=" %%i in ('where eim 2^>nul') do set "_EimBinPath=%%i" & goto :eim_found
+:eim_found
+
+{{env_var_pairs}}
+
+REM Parse IDF version from CMake
+set IdfVersion=
+for /f "usebackq tokens=1,2 delims==#" %%a in ("{{idf_path}}\tools\cmake\version.cmake") do (
+    if "%%a"=="set(IDF_VERSION_MAJOR" call set "IdfVersionMajor=%%b"
+    if "%%a"=="set(IDF_VERSION_MINOR" call set "IdfVersionMinor=%%b"
+)
+if defined IdfVersionMajor if defined IdfVersionMinor set IdfVersion=%IdfVersionMajor%.%IdfVersionMinor%
+
+REM If -e parameter is provided, print variables and exit
+if "%~1"=="-e" goto print_env
+
+REM Set environment variables
+set ESP_IDF_VERSION=%IdfVersion%
+
+REM Set system PATH - add all IDF toolchain directories
+set PATH={{add_paths_extras}};{{idf_path}}\tools;%PATH%
+
+REM Activate Python environment (call the activate script)
+if exist "{{idf_python_env_path}}\Scripts\activate.bat" call "{{idf_python_env_path}}\Scripts\activate.bat"
+
+REM Re-prepend IDF tools after venv activation (venv modifies PATH)
+set PATH={{add_paths_extras}};{{idf_path}}\tools;%PATH%
+
+REM Create command aliases (CMD equivalent of PowerShell functions)
+doskey idf.py={{python_bin_path}} {{idf_path}}\tools\idf.py $*
+doskey esptool.py={{python_bin_path}} {{idf_path}}\components\esptool_py\esptool\esptool.py $*
+doskey espefuse.py={{python_bin_path}} {{idf_path}}\components\esptool_py\esptool\espefuse.py $*
+doskey espsecure.py={{python_bin_path}} {{idf_path}}\components\esptool_py\esptool\espsecure.py $*
+doskey otatool.py={{python_bin_path}} {{idf_path}}\components\app_update\otatool.py $*
+doskey parttool.py={{python_bin_path}} {{idf_path}}\components\partition_table\parttool.py $*
+
+REM Display setup information
+echo IDF Command Prompt Environment
+echo ---------------------------------
+echo Environment variables set:
+echo IDF_PATH: %IDF_PATH%
+echo IDF_TOOLS_PATH: %IDF_TOOLS_PATH%
+echo IDF_PYTHON_ENV_PATH: %IDF_PYTHON_ENV_PATH%
+echo.
+echo Custom commands available:
+echo idf.py - Use this to run IDF commands (e.g., idf.py build)
+echo esptool.py
+echo espefuse.py
+echo espsecure.py
+echo otatool.py
+echo parttool.py
+echo.
+echo Python environment activated.
+echo You can now use IDF commands and Python tools.
+
+REM Sync selection with eim_idf.json for IDEs (silent on failure)
+if defined _EimBinPath (
+    call %_EimBinPath% select "{{idf_version}}" 2>nul
+)
+
+goto :end
+
+:print_env
+echo PATH={{add_paths_extras}};{{idf_path}}\tools;%PATH%
+echo ESP_IDF_VERSION=%IdfVersion%
+echo SYSTEM_PATH={{current_system_path}}
+{{env_var_pairs_print}}
+goto :end
+
+:end
+REM Note: We intentionally don't use endlocal to allow environment changes to persist
+REM in the parent CMD session when the batch file is called with 'call'

--- a/src-tauri/src/cli/cli_args.rs
+++ b/src-tauri/src/cli/cli_args.rs
@@ -294,6 +294,12 @@ pub struct InstallArgs {
         value_parser = is_valid_python_version
     )]
     pub python_version_override: Option<String>, // Optional override for Python version to install when installing prerequisites
+
+    #[arg(
+        long,
+        help = "Whether to create a .bat activation script on Windows. This is useful for users who want to activate the ESP-IDF environment using a batch file instead of PowerShell. Default is false. This is for legacy compatibility reasons as the default activation method on Windows is now PowerShell script.",
+    )]
+    pub create_bat_activation_script: Option<bool>, // Whether to create a .bat activation script on Windows
 }
 
 impl IntoIterator for InstallArgs {
@@ -400,6 +406,10 @@ impl IntoIterator for InstallArgs {
             (
                 "python_version_override".to_string(),
                 self.python_version_override.map(Into::into),
+            ),
+            (
+                "create_bat_activation_script".to_string(),
+                self.create_bat_activation_script.map(Into::into),
             ),
         ]
         .into_iter()

--- a/src-tauri/src/cli/wizard.rs
+++ b/src-tauri/src/cli/wizard.rs
@@ -831,7 +831,8 @@ pub async fn run_wizzard_run(mut config: Settings) -> Result<(), String> {
             export_paths,
             paths.python_venv_path.to_str(),
             None, // env_vars
-            &paths.python_path.to_string_lossy().to_string()
+            &paths.python_path.to_string_lossy(),
+            config.create_bat_activation_script.unwrap_or(false),
         )
     }
     save_config_if_desired(&config)?;

--- a/src-tauri/src/gui/commands/installation.rs
+++ b/src-tauri/src/gui/commands/installation.rs
@@ -227,6 +227,7 @@ pub async fn install_single_version(
       paths.python_venv_path.to_str(),
       None, // env_vars
       &paths.python_path.to_string_lossy().to_string(),
+      false, // create_cmd_bat
   );
 
   Ok(())
@@ -1815,7 +1816,8 @@ pub async fn start_offline_installation(app_handle: AppHandle, archives: Vec<Str
                 export_vars,
                 paths.python_venv_path.to_str(),
                 None,
-                &paths.python_path.to_string_lossy().to_string()
+                &paths.python_path.to_string_lossy(),
+                false, // create_cmd_bat
             );
 
             emit_log_message(&app_handle, MessageLevel::Success,

--- a/src-tauri/src/lib/mod.rs
+++ b/src-tauri/src/lib/mod.rs
@@ -12,10 +12,20 @@ use sha2::{Digest, Sha256};
 use system_dependencies::copy_openocd_rules;
 use tempfile::TempDir;
 use tar::Archive;
-use tera::{Context, Tera};
 use thiserror::Error;
 use utils::{find_directories_by_name};
 use zip::ZipArchive;
+
+/// Simple template renderer - replaces {{variable}} placeholders with values
+/// This is a lightweight replacement for tera, using only std library
+pub fn render_template(template: &str, variables: &[(&str, String)]) -> String {
+    let mut result = template.to_string();
+    for (key, value) in variables {
+        let placeholder = format!("{{{{{}}}}}", key);
+        result = result.replace(&placeholder, value);
+    }
+    result
+}
 
 pub mod command_executor;
 pub mod git_tools;
@@ -95,6 +105,16 @@ EOF
 }}", formatted_pairs.join("\n"))
 }
 
+/// Formats a vector of key-value pairs into a fish shell-compatible format for environment variables.
+fn format_fish_env_pairs(pairs: &[(String, String)]) -> String {
+    // Fish uses semicolon-separated list for easy parsing
+    pairs
+        .iter()
+        .map(|(key, value)| format!("{}:{}", key, value))
+        .collect::<Vec<_>>()
+        .join(";")
+}
+
 /// Formats a vector of key-value pairs into a PowerShell-compatible format for environment variables.
 ///
 /// # Parameters
@@ -114,6 +134,92 @@ fn format_powershell_env_pairs(pairs: &[(String, String)]) -> String {
     format!("$env_var_pairs = @{{\n{}\n}}", formatted_pairs.join("\n"))
 }
 
+/// Formats a vector of key-value pairs into a batch file-compatible format for environment variables.
+/// Common parameters for profile script creation
+struct ProfileParams<'a> {
+    pub idf_path: &'a str,
+    pub idf_tools_path: &'a str,
+    pub idf_python_env_path: Option<&'a str>,
+    pub idf_version: &'a str,
+    pub export_paths: Vec<String>,
+    pub env_var_pairs: Vec<(String, String)>,
+    pub python_bin_path: &'a str,
+}
+
+/// Builds the template variables for batch profile
+fn build_batch_variables(params: &ProfileParams) -> Vec<(&'static str, String)> {
+    vec![
+        ("idf_path", replace_unescaped_spaces_win(params.idf_path)),
+        ("idf_version", params.idf_version.to_string()),
+        ("env_var_pairs", format_batch_env_pairs(&params.env_var_pairs)),
+        ("env_var_pairs_print", format_batch_env_pairs_print(&params.env_var_pairs)),
+        ("idf_tools_path", replace_unescaped_spaces_win(params.idf_tools_path)),
+        ("idf_python_env_path", replace_unescaped_spaces_win(
+            params.idf_python_env_path.unwrap_or(&format!("{}\\python", params.idf_tools_path))
+        )),
+        ("add_paths_extras", params.export_paths.join(";")),
+        ("current_system_path", env::var("PATH").unwrap_or_default()),
+        ("python_bin_path", replace_unescaped_spaces_win(params.python_bin_path)),
+    ]
+}
+
+/// Builds the template variables for PowerShell profile
+fn build_powershell_variables(params: &ProfileParams) -> Vec<(&'static str, String)> {
+    vec![
+        ("idf_path", replace_unescaped_spaces_win(params.idf_path)),
+        ("idf_version", params.idf_version.to_string()),
+        ("env_var_pairs", format_powershell_env_pairs(&params.env_var_pairs)),
+        ("idf_tools_path", replace_unescaped_spaces_win(params.idf_tools_path)),
+        ("idf_python_env_path", replace_unescaped_spaces_win(
+            params.idf_python_env_path.unwrap_or(&format!("{}\\python", params.idf_tools_path))
+        )),
+        ("add_paths_extras", params.export_paths.join(";")),
+        ("current_system_path", env::var("PATH").unwrap_or_default()),
+        ("python_bin_path", replace_unescaped_spaces_win(params.python_bin_path)),
+    ]
+}
+
+/// Renders a profile template and writes it to a file
+fn render_and_write_profile(
+    profile_path: &str,
+    _template_name: &str,
+    template_content: &str,
+    variables: Vec<(&str, String)>,
+    filename: &str,
+) -> Result<String, std::io::Error> {
+    ensure_path(profile_path).expect("Unable to create directory");
+
+    let mut rendered = render_template(template_content, &variables);
+
+    if std::env::consts::OS == "windows" {
+        rendered = rendered.replace("\r\n", "\n").replace("\n", "\r\n");
+    }
+
+    let mut filepath = PathBuf::from(profile_path);
+    filepath.push(filename);
+    fs::write(&filepath, rendered).expect("Unable to write file");
+    Ok(filepath.display().to_string())
+}
+
+fn format_batch_env_pairs(pairs: &[(String, String)]) -> String {
+    let formatted_pairs: Vec<String> = pairs
+        .iter()
+        .map(|(key, value)| format!("set {}={}", key, value))
+        .collect();
+
+    formatted_pairs.join("\n")
+}
+
+/// Formats env var pairs for printing in batch file -e mode
+fn format_batch_env_pairs_print(pairs: &[(String, String)]) -> String {
+    let formatted_pairs: Vec<String> = pairs
+        .iter()
+        .map(|(key, value)| format!("echo {}={}", key, value))
+        .collect();
+
+    formatted_pairs.join("\n")
+}
+
 /// Creates an activation shell script for the ESP-IDF toolchain.
 ///
 /// # Parameters
@@ -127,6 +233,46 @@ fn format_powershell_env_pairs(pairs: &[(String, String)]) -> String {
 /// # Return
 ///
 /// * `Result<(), String>`: On success, returns `Ok(())`. On error, returns `Err(String)` containing the error message.
+/// Common parameters for Unix shell activation scripts
+struct UnixShellParams<'a> {
+    pub idf_path: &'a str,
+    pub idf_tools_path: &'a str,
+    pub idf_python_env_path: Option<&'a str>,
+    pub idf_version: &'a str,
+    pub export_paths: Vec<String>,
+    pub env_var_pairs: Vec<(String, String)>,
+    pub python_bin_path: &'a str,
+}
+
+/// Builds template variables for Unix shell scripts (bash/fish)
+fn build_unix_shell_variables(params: &UnixShellParams) -> Vec<(&'static str, String)> {
+    let env_var_pairs_str = format_bash_env_pairs(&params.env_var_pairs);
+    let fish_env_var_pairs_str = format_fish_env_pairs(&params.env_var_pairs);
+    let idf_python_env_path_val = match params.idf_python_env_path {
+        Some(path) => path.to_string(),
+        None => format!("{}/python", params.idf_tools_path),
+    };
+
+    let addition_to_path = params.export_paths.join(":");
+    let current_system_path = env::var("PATH").unwrap_or_default();
+
+    vec![
+        ("env_var_pairs", env_var_pairs_str),
+        ("fish_env_var_pairs", fish_env_var_pairs_str),
+        ("idf_path", params.idf_path.to_string()),
+        ("idf_path_escaped", replace_unescaped_spaces_posix(params.idf_path)),
+        ("idf_tools_path", params.idf_tools_path.to_string()),
+        ("idf_tools_path_escaped", replace_unescaped_spaces_posix(params.idf_tools_path)),
+        ("idf_version", params.idf_version.to_string()),
+        ("addition_to_path", addition_to_path),
+        ("current_system_path", current_system_path),
+        ("python_bin_path", params.python_bin_path.to_string()),
+        ("idf_python_env_path", idf_python_env_path_val.clone()),
+        ("idf_python_env_path_escaped", replace_unescaped_spaces_posix(&idf_python_env_path_val)),
+    ]
+}
+
+/// Creates a bash shell activation script for the ESP-IDF toolchain.
 pub fn create_activation_shell_script(
     file_path: &str,
     idf_path: &str,
@@ -141,50 +287,50 @@ pub fn create_activation_shell_script(
     let mut filename = PathBuf::from(file_path);
     filename.push(format!("activate_idf_{}.sh", idf_version));
     let template = include_str!("../../bash_scripts/activate_idf_template.sh");
-    let mut tera = Tera::default();
-    if let Err(e) = tera.add_raw_template("activate_idf_template", template) {
-        error!("Failed to add template: {}", e);
-        return Err(e.to_string());
-    }
-    let mut context = Context::new();
-    let env_var_pairs_str = format_bash_env_pairs(&env_var_pairs);
-    context.insert("env_var_pairs", &env_var_pairs_str);
-    context.insert("idf_path", &idf_path);
-    context.insert(
-        "idf_path_escaped",
-        &replace_unescaped_spaces_posix(idf_path),
-    );
 
-    context.insert("idf_tools_path", &idf_tools_path);
-    context.insert(
-        "idf_tools_path_escaped",
-        &replace_unescaped_spaces_posix(idf_tools_path),
-    );
-    context.insert("idf_version", &idf_version);
-    context.insert("addition_to_path", &export_paths.join(":"));
-    context.insert("current_system_path", &env::var("PATH").unwrap_or_default());
-    context.insert("python_bin_path", &python_bin_path);
-
-    if let Some(idf_python_env_path) = idf_python_env_path {
-        context.insert("idf_python_env_path", &idf_python_env_path);
-        context.insert(
-            "idf_python_env_path_escaped",
-            &replace_unescaped_spaces_posix(idf_python_env_path),
-        );
-    } else {
-        context.insert("idf_python_env_path", &format!("{}/python", idf_tools_path));
-        context.insert(
-            "idf_python_env_path_escaped",
-            &replace_unescaped_spaces_posix(&format!("{}/python", idf_tools_path)),
-        );
-    }
-    let rendered = match tera.render("activate_idf_template", &context) {
-        Err(e) => {
-            error!("Failed to render template: {}", e);
-            return Err(e.to_string());
-        }
-        Ok(text) => text,
+    let params = UnixShellParams {
+        idf_path,
+        idf_tools_path,
+        idf_python_env_path,
+        idf_version,
+        export_paths,
+        env_var_pairs,
+        python_bin_path,
     };
+    let variables = build_unix_shell_variables(&params);
+    let rendered = render_template(template, &variables);
+
+    create_executable_shell_script(filename.to_str().unwrap(), &rendered)?;
+    Ok(())
+}
+
+/// Creates a fish shell activation script for the ESP-IDF toolchain.
+pub fn create_fish_script(
+    file_path: &str,
+    idf_path: &str,
+    idf_tools_path: &str,
+    idf_python_env_path: Option<&str>,
+    idf_version: &str,
+    export_paths: Vec<String>,
+    env_var_pairs: Vec<(String, String)>,
+    python_bin_path: &str,
+) -> Result<(), String> {
+    ensure_path(file_path).map_err(|e| e.to_string())?;
+    let mut filename = PathBuf::from(file_path);
+    filename.push(format!("activate_idf_{}.fish", idf_version));
+    let template = include_str!("../../bash_scripts/activate_idf_template.fish");
+
+    let params = UnixShellParams {
+        idf_path,
+        idf_tools_path,
+        idf_python_env_path,
+        idf_version,
+        export_paths,
+        env_var_pairs,
+        python_bin_path,
+    };
+    let variables = build_unix_shell_variables(&params);
+    let rendered = render_template(template, &variables);
 
     create_executable_shell_script(filename.to_str().unwrap(), &rendered)?;
     Ok(())
@@ -618,61 +764,65 @@ fn create_powershell_profile(
     python_bin_path: &str,
 ) -> Result<String, std::io::Error> {
     let profile_template = include_str!("../../powershell_scripts/idf_tools_profile_template.ps1");
-
-    let mut tera = Tera::default();
-    if let Err(e) = tera.add_raw_template("powershell_profile", profile_template) {
-        error!("Failed to add template: {}", e);
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            "Failed to add template",
-        ));
-    }
-    ensure_path(profile_path).expect("Unable to create directory");
-    let mut context = Context::new();
-    println!("idf_path: {}", replace_unescaped_spaces_win(idf_path));
-    context.insert("idf_path", &replace_unescaped_spaces_win(idf_path));
-    context.insert("idf_version", &idf_version);
-    context.insert(
-        "env_var_pairs",
-        &format_powershell_env_pairs(&env_var_pairs),
-    );
-
-    context.insert(
-        "idf_tools_path",
-        &replace_unescaped_spaces_win(idf_tools_path),
-    );
-    if let Some(idf_python_env_path) = idf_python_env_path {
-        context.insert(
-            "idf_python_env_path",
-            &replace_unescaped_spaces_win(idf_python_env_path),
-        );
-    } else {
-        context.insert(
-            "idf_python_env_path",
-            &replace_unescaped_spaces_win(&format!("{}\\python", idf_tools_path)),
-        );
-    }
-    context.insert("add_paths_extras", &export_paths.join(";"));
-    context.insert("current_system_path", &env::var("PATH").unwrap_or_default());
-    context.insert("python_bin_path", &replace_unescaped_spaces_win(python_bin_path));
-    let mut rendered = match tera.render("powershell_profile", &context) {
-        Err(e) => {
-            error!("Failed to render template: {}", e);
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "Failed to render template",
-            ));
-        }
-        Ok(text) => text,
+    let params = ProfileParams {
+        idf_path,
+        idf_tools_path,
+        idf_python_env_path,
+        idf_version,
+        export_paths,
+        env_var_pairs,
+        python_bin_path,
     };
+    let variables = build_powershell_variables(&params);
+    render_and_write_profile(
+        profile_path,
+        "powershell_profile",
+        profile_template,
+        variables,
+        &format!("Microsoft.{}.PowerShell_profile.ps1", idf_version),
+    )
+}
 
-    if std::env::consts::OS == "windows" {
-        rendered = rendered.replace("\r\n", "\n").replace("\n", "\r\n");
-    }
-    let mut filename = PathBuf::from(profile_path);
-    filename.push(format!("Microsoft.{}.PowerShell_profile.ps1", idf_version));
-    fs::write(&filename, rendered).expect("Unable to write file");
-    Ok(filename.display().to_string())
+/// Creates a batch file profile script for the ESP-IDF tools.
+///
+/// # Parameters
+///
+/// * `profile_path` - A string representing the path where the batch profile script should be created.
+/// * `idf_path` - A string representing the path to the ESP-IDF repository.
+/// * `idf_tools_path` - A string representing the path to the ESP-IDF tools directory.
+///
+/// # Returns
+///
+/// * `Result<String, std::io::Error>` - On success, returns the path to the created batch profile script.
+///   On error, returns an `std::io::Error` indicating the cause of the error.
+fn create_batch_profile(
+    profile_path: &str,
+    idf_path: &str,
+    idf_tools_path: &str,
+    idf_python_env_path: Option<&str>,
+    idf_version: &str,
+    export_paths: Vec<String>,
+    env_var_pairs: Vec<(String, String)>,
+    python_bin_path: &str,
+) -> Result<String, std::io::Error> {
+    let profile_template = include_str!("../../powershell_scripts/idf_tools_profile_template.bat");
+    let params = ProfileParams {
+        idf_path,
+        idf_tools_path,
+        idf_python_env_path,
+        idf_version,
+        export_paths,
+        env_var_pairs,
+        python_bin_path,
+    };
+    let variables = build_batch_variables(&params);
+    render_and_write_profile(
+        profile_path,
+        "batch_profile",
+        profile_template,
+        variables,
+        &format!("Microsoft.{}_profile.bat", idf_version),
+    )
 }
 
 /// Creates a desktop shortcut for the IDF tools using PowerShell on Windows.
@@ -722,28 +872,12 @@ pub fn create_desktop_shortcut(
             fs::write(&home, icon).expect("Unable to write file");
             let powershell_script_template =
                 include_str!("../../powershell_scripts/create_desktop_shortcut_template.ps1");
-            // Create a new Tera instance
-            let mut tera = Tera::default();
-            if let Err(e) = tera.add_raw_template("powershell_script", powershell_script_template) {
-                error!("Failed to add template: {}", e);
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::Other,
-                    "Failed to add template",
-                ));
-            }
-            let mut context = Context::new();
-            context.insert("custom_profile_filename", &filename);
-            context.insert("name", &idf_version);
-            let rendered = match tera.render("powershell_script", &context) {
-                Err(e) => {
-                    error!("Failed to render template: {}", e);
-                    return Err(std::io::Error::new(
-                        std::io::ErrorKind::Other,
-                        "Failed to render template",
-                    ));
-                }
-                Ok(text) => text,
-            };
+
+            let variables = vec![
+                ("custom_profile_filename", filename.clone()),
+                ("name", idf_version.to_string()),
+            ];
+            let rendered = render_template(powershell_script_template, &variables);
 
             let output = match run_powershell_script(&rendered) {
                 Ok(o) => o,
@@ -1639,6 +1773,7 @@ pub fn single_version_post_install(
     idf_python_env_path: Option<&str>,
     env_vars: Option<Vec<(String, String)>>,
     python_bin_path: &str,
+    create_cmd_bat: bool,
 ) {
     let mut env_vars = match env_vars {
         Some(vars) => vars,
@@ -1687,8 +1822,8 @@ pub fn single_version_post_install(
                 idf_version,
                 tool_install_directory,
                 idf_python_env_path,
-                export_paths,
-                env_vars,
+                export_paths.clone(),
+                env_vars.clone(),
                 python_bin_path,
             ) {
                 error!(
@@ -1699,9 +1834,51 @@ pub fn single_version_post_install(
             } else {
                 info!("Desktop shortcut created successfully")
             }
+
+            // Also create CMD batch file if requested
+            if create_cmd_bat {
+                if let Err(err) = create_batch_profile(
+                    activation_script_path,
+                    idf_path,
+                    tool_install_directory,
+                    idf_python_env_path,
+                    idf_version,
+                    export_paths,
+                    env_vars,
+                    python_bin_path,
+                ) {
+                    error!(
+                        "{} {:?}",
+                        "Failed to create CMD batch profile",
+                        err.to_string()
+                    )
+                } else {
+                    info!("CMD batch profile created successfully")
+                }
+            }
         }
         _ => {
+            // Create bash activation script
             match create_activation_shell_script(
+              activation_script_path,
+              idf_path,
+              tool_install_directory,
+              idf_python_env_path,
+              idf_version,
+              export_paths.clone(),
+              env_vars.clone(),
+              python_bin_path,
+            ) {
+              Ok(_) => info!("Bash activation script created successfully"),
+              Err(err) => error!(
+                  "{} {:?}",
+                  "Failed to create activation shell script",
+                  err.to_string()
+              ),
+            };
+
+            // Create fish shell activation script (always)
+            match create_fish_script(
               activation_script_path,
               idf_path,
               tool_install_directory,
@@ -1711,13 +1888,14 @@ pub fn single_version_post_install(
               env_vars,
               python_bin_path,
             ) {
-              Ok(_) => info!("Activation shell script created successfully"),
+              Ok(_) => info!("Fish shell activation script created successfully"),
               Err(err) => error!(
                   "{} {:?}",
-                  "Failed to create activation shell script",
+                  "Failed to create fish shell script",
                   err.to_string()
               ),
             };
+
             // copy openocd rules (it's noop on macOs)
             match copy_openocd_rules(tool_install_directory) {
                 Ok(_) => info!("OpenOCD rules copied successfully"),

--- a/src-tauri/src/lib/offline_installer.rs
+++ b/src-tauri/src/lib/offline_installer.rs
@@ -2,9 +2,8 @@ use std::{fs, io::{self, Read, Write}, path::{Path, PathBuf}};
 
 use log::{debug, error, info, warn};
 use tempfile::TempDir;
-use tera::{Context, Tera};
 
-use crate::{add_path_to_path, command_executor::{self, execute_command}, settings::Settings, system_dependencies::{add_to_path, get_correct_powershell_command, get_scoop_path}, utils::{copy_dir_contents_preserving_mtime, extract_zst_archive}};
+use crate::{add_path_to_path, command_executor::{self, execute_command}, render_template, settings::Settings, system_dependencies::{add_to_path, get_correct_powershell_command, get_scoop_path}, utils::{copy_dir_contents,copy_dir_contents_preserving_mtime, extract_zst_archive}};
 
 /// Structure to define package information with compile-time template content.
 ///
@@ -22,60 +21,40 @@ pub struct ScoopPackage {
     pub test_command: &'static str,
 }
 
-/// Creates and writes a Scoop manifest file for a given package.
+/// Creates a Scoop package manifest file with templated content.
 ///
-/// This function takes a package definition, renders its template with the provided context,
-/// normalizes line endings for Windows compatibility, and writes the resulting manifest
-/// to the specified Scoop directory.
+/// This function renders a package manifest template by substituting variables,
+/// normalizes line endings to Windows format (CRLF), and writes the result to disk.
 ///
 /// # Arguments
 ///
-/// * `package` - The package definition containing template content and metadata
-/// * `context` - Tera template context with variables for rendering
-/// * `scoop_path` - Path to the Scoop directory where the manifest will be written
-/// * `tera` - Mutable reference to the Tera template engine
+/// * `package` - The Scoop package metadata containing the template content and desired filename
+/// * `variables` - A vector of (name, value) pairs to substitute in the template
+/// * `scoop_path` - The directory path where the manifest file will be written
 ///
 /// # Returns
 ///
-/// * `Ok(PathBuf)` - Path to the created manifest file on success
-/// * `Err(String)` - Error message if template rendering or file writing fails
+/// * `Ok(PathBuf)` - The full path to the created manifest file
+/// * `Err(String)` - An error message if template rendering or file writing fails
 ///
-/// # Examples
+/// # Errors
 ///
-/// ```rust
-/// let package = ScoopPackage { /* ... */ };
-/// let mut context = Context::new();
-/// let mut tera = Tera::default();
-/// let manifest_path = create_manifest(&package, &context, &scoop_path, &mut tera)?;
-/// ```
+/// Returns an error if:
+/// - The manifest file cannot be written to the filesystem
 fn create_manifest(
     package: &ScoopPackage,
-    context: &Context,
+    variables: Vec<(&str, String)>,
     scoop_path: &Path,
-    tera: &mut Tera,
 ) -> Result<PathBuf, String> {
-    // Add template to Tera
-    let template_name = format!("{}_manifest", package.name);
-    if let Err(e) = tera.add_raw_template(&template_name, package.template_content) {
-        error!("Failed to add {} template: {}", package.name, e);
-        return Err(format!("Failed to add {} template", package.name));
-    }
-
-    // Render the template
-    let mut rendered_manifest = match tera.render(&template_name, context) {
-        Err(e) => {
-            error!("Failed to render {} template: {}", package.name, e);
-            return Err(format!("Failed to render {} template", package.name));
-        }
-        Ok(text) => text,
-    };
+    // Render the template using simple template renderer
+    let rendered_manifest = render_template(package.template_content, &variables);
 
     // Normalize line endings
-    rendered_manifest = rendered_manifest.replace("\r\n", "\n").replace("\n", "\r\n");
+    let rendered_manifest = rendered_manifest.replace("\r\n", "\n").replace("\n", "\r\n");
 
     // Write manifest to file
     let manifest_path = scoop_path.join(package.manifest_filename);
-    if let Err(e) = fs::write(&manifest_path, rendered_manifest) {
+    if let Err(e) = fs::write(&manifest_path, &rendered_manifest) {
         error!("Failed to write {} manifest: {}", package.name, e);
         return Err(format!("Failed to write {} manifest", package.name));
     }
@@ -311,9 +290,11 @@ fn test_package_installation(test_command: &str, main_command: &str, path_with_s
 /// setup_scoop_packages(&scoop_path, &scoop_command)?;
 /// ```
 fn setup_scoop_packages(scoop_path: &Path, scoop_command: &Path) -> Result<(), String> {
-    // Create Tera context
-    let mut context = Context::new();
-    context.insert("offline_archive_scoop_dir", &scoop_path.to_str().unwrap().replace("\\", "/"));
+    // Create template variables
+    let offline_dir = scoop_path.to_str().unwrap().replace("\\", "/");
+    let variables = vec![
+        ("offline_archive_scoop_dir", offline_dir),
+    ];
 
     // Define packages to install with compile-time template content
     let packages = [
@@ -344,11 +325,10 @@ fn setup_scoop_packages(scoop_path: &Path, scoop_command: &Path) -> Result<(), S
     ];
 
     // Create all manifests
-    let mut tera = Tera::default();
     let mut manifest_paths = Vec::new();
 
     for package in &packages {
-        let manifest_path = create_manifest(package, &context, scoop_path, &mut tera)?;
+        let manifest_path = create_manifest(package, variables.clone(), scoop_path)?;
         manifest_paths.push((manifest_path, package.name));
     }
 

--- a/src-tauri/src/lib/settings.rs
+++ b/src-tauri/src/lib/settings.rs
@@ -54,6 +54,7 @@ pub struct Settings {
     pub use_local_archive: Option<PathBuf>, // Path to a local archive for offline installation
     pub activation_script_path_override: Option<String>, // Optional override for activation script path
     pub python_version_override: Option<String>, // Optional override for Python version to install when installing prerequisites
+    pub create_bat_activation_script: Option<bool>, // Whether to create a .bat activation script on Windows
 }
 
 #[derive(Debug, Clone)]
@@ -131,6 +132,7 @@ impl Default for Settings {
             use_local_archive: None,
             activation_script_path_override: Some(default_activation_script_path_override),
             python_version_override: Some(PYTHON_NAME_TO_INSTALL.to_string()),
+            create_bat_activation_script: Some(false),
         }
     }
 }
@@ -217,7 +219,8 @@ impl Settings {
             python_env_folder_name,
             use_local_archive,
             activation_script_path_override,
-            python_version_override
+            python_version_override,
+            create_bat_activation_script
           );
         }
 
@@ -301,7 +304,8 @@ impl Settings {
             python_env_folder_name,
             use_local_archive,
             activation_script_path_override,
-            python_version_override
+            python_version_override,
+            create_bat_activation_script
         );
     }
 

--- a/src-tauri/src/lib/utils.rs
+++ b/src-tauri/src/lib/utils.rs
@@ -619,6 +619,7 @@ pub fn parse_tool_set_config(config_path: &str) -> Result<()> {
             idf_python_env_path.as_deref(),
             Some(env_vars_vec),
             &paths.python_path.to_string_lossy().to_string(),
+            false, // create_cmd_bat
         );
 
         let installation = IdfInstallation {

--- a/src-tauri/src/lib/version_manager.rs
+++ b/src-tauri/src/lib/version_manager.rs
@@ -21,6 +21,36 @@ use crate::{
     settings::Settings,
 };
 
+/// Removes activation scripts (sh, fish, ps1, bat) for a given version from the activation script directory
+fn remove_activation_scripts(activation_script_path: &str, idf_version: &str) -> Result<(), String> {
+    let path = PathBuf::from(activation_script_path);
+    let parent_dir = path.parent().ok_or("No parent directory")?;
+
+    // Define all possible activation script names for this version
+    let scripts_to_remove = match std::env::consts::OS {
+        "windows" => vec![
+            format!("Microsoft.{}.PowerShell_profile.ps1", idf_version),
+            format!("Microsoft.{}_profile.bat", idf_version),
+        ],
+        _ => vec![
+            format!("activate_idf_{}.sh", idf_version),
+            format!("activate_idf_{}.fish", idf_version),
+        ],
+    };
+
+    for script_name in scripts_to_remove {
+        let script_path = parent_dir.join(&script_name);
+        if script_path.exists() {
+            match fs::remove_file(&script_path) {
+                Ok(_) => info!("Removed activation script: {}", script_path.display()),
+                Err(e) => warn!("Failed to remove {}: {}", script_path.display(), e),
+            }
+        }
+    }
+
+    Ok(())
+}
+
 /// Returns the default path to the ESP-IDF configuration file.
 ///
 /// The default path is constructed by joining the `esp_idf_json_path` setting from the `Settings` struct
@@ -280,6 +310,12 @@ pub fn remove_single_idf_version(identifier: &str, keep_idf_folder: bool) -> Res
                 return Err(anyhow!("Failed to remove activation script: {}", e));
             }
         }
+
+        // Also remove fish/bat activation scripts
+        if let Err(e) = remove_activation_scripts(&installation.clone().activation_script, &installation.name) {
+            warn!("Failed to remove additional activation scripts: {}", e);
+        }
+
         if ide_config.remove_installation(identifier) {
             debug!("Removed installation from config file");
         } else {


### PR DESCRIPTION
For the purpose of backwards compatibility with the existing esp-idf solution, we need also the activation bat and fish scripts.
bat tested and working
fish tested and working