### PR TITLE
EIM-34: Add retry logic to files download

### DIFF
--- a/src-tauri/locales/app.yml
+++ b/src-tauri/locales/app.yml
@@ -242,6 +242,9 @@ wizard.idf_path_exists.prompt:
 wizard.tools_download.progress:
   en: Downloading tools to
   cn: 下载工具至
+wizard.tools_download.downloading:
+  en: Downloading
+  cn: 正在下载
 wizard.tool_download.progress:
   en: Downloading tool
   cn: 下载工具
@@ -599,6 +602,9 @@ gui.setup_tools.preparing_tools:
 gui.setup_tools.downloading:
   en: "Downloading: %{tool_name}"
   cn: "正在下载：%{tool_name}"
+gui.setup_tools.tool_progress_indeterminate:
+  en: "Downloading %{bytes} of unknown size..."
+  cn: "正在下载 %{bytes}，总大小未知..."
 gui.setup_tools.tool_progress:
   en: "Tool %{current}/%{total} - %{percentage}%"
   cn: "工具 %{current}/%{total} - %{percentage}%"

--- a/src-tauri/src/cli/wizard.rs
+++ b/src-tauri/src/cli/wizard.rs
@@ -279,6 +279,10 @@ async fn download_and_extract_tools(
             progress_bar.set_length(total);
             progress_bar.set_position(current);
         }
+        DownloadProgress::Indeterminate(current) => {
+            progress_bar.set_length(current * 2); // Set a length to allow the bar to move
+            progress_bar.set_position(current);
+        }
         DownloadProgress::Complete => {
             progress_bar.finish();
         }

--- a/src-tauri/src/gui/commands/idf_tools.rs
+++ b/src-tauri/src/gui/commands/idf_tools.rs
@@ -257,6 +257,27 @@ pub async fn setup_tools(
                 }
             }
 
