### PR TITLE
atempt to fix serialisation of data sed to telemetry

### DIFF
--- a/src-tauri/src/cli/helpers.rs
+++ b/src-tauri/src/cli/helpers.rs
@@ -125,12 +125,13 @@ pub fn update_progress_bar_number(pb: &ProgressBar, value: u64) {
 const EIM_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub async fn track_cli_event(event_name: &str, additional_data: Option<serde_json::Value>) {
+  let data = additional_data.unwrap_or(serde_json::Value::Null);
   let system_info = idf_im_lib::telemetry::get_system_info();
     track_event("CLI event", serde_json::json!({
       "event_name": event_name,
       "system_info": system_info,
       "eim_version": EIM_VERSION,
-      "additional_data": additional_data
+      "additional_data": data.to_string(),
     })).await;
 }
 

--- a/src-tauri/src/gui/commands/utils_commands.rs
+++ b/src-tauri/src/gui/commands/utils_commands.rs
@@ -307,13 +307,14 @@ pub async fn track_event_command(app_handle: AppHandle,name: &str, additional_da
     return Ok(());
   }
   let system_info = get_system_info();
+  let data = additional_data.unwrap_or(serde_json::Value::Null);
   log::debug!("System info: {}", system_info);
   log::debug!("Track event called with name: {}", name);
   track_event("GUI event", serde_json::json!({
     "event_name": name,
     "system_info": system_info,
     "eim_version": EIM_VERSION,
-    "additional_data": additional_data
+    "additional_data": data.to_string(),
   })).await;
   Ok(())
 }


### PR DESCRIPTION
this PR should fix the bad serialisation of data in the telmetry on azure.
running binary from this build should lopg into the telemetry corectly serialized data

<img width="1224" height="529" alt="image" src="https://github.com/user-attachments/assets/a88753b4-d77b-4c88-90d9-fa8470072071" />
Seems to be working properly now.
