### PR TITLE
Improve window sizing for high-DPI and scaled displays (EIM-599)

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -14,7 +14,11 @@
       {
         "title": "ESP-IDF Installation Manager(EIM)",
         "width": 1200,
-        "height": 1000
+        "height": 875,
+        "minWidth": 600,
+        "minHeight": 175,
+        "resizable": true,
+        "center": true
       }
     ],
     "security": {

--- a/src/components/Welcome.vue
+++ b/src/components/Welcome.vue
@@ -382,7 +382,7 @@ export default {
 
 .welcome-card {
   background: white;
-  padding: 3rem 4rem;
+  padding: 3rem 4rem 0.25rem;
   border-radius: 12px;
   box-shadow: 0 10px 40px rgba(0, 0, 0, 0.1);
   width: 100%;


### PR DESCRIPTION
**Problem**
On monitors with certain resolutions or display scaling (e.g. 1440p @ 150%, which is very common on laptops), the default window height of 1000px causes the bottom UI elements (buttons and action cards) to be cut off or hidden behind the taskbar, making them inaccessible without manually resizing the window.
Additionally, the welcome card had excessive bottom padding (3rem) that created a large empty space below the "Learn more about usage tracking" link, pushing content layout further down unnecessarily.
**Changes**
_tauri.conf.json_
• Reduced default window height from 1000 to 875 to better fit common screen configurations with scaling enabled
• Added minWidth: 600 and minHeight: 175 to prevent the window from being resized to a state where UI becomes unusable
• Added center: true to ensure the window opens centered on screen, avoiding edge cases where it spawns partially off-screen
• Explicitly set resizable: true for clarity
_Welcome.vue_
• Reduced .welcome-card bottom padding from 3rem to 0.25rem to eliminate unnecessary blank space below the tracking documentation link
**Tested on**
• Windows 11, 2560x1440 @ 150% scaling, 2560x1600 @ 150% scaling
**The bottom element is completely obscured:**
<img width="2556" height="1439" alt="QQ_1773072642657" src="https://github.com/user-attachments/assets/e3bc2ed7-2b55-46e4-a1ae-103997ac58c4" />
**The window size can be adjusted to 0x0 px:**
<img width="122" height="32" alt="QQ_1773071523202" src="https://github.com/user-attachments/assets/62d446a8-949d-490b-9668-1964eb216b63" />
**Modified effect:**
<img width="2556" height="1436" alt="QQ_1773071472960" src="https://github.com/user-attachments/assets/b451e5f0-07cf-44f3-9350-62fc80a4ade6" />
<img width="602" height="207" alt="QQ_1773071500893" src="https://github.com/user-attachments/assets/c9b0805c-176d-4027-aa2c-65ce7c8b5fd9" />