+            DownloadProgress::Indeterminate(current) => {
+                let completed = *completed_tools_clone.lock().unwrap();
+                let tool_name = current_tool_name_clone.lock().unwrap().clone();
+
+                let overall_tool_progress = (completed as f32 / total_tools) * tools_range as f32;
+
+                emit_installation_event(&app_handle_clone, InstallationProgress {
+                    stage: InstallationStage::Tools,
+                    percentage: overall_tool_progress as u32,
+                    message: t!("gui.setup_tools.downloading",
+                        tool_name = tool_name.split('/').last()
+                            .unwrap_or(&tool_name)
+                            .replace("-", " ")
+                    ).to_string(),
+                    detail: Some(t!("gui.setup_tools.tool_progress_indeterminate",
+                        bytes = current,
+                    ).to_string()),
+                    version: Some(idf_version_clone.clone()),
+                });
+            }
+
             DownloadProgress::Start(url) => {
                 // Extract tool name from URL
                 let tool_name = if let Some(filename) = Path::new(&url).file_name().and_then(|f| f.to_str()) {

--- a/src-tauri/src/lib/mod.rs
+++ b/src-tauri/src/lib/mod.rs
@@ -1,4 +1,5 @@
 use flate2::read::GzDecoder;
+use std::ffi::OsStr;
 use std::hash::{DefaultHasher, Hash,Hasher};
 use anyhow::{anyhow, Result};
 use idf_env::driver;
@@ -983,6 +984,7 @@ pub enum DownloadProgress {
     Downloaded(String),
     Verified(String),
     Extracted(String, String), // (url, destination_path)
+    Indeterminate(u64), // downloaded
     Complete,
     Error(String),
 }
@@ -996,6 +998,7 @@ pub async fn download_file(
         destination_path,
         progress_sender,
         None, // No new name provided
+        3,
     ).await
 }
 
@@ -1004,9 +1007,77 @@ pub async fn download_file_and_rename(
     destination_path: &str,
     progress_sender: Option<Sender<DownloadProgress>>,
     new_name: Option<&str>,
+    max_retries: u32,
 ) -> Result<(), std::io::Error> {
-    let client:reqwest::Client = reqwest::Client::new();
+    let client: reqwest::Client = reqwest::Client::new();
+    let retries = max_retries.max(1); // At least one attempt
 
+    let filename = if let Some(new_name) = new_name {
+        new_name.to_string()
+    } else {
+        Path::new(&url)
+            .file_name()
+            .and_then(OsStr::to_str)
+            .unwrap_or("file")
+            .to_string()
+    };
+
+    let file_path = Path::new(destination_path).join(&filename);
+
+    for attempt in 1..=retries {
+        if attempt > 1 {
+            let delay = std::time::Duration::from_secs(2u64.pow(attempt - 1)); // 2s, 4s, 8s, 16s...
+            log::info!(
+                "Retry {}/{} for {} in {:.1}s",
+                attempt,
+                retries,
+                url,
+                delay.as_secs_f64()
+            );
+            tokio::time::sleep(delay).await;
+        }
+
+        let result = attempt_download(
+            &client,
+            url,
+            &file_path,
+            &progress_sender,
+        )
+        .await;
+
+        match result {
+            Ok(()) => return Ok(()),
+            Err(e) => {
+                log::warn!(
+                    "Download attempt {}/{} failed for {}: {}",
+                    attempt,
+                    retries,
+                    url,
+                    e
+                );
+
+                if attempt == retries {
+                    if let Some(sender) = &progress_sender {
+                        let _ = sender.send(DownloadProgress::Error(format!(
+                            "All {} attempts failed for {}: {}",
+                            retries, url, e
+                        )));
+                    }
+                    return Err(e);
+                }
+            }
+        }
+    }
+
+    unreachable!()
+}
+
+async fn attempt_download(
+    client: &reqwest::Client,
+    url: &str,
+    file_path: &Path,
+    progress_sender: &Option<Sender<DownloadProgress>>,
+) -> Result<(), std::io::Error> {
     let mut response: reqwest::Response = client
         .get(url)
         .send()
@@ -1014,43 +1085,24 @@ pub async fn download_file_and_rename(
         .map_err(|e: reqwest::Error| std::io::Error::new(std::io::ErrorKind::Other, e))?;
 
     if !response.status().is_success() {
-        if let Some(sender) = &progress_sender {
-            let _ = sender.send(DownloadProgress::Error(format!(
-                "HTTP error: {}",
-                response.status()
-            )));
-        }
         return Err(std::io::Error::new(
             std::io::ErrorKind::Other,
             format!("HTTP error: {}", response.status()),
         ));
     }
 
-    let total_size = response.content_length().ok_or_else(|| {
-        if let Some(sender) = &progress_sender {
-            let _ = sender.send(DownloadProgress::Error(
-                "Failed to get content length".into(),
-            ));
-        }
-        std::io::Error::new(std::io::ErrorKind::Other, "Failed to get content length")
-    })?;
+    let total_size = response.content_length();
 
-    log::debug!("Downloading {} to {}", url, destination_path);
+    if total_size.is_none() {
+        log::debug!(
+            "No Content-Length header for {}; progress will be indeterminate",
+            url
+        );
+    }
 
-    let filename = if let Some(new_name) = new_name {
-        new_name.to_string()
-    } else {
-        Path::new(&url).file_name().unwrap().to_str().unwrap().to_string()
-    };
+    log::debug!("Downloading {} to {}", url, file_path.display());
 
-    log::debug!(
-        "Filename: {} and destination: {}",
-        &filename,
-        destination_path
-    );
-
-    let mut file = File::create(Path::new(&destination_path).join(Path::new(&filename)))?;
-    log::debug!("Created file at {}", destination_path);
+    let mut file = File::create(file_path)?;
 
     let mut downloaded: u64 = 0;
 
@@ -1059,12 +1111,16 @@ pub async fn download_file_and_rename(
         .await
         .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?
     {
-        let chunk: bytes::Bytes = chunk;
         downloaded += chunk.len() as u64;
         file.write_all(&chunk)?;
 
-        if let Some(sender) = &progress_sender {
-            if let Err(e) = sender.send(DownloadProgress::Progress(downloaded, total_size)) {
+        if let Some(sender) = progress_sender {
+            let progress = if let Some(total) = total_size {
+                DownloadProgress::Progress(downloaded, total)
+            } else {
+                DownloadProgress::Indeterminate(downloaded)
+            };
+            if let Err(e) = sender.send(progress) {
                 return Err(std::io::Error::new(
                     std::io::ErrorKind::Other,
                     format!("Failed to send progress: {}", e),
@@ -1073,9 +1129,9 @@ pub async fn download_file_and_rename(
         }
     }
 
-    if let Some(sender) = &progress_sender {
+    if let Some(sender) = progress_sender {
         if let Err(e) = sender.send(DownloadProgress::Complete) {
-            warn!("Failed to send completion: {}", e);
+            log::warn!("Failed to send completion: {}", e);
         }
     }
 

--- a/src-tauri/src/offline_installer_builder.rs
+++ b/src-tauri/src/offline_installer_builder.rs
@@ -763,7 +763,7 @@ async fn main() {
 
             for (link, name) in scoop_list {
                 info!("Downloading Scoop prereq: {} as {}", link, name);
-                match download_file_and_rename(link, scoop_path.to_str().unwrap(), None, Some(name)).await {
+                match download_file_and_rename(link, scoop_path.to_str().unwrap(), None, Some(name), 3).await {
                     Ok(_) => info!("Downloaded: {}", name),
                     Err(err) => {
                         error!("Failed to download {}: {}", name, err);


### PR DESCRIPTION
This PR is adding a retry to all file downloads (default 3) and also fixed the recent problem with offline installer in pipeline:
https://github.com/espressif/idf-im-ui/actions/runs/22715052972/job/66007751960
fixed pipeline:
https://github.com/espressif/idf-im-ui/actions/runs/22765249926
