### PR TITLE
EIM-600: Offline archives symlinks and extraction respecting original archive file params

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1417,6 +1417,7 @@ dependencies = [
  "dialoguer",
  "dirs 6.0.0",
  "fern",
+ "filetime",
  "flate2",
  "fork",
  "fs_extra",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -113,6 +113,7 @@ anyhow = "^1.0"
 rust_search = "2.1.0"
 flate2 = { version = "1.0", default-features = false, features = ["rust_backend"] }
 tar = { version = "0.4", default-features = false }
+filetime = "0.2"
 zip = { version = "8.1", default-features = true }
 lzma-rs = "0.3.0"
 thiserror = "2.0"

--- a/src-tauri/src/lib/git_tools.rs
+++ b/src-tauri/src/lib/git_tools.rs
@@ -1157,7 +1157,7 @@ fn checkout_submodule_worktree(
     // Need this to prevent untracked files in the submodule workdir
     populate_index_from_tree(&repo, &tree)?;
 
-    
+
     Ok(())
 }
 
@@ -1772,6 +1772,11 @@ fn checkout_reference(repo: &gix::Repository, reference: &GitReference) -> Resul
 
             // Set HEAD
             set_head_to_ref(repo, &local_refname, &format!("checkout: moving to {}", branch))?;
+            // CHECK OUT THE FILES
+            checkout_commit_gix(repo, commit.id().into()).map_err(|e| {
+              error!("Error checking out files for branch {}: {}", branch, e);
+              anyhow::anyhow!("{}", e)
+          })?
         }
         GitReference::Tag(tag) => {
             info!("Checking out tag: {}", tag);

--- a/src-tauri/src/lib/offline_installer.rs
+++ b/src-tauri/src/lib/offline_installer.rs
@@ -4,7 +4,7 @@ use log::{debug, error, info, warn};
 use tempfile::TempDir;
 use tera::{Context, Tera};
 
-use crate::{add_path_to_path, command_executor::{self, execute_command}, settings::Settings, system_dependencies::{add_to_path, get_correct_powershell_command, get_scoop_path}, utils::{copy_dir_contents, extract_zst_archive}};
+use crate::{add_path_to_path, command_executor::{self, execute_command}, settings::Settings, system_dependencies::{add_to_path, get_correct_powershell_command, get_scoop_path}, utils::{copy_dir_contents_preserving_mtime, extract_zst_archive}};
 
 /// Structure to define package information with compile-time template content.
 ///
@@ -526,62 +526,84 @@ pub fn install_prerequisites_offline(
 pub fn copy_idf_from_offline_archive(
     archive_dir: &TempDir,
     config: &Settings
-)-> Result<(), String> {
-  let mut everything_copied = true;
-  for archive_version in config.clone().idf_versions.unwrap() {
-    match std::env::consts::OS {
-      "windows" => {
-        // As on windows the IDF contains too long paths, we need to copy the content from the offline archive to the IDF path
-        // using windows powershell command
-        let mut main_command = get_correct_powershell_command();
+) -> Result<(), String> {
+    let mut everything_copied = true;
+    for archive_version in config.clone().idf_versions.unwrap() {
+        let src_path = archive_dir.path().join(&archive_version);
+        let dst_path = config.clone().path.unwrap().join(&archive_version);
 
-        let output_cp = command_executor::execute_command(
-            &main_command,
-            &vec![
-                "-ExecutionPolicy",
-                "Bypass",
-                "-Command",
-                "cp",
-                "-r",
-                &archive_dir.path().join(&archive_version).to_str().unwrap(),
-                &config.clone().path.unwrap().join(&archive_version).to_str().unwrap(),
-            ],
-        );
-        match output_cp {
-            Ok(out) => {
-                if out.status.success() {
-                    info!("Successfully copied content from offline archive to IDF path");
-                } else {
-                    error!("Failed to copy content from offline archive: {:?} | {:?}", out.stdout, out.stderr);
+        if let Some(parent) = dst_path.parent() {
+            if !parent.exists() {
+                if let Err(e) = fs::create_dir_all(parent) {
+                    error!("Failed to create destination directory: {}", e);
                     everything_copied = false;
+                    continue;
                 }
             }
-            Err(err) => {
-                error!("Failed to copy content from offline archive: {}", err);
-                everything_copied = false;
-            }
         }
 
-      },
-      _ => {
-        debug!("Copying IDF version: {}", archive_version);
-        match copy_dir_contents(&archive_dir.path().join(&archive_version), &config.clone().path.unwrap().join(&archive_version)) {
-          Ok(_) => {
-            info!("Successfully copied IDF version: {}", archive_version);
-          }
-          Err(err) => {
-            error!("Failed to copy IDF version {}: {}", archive_version, err);
-            everything_copied = false;
-          }
+        match std::env::consts::OS {
+            "windows" => {
+                // robocopy handles long paths (no MAX_PATH limit) and preserves timestamps
+                // via /COPY:DAT (Data, Attributes, Timestamps). Exit codes 0-7 are success.
+                let output = command_executor::execute_command(
+                    "robocopy",
+                    &[
+                        src_path.to_str().unwrap(),
+                        dst_path.to_str().unwrap(),
+                        "/E",
+                        "/COPY:DAT",
+                        "/R:3",
+                        "/W:1",
+                        "/NP",
+                        "/NFL",
+                        "/NDL",
+                    ],
+                );
+                match output {
+                    Ok(out) => {
+                        let exit_code = out.status.code().unwrap_or(-1);
+                        if exit_code <= 7 {
+                            info!("Successfully copied IDF version {} (robocopy exit code: {})", archive_version, exit_code);
+                        } else {
+                            error!("robocopy failed for version {} with exit code {}: {:?} | {:?}",
+                                archive_version, exit_code, out.stdout, out.stderr);
+                            everything_copied = false;
+                        }
+                    }
+                    Err(err) => {
+                        error!("Failed to execute robocopy for version {}: {}", archive_version, err);
+                        everything_copied = false;
+                    }
+                }
+            },
+            _ => {
+                debug!("Moving IDF version: {}", archive_version);
+                match fs::rename(&src_path, &dst_path) {
+                    Ok(_) => {
+                        info!("Successfully moved IDF version: {}", archive_version);
+                    }
+                    Err(rename_err) => {
+                        debug!("fs::rename failed (likely cross-filesystem): {}, falling back to mtime-preserving copy", rename_err);
+                        match copy_dir_contents_preserving_mtime(&src_path, &dst_path) {
+                            Ok(_) => {
+                                info!("Successfully copied IDF version with preserved timestamps: {}", archive_version);
+                            }
+                            Err(err) => {
+                                error!("Failed to copy IDF version {}: {}", archive_version, err);
+                                everything_copied = false;
+                            }
+                        }
+                    }
+                }
+            }
         }
-      }
     }
-  }
-  if everything_copied {
-    Ok(())
-  } else {
-    Err("Failed to copy some IDF versions".into())
-  }
+    if everything_copied {
+        Ok(())
+    } else {
+        Err("Failed to copy some IDF versions".into())
+    }
 }
 
 pub fn use_offline_archive(mut config: Settings, offline_archive_dir: &TempDir) -> Result<Settings, String> {

--- a/src-tauri/src/lib/offline_installer.rs
+++ b/src-tauri/src/lib/offline_installer.rs
@@ -549,8 +549,8 @@ pub fn copy_idf_from_offline_archive(
                 let output = command_executor::execute_command(
                     "robocopy",
                     &[
-                        src_path.to_str().unwrap(),
-                        dst_path.to_str().unwrap(),
+                        src_path.to_string_lossy().as_ref(),
+                        dst_path.to_string_lossy().as_ref(),
                         "/E",
                         "/COPY:DAT",
                         "/R:3",

--- a/src-tauri/src/lib/utils.rs
+++ b/src-tauri/src/lib/utils.rs
@@ -9,6 +9,7 @@ use rust_search::SearchBuilder;
 use serde::{Deserialize, Serialize};
 use tar::Archive;
 use zstd::{decode_all, Decoder};
+use filetime::{FileTime, set_file_mtime};
 #[cfg(not(windows))]
 use std::os::unix::fs::MetadataExt;
 use std::{
@@ -859,6 +860,37 @@ pub fn extract_zst_archive(archive_path: &Path, extract_to: &Path) -> Result<(),
 
 pub fn copy_dir_contents(src: &Path, dst: &Path) -> io::Result<()> {
     copy_dir_contents_with_retries(src, dst, 3, std::time::Duration::from_millis(100))
+}
+
+/// Copies directory contents while preserving file modification times.
+/// This prevents `git status` from reporting a dirty working tree after
+/// offline IDF installation.
+pub fn copy_dir_contents_preserving_mtime(src: &Path, dst: &Path) -> io::Result<()> {
+    if !dst.exists() {
+        fs::create_dir_all(dst)?;
+    }
+
+    for entry in fs::read_dir(src)? {
+        let entry = entry?;
+        let path = entry.path();
+        let file_name = path.file_name().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("Invalid file name for path: {:?}", path),
+            )
+        })?;
+        let dest_path = dst.join(file_name);
+
+        if path.is_dir() {
+            copy_dir_contents_preserving_mtime(&path, &dest_path)?;
+        } else {
+            let metadata = fs::metadata(&path)?;
+            let mtime = FileTime::from_last_modification_time(&metadata);
+            fs::copy(&path, &dest_path)?;
+            set_file_mtime(&dest_path, mtime)?;
+        }
+    }
+    Ok(())
 }
 
 pub fn copy_dir_contents_with_retries(

--- a/src-tauri/src/lib/utils.rs
+++ b/src-tauri/src/lib/utils.rs
@@ -862,7 +862,7 @@ pub fn copy_dir_contents(src: &Path, dst: &Path) -> io::Result<()> {
     copy_dir_contents_with_retries(src, dst, 3, std::time::Duration::from_millis(100))
 }
 
-/// Copies directory contents while preserving file modification times.
+/// Copies directory contents while preserving file modification times and symlinks.
 /// This prevents `git status` from reporting a dirty working tree after
 /// offline IDF installation.
 pub fn copy_dir_contents_preserving_mtime(src: &Path, dst: &Path) -> io::Result<()> {
@@ -881,15 +881,81 @@ pub fn copy_dir_contents_preserving_mtime(src: &Path, dst: &Path) -> io::Result<
         })?;
         let dest_path = dst.join(file_name);
 
-        if path.is_dir() {
+        let meta = fs::symlink_metadata(&path)?;
+        if meta.file_type().is_symlink() {
+            debug!("Symlink entry: {:?} -> {:?}", path, dest_path);
+            create_symlink_rewritten(&path, &dest_path, src, dst)?;
+            debug!("Symlink entry rewritten: {:?} -> {:?}", path, dest_path);
+            set_file_mtime(&dest_path, FileTime::from_last_modification_time(&meta))?;
+        } else if meta.is_dir() {
+            debug!("Directory entry: {:?} -> {:?}", path, dest_path);
             copy_dir_contents_preserving_mtime(&path, &dest_path)?;
         } else {
-            let metadata = fs::metadata(&path)?;
-            let mtime = FileTime::from_last_modification_time(&metadata);
+            let mtime = FileTime::from_last_modification_time(&meta);
             fs::copy(&path, &dest_path)?;
             set_file_mtime(&dest_path, mtime)?;
         }
     }
+    Ok(())
+}
+
+pub fn create_symlink_rewritten(
+    src_link_path: &Path,
+    dest_link_path: &Path,
+    src_root: &Path,
+    dst_root: &Path,
+) -> io::Result<()> {
+    if dest_link_path.exists() {
+        let meta = fs::symlink_metadata(dest_link_path)?;
+        if meta.file_type().is_dir() {
+            fs::remove_dir_all(dest_link_path)?;
+        } else {
+            fs::remove_file(dest_link_path)?;
+        }
+    }
+
+    let raw_target = fs::read_link(src_link_path)?;
+
+    // Decide final target for the new symlink
+    let final_target: PathBuf = if raw_target.is_absolute() {
+        // If the absolute link points inside the source tree,
+        // rewrite it to point inside the destination tree.
+        if let Ok(rel_inside_src) = raw_target.strip_prefix(src_root) {
+            let new_abs_target = dst_root.join(rel_inside_src);
+
+            // Convert to relative path from the new link location
+            let parent = dest_link_path.parent().ok_or_else(|| {
+                io::Error::new(io::ErrorKind::Other, "Destination symlink has no parent")
+            })?;
+
+            pathdiff::diff_paths(&new_abs_target, parent).unwrap_or(new_abs_target)
+        } else {
+            // Absolute link outside copied tree — preserve as-is
+            raw_target.clone()
+        }
+    } else {
+        // Relative symlink — preserve as-is
+        raw_target.clone()
+    };
+
+    #[cfg(unix)]
+    {
+        std::os::unix::fs::symlink(&final_target, dest_link_path)?;
+    }
+
+    #[cfg(windows)]
+    {
+        let is_dir = fs::metadata(src_link_path)
+            .map(|m| m.is_dir())
+            .unwrap_or(false);
+
+        if is_dir {
+            std::os::windows::fs::symlink_dir(&final_target, dest_link_path)?;
+        } else {
+            std::os::windows::fs::symlink_file(&final_target, dest_link_path)?;
+        }
+    }
+
     Ok(())
 }
 

--- a/src-tauri/src/offline_installer_builder.rs
+++ b/src-tauri/src/offline_installer_builder.rs
@@ -982,6 +982,7 @@ async fn main() {
 
             // Tar + Zstd compress
             let mut tar = TarBuilder::new(Vec::new());
+            tar.follow_symlinks(false);
             if let Err(e) = tar.append_dir_all(".", archive_dir.path()) {
                 error!("Failed to create tar for {}: {}", idf_version, e);
                 build_summaries.push(summary);


### PR DESCRIPTION
## Problem

After installing ESP-IDF from an **offline archive**, running `git status` inside the installed IDF directory showed a **dirty working tree** (unintended changes). This did not happen when installing the same version via the normal (online) flow. The dirty state made it look as if files had been modified and could confuse users and tooling that rely on a clean repo.

## Root causes

Two separate issues contributed to the dirty status:

### 1. Symlinks were stored as regular files in the archive

When building the offline `.tar.zst` archive, the `tar-rs` crate was used with its **default** behavior of **following symlinks**. That meant:

- Symlinks in the cloned IDF repo (e.g. scripts under `tools/`) were **not** stored as symlink entries in the tar.
- Instead, the **content of the symlink targets** was archived as normal files.
- On extraction, those entries became regular files rather than symlinks.
- Git then saw a difference: index had symlinks, working tree had regular files → **dirty status**.

### 2. File modification times were lost during copy

When moving/copying the extracted archive contents to the final install location:

- **Windows:** The previous approach used PowerShell `cp -r`, which did not reliably preserve timestamps and had long-path limitations.
- **Non-Windows:** A plain copy was used instead of a move where possible, and the copy did not preserve modification times (mtime).
- Git uses mtime (among other things) to detect changes. When mtime was reset, git could report files as modified → **dirty status**.

## Solution

### Archive creation (offline installer builder)

- **`src-tauri/src/offline_installer_builder.rs`**  
  Before adding the archive directory to the tar, call `tar.follow_symlinks(false)`.  
  Symlinks are now stored as **symlink entries** in the archive, so extraction restores them correctly and git no longer sees symlinks turned into regular files.

### Extraction and copy to install path

- **`src-tauri/src/lib/offline_installer.rs`** — `copy_idf_from_offline_archive`:
  - **Windows:** Use **robocopy** instead of PowerShell `cp -r`:
    - Handles long paths (avoids MAX_PATH issues).
    - Uses `/COPY:DAT` to copy Data, Attributes, and Timestamps, so mtime is preserved.
    - Exit codes 0–7 are treated as success; failures are logged and reported.
  - **Non-Windows:** Prefer **`fs::rename`** (move) when possible so metadata is preserved. If `rename` fails (e.g. cross-filesystem), fall back to a **mtime-preserving copy** instead of a plain copy.

- **`src-tauri/src/lib/utils.rs`** — new helper:
  - **`copy_dir_contents_preserving_mtime`** recursively copies a directory and, for each file, copies the content then sets the destination file’s modification time to match the source (using the `filetime` crate). This keeps git’s view of the working tree consistent when a move is not possible.

- **Path handling:** Use `to_string_lossy().as_ref()` for paths passed to `robocopy` so that paths with non-UTF-8 characters (e.g. some Windows user names) do not cause a panic; invalid sequences are replaced and robocopy failure is handled in the existing error path.

### Dependencies

- **`src-tauri/Cargo.toml`**  
  Added the **`filetime`** crate for setting file modification times in `copy_dir_contents_preserving_mtime`.

## Summary of changes

| Area | Change |
|------|--------|
| **Archive creation** | `tar.follow_symlinks(false)` so symlinks are stored as symlinks. |
| **Windows copy** | Use robocopy with `/COPY:DAT` for long paths and timestamp preservation; safe path strings via `to_string_lossy()`. |
| **Non-Windows copy** | Prefer `fs::rename`; fallback to `copy_dir_contents_preserving_mtime` when rename fails. |
| **New utility** | `copy_dir_contents_preserving_mtime` in `utils.rs` (uses `filetime`). |
| **Dependency** | Added `filetime` in `Cargo.toml` / `Cargo.lock`. |

With these changes, installing IDF from an offline archive results in a **clean `git status`** in the installed IDF directory, consistent with an online installation.
