### PR TITLE
EIM-614: Avoiding Shell Expansion in jira workflow

### DIFF
--- a/.github/workflows/jira-pr-comment.yml
+++ b/.github/workflows/jira-pr-comment.yml
@@ -22,15 +22,17 @@ jobs:
   add-pr-comment-to-jira:
     name: Add PR Comment to Jira
     runs-on: ubuntu-latest
+    permissions: {}  # read-only; this workflow only writes to Jira via API
     steps:
       - name: Extract Jira Issue Key from PR Title
         id: extract
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          TITLE="${{ github.event.pull_request.title }}"
-          echo "PR Title: $TITLE"
+          echo "PR Title: $PR_TITLE"
 
           # Match pattern: EIM-12345: description
-          if [[ "$TITLE" =~ ^(EIM-[0-9]+): ]]; then
+          if [[ "$PR_TITLE" =~ ^(EIM-[0-9]+): ]]; then
             ISSUE_KEY="${BASH_REMATCH[1]}"
             echo "Found Jira issue key: $ISSUE_KEY"
             echo "issue_key=$ISSUE_KEY" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Avoiding shell expansion in jira pr comment workflow by using env 