### PR TITLE
EIM-624: Fix the possibility of deadlock on windows on slow hdd with big archive

### DIFF
--- a/src-tauri/src/lib/mod.rs
+++ b/src-tauri/src/lib/mod.rs
@@ -15,6 +15,7 @@ use tar::Archive;
 use thiserror::Error;
 use utils::{find_directories_by_name};
 use zip::ZipArchive;
+use std::io::Seek;
 
 /// Simple template renderer - replaces {{variable}} placeholders with values
 /// This is a lightweight replacement for tera, using only std library
@@ -1521,22 +1522,14 @@ fn decompress_tar_xz(
     let file = File::open(archive_path)?;
     let mut reader = BufReader::new(file);
 
-    let (pipe_reader, mut pipe_writer) = os_pipe::pipe()?;
+    let mut temp = tempfile::tempfile()?;
+    lzma_rs::xz_decompress(&mut reader, &mut temp)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
 
-    let decompress_thread = std::thread::spawn(move || {
-        lzma_rs::xz_decompress(&mut reader, &mut pipe_writer)
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))
-    });
+    temp.seek(std::io::SeekFrom::Start(0))?;
+    let mut archive = Archive::new(BufReader::new(temp));
+    archive.unpack(destination_path)?;
 
-    let mut archive = Archive::new(pipe_reader);
-    let unpack_result = archive.unpack(destination_path);
-
-    let decompress_result = decompress_thread
-        .join()
-        .map_err(|_| std::io::Error::new(std::io::ErrorKind::Other, "decompressor thread panicked"))?;
-
-    unpack_result?;
-    decompress_result?;
     Ok(())
 }
 


### PR DESCRIPTION
Fix: Resolve Windows hang in tar.xz decompression (streaming pipe deadlock)

this should solve #596

Problem
After switching decompress_tar_xz to a streaming pipe-based approach in #576 (EIM-519), the application hangs on Windows during decompression of .tar.xz archives.
The root cause is a classic pipe deadlock. OS pipes have a fixed-size internal buffer (4–8KB on Windows). When the tar unpacker slows down — due to slow filesystem writes, antivirus scanning, or the extra path sanitization the tar crate does on Windows — the pipe buffer fills up and the decompressor thread blocks on the write side. Both threads end up waiting on each other, resulting in a deadlock.
This does not reproduce on Linux/macOS because Unix pipes have larger kernel buffers (64KB on Linux) and faster filesystem operations, giving enough headroom for the producer and consumer to stay in sync.

Solution

Replace the pipe with a temporary file via tempfile::tempfile(). The decompressed tar stream is written to an anonymous temp file, then read back for unpacking. The OS disk cache handles paging, so heap memory usage stays minimal regardless of archive size. The temp file is automatically deleted when closed.