### PR TITLE
EIM-519: updated decompression of targz to streaming so it has lower memory footprint

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1402,6 +1402,7 @@ dependencies = [
  "lzma-rs",
  "once_cell",
  "openssl-sys",
+ "os_pipe",
  "pathdiff",
  "regex",
  "reqwest 0.13.2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -151,6 +151,7 @@ indicatif = { version = "0.18", optional = true }
 # userustpython feature dependencies
 rustpython-vm = { git = "https://github.com/Hahihula/RustPython.git", branch = "test-rust-build", features = ["freeze-stdlib"], optional = true }
 rustpython-stdlib = { git = "https://github.com/Hahihula/RustPython.git", branch = "test-rust-build", features = ["ssl-vendor"], optional = true }
+os_pipe = "1.2.3"
 
 # OS-specific dependency
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/src-tauri/src/lib/mod.rs
+++ b/src-tauri/src/lib/mod.rs
@@ -1520,16 +1520,23 @@ fn decompress_tar_xz(
 ) -> Result<(), DecompressionError> {
     let file = File::open(archive_path)?;
     let mut reader = BufReader::new(file);
-    let mut decompressed_data = Vec::new();
 
-    // First decompress the XZ data
-    lzma_rs::xz_decompress(&mut reader, &mut decompressed_data)
-        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+    let (pipe_reader, mut pipe_writer) = os_pipe::pipe()?;
 
-    // Then process the tar archive from the decompressed data
-    let cursor = std::io::Cursor::new(decompressed_data);
-    let mut archive = Archive::new(cursor);
-    archive.unpack(destination_path)?;
+    let decompress_thread = std::thread::spawn(move || {
+        lzma_rs::xz_decompress(&mut reader, &mut pipe_writer)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))
+    });
+
+    let mut archive = Archive::new(pipe_reader);
+    let unpack_result = archive.unpack(destination_path);
+
+    let decompress_result = decompress_thread
+        .join()
+        .map_err(|_| std::io::Error::new(std::io::ErrorKind::Other, "decompressor thread panicked"))?;
+
+    unpack_result?;
+    decompress_result?;
     Ok(())
 }
 


### PR DESCRIPTION
This is the correct solution of #449 
it replaces obviously abandoned effort #453 which was introducing problematic c library.