### PR TITLE
Add support for Portage-based Linux distros (e.g. Gentoo) (EIM-659)

### DIFF
--- a/src-tauri/src/lib/system_dependencies.rs
+++ b/src-tauri/src/lib/system_dependencies.rs
@@ -702,12 +702,7 @@ pub fn get_scoop_git_path() -> Option<String> {
                 return None;
             }
         };
-        let scoop_git_path = home_dir
-            .join("scoop")
-            .join("apps")
-            .join("git")
-            .join("current")
-            .join("bin");
+        let scoop_git_path = home_dir.join("scoop").join("apps").join("git").join("current").join("bin");
         Some(scoop_git_path.to_string_lossy().to_string())
     } else {
         None
@@ -785,9 +780,7 @@ pub fn ensure_scoop_package_manager() -> Result<(), String> {
             add_to_path(&path_with_scoop).unwrap();
 
             let executor = command_executor::get_executor();
-            let output = executor.run_script_from_string(
-                "if (Get-Command scoop -ErrorAction SilentlyContinue) { exit 0 } else { exit 1 }",
-            );
+            let output = executor.run_script_from_string("if (Get-Command scoop -ErrorAction SilentlyContinue) { exit 0 } else { exit 1 }");
             match output {
                 Ok(o) => {
                     let stdout = String::from_utf8_lossy(&o.stdout);
@@ -910,8 +903,7 @@ pub fn install_prerequisites(packages_list: Vec<String>) -> Result<(), String> {
         }
         "macos" => {
             for package in packages_list {
-                let output =
-                    command_executor::execute_command_direct("brew", &["install", &package]);
+                let output = command_executor::execute_command_direct("brew", &["install", &package]);
                 match output {
                     Ok(_) => {
                         debug!("Successfully installed {}", package);
@@ -952,10 +944,7 @@ pub fn install_prerequisites(packages_list: Vec<String>) -> Result<(), String> {
                         } else {
                             let stderr = String::from_utf8_lossy(&o.stderr);
                             let stdout = String::from_utf8_lossy(&o.stdout);
-                            debug!(
-                                "Failed to add versions bucket to scoop: {} {}",
-                                stderr, stdout
-                            );
+                            debug!("Failed to add versions bucket to scoop: {} {}", stderr, stdout);
                         }
                     }
                     Err(e) => {
@@ -981,10 +970,7 @@ pub fn install_prerequisites(packages_list: Vec<String>) -> Result<(), String> {
                             let stderr = String::from_utf8_lossy(&o.stderr);
                             debug!("Failed to install {}: {}", package, stderr);
                             debug!("Output: {}", stdout);
-                            return Err(format!(
-                                "Failed to install {}: {} {}",
-                                package, stderr, stdout
-                            ));
+                            return Err(format!("Failed to install {}: {} {}", package, stderr, stdout));
                         }
                     }
                     Err(e) => panic!("Failed to install {}: {}", package, e),
@@ -1005,10 +991,7 @@ pub fn get_correct_powershell_command() -> String {
                 debug!("Powershell core is available: {:?}", o.stdout);
                 "pwsh".to_string()
             } else {
-                debug!(
-                    "Powershell core check failed: {:?}, {:?}",
-                    o.stdout, o.stderr
-                );
+                debug!("Powershell core check failed: {:?}, {:?}", o.stdout, o.stderr);
                 "powershell".to_string()
             }
         }

--- a/src-tauri/src/lib/system_dependencies.rs
+++ b/src-tauri/src/lib/system_dependencies.rs
@@ -987,13 +987,13 @@ pub fn install_prerequisites(packages_list: Vec<String>) -> Result<(), String> {
 pub fn get_correct_powershell_command() -> String {
     match command_executor::execute_command_direct("pwsh", &["--version"]) {
         Ok(o) => {
-            if (o.status.success()) {
-                debug!("Powershell core is available: {:?}", o.stdout);
-                "pwsh".to_string()
-            } else {
-                debug!("Powershell core check failed: {:?}, {:?}", o.stdout, o.stderr);
-                "powershell".to_string()
-            }
+          if (o.status.success()) {
+            debug!("Powershell core is available: {:?}", o.stdout);
+            "pwsh".to_string()
+          } else {
+            debug!("Powershell core check failed: {:?}, {:?}", o.stdout, o.stderr);
+            "powershell".to_string()
+          }
         }
         Err(_) => {
             debug!("Powershell core not found, using powershell");

--- a/src-tauri/src/lib/system_dependencies.rs
+++ b/src-tauri/src/lib/system_dependencies.rs
@@ -68,7 +68,7 @@ fn determine_package_manager() -> Option<&'static str> {
     // Fallback: probe for package manager binaries (excluding dpkg to avoid
     // false positives on non-Debian systems where dpkg is installed as a
     // standalone tool)
-    let package_managers = vec!["apt", "dnf", "pacman", "zypper"];
+    let package_managers = vec!["apt", "dnf", "emerge", "pacman", "zypper"];
 
     for manager in package_managers {
         let output = command_executor::execute_command(manager, &["--version"]);
@@ -148,6 +148,8 @@ fn map_distro_to_package_manager(distro: &str) -> Option<&'static str> {
         "arch" | "manjaro" | "endeavouros" | "garuda" | "artix" | "cachyos" => Some("pacman"),
         // SUSE-based
         "opensuse" | "opensuse-leap" | "opensuse-tumbleweed" | "sles" | "sled" => Some("zypper"),
+        // Portage-based (emerge)
+        "gentoo" => Some("emerge"),
         _ => None,
     }
 }
@@ -239,6 +241,11 @@ pub fn get_prequisites() -> Vec<&'static str> {
 ///   - `libusb`: Runtime library for USB device access.
 ///   - `openssl-devel`: Development headers for OpenSSL.
 ///
+/// - **emerge (Gentoo Linux):**
+///   - `dev-libs/libffi`: Development headers for Foreign Function Interface.
+///   - `dev-libs/libusb`: Runtime library for USB device access.
+///   - `dev-libs/openssl`: Includes both runtime and development files for OpenSSL.
+///
 /// - **pacman (Arch Linux):**
 ///   - `libusb`: Includes both runtime and development files for USB access.
 ///   - `libffi`: Includes both runtime and development files for Foreign Function Interface.
@@ -256,6 +263,7 @@ pub fn get_general_prerequisites_based_on_package_manager() -> Vec<&'static str>
         "linux" => match determine_package_manager() {
             Some("apt") => vec!["libffi-dev", "libusb-1.0-0", "libssl-dev"],
             Some("dnf") => vec!["libffi-devel", "libusb", "openssl-devel"],
+            Some("emerge") => vec!["dev-libs/libffi", "dev-libs/libusb", "dev-libs/openssl"],
             Some("pacman") => vec!["libusb", "libffi", "openssl"],
             Some("zypper") => vec!["libusb-1_0-0", "libffi-devel", "libopenssl-devel"],
             _ => vec![],
@@ -293,6 +301,13 @@ pub fn get_general_prerequisites_based_on_package_manager() -> Vec<&'static str>
 ///   - `SDL2`: Runtime library for SDL2 (QEMU dependency).
 ///   - `libslirp`: Runtime library for SLIRP user-mode networking (QEMU dependency).
 ///
+/// - **emerge (Gentoo Linux):**
+///   - `dev-libs/libgcrypt`: Runtime library for cryptographic functions (QEMU dependency).
+///   - `dev-libs/glib`: Runtime library for GLib (QEMU dependency).
+///   - `x11-libs/pixman`: Runtime library for pixman (QEMU dependency).
+///   - `media-libs/libsdl2`: Runtime library for SDL2 (QEMU dependency).
+///   - `net-libs/libslirp`: Runtime library for SLIRP user-mode networking (QEMU dependency).
+///
 /// - **pacman (Arch Linux):**
 ///   - `libgcrypt`: Runtime library for cryptographic functions (QEMU dependency).
 ///   - `glib`: Runtime library for GLib (QEMU dependency).
@@ -325,8 +340,14 @@ pub fn get_qemu_prerequisites_based_on_package_manager() -> Vec<&'static str> {
                 "libsdl2-2.0-0",
                 "libslirp0",
             ],
-
             Some("dnf") => vec!["libgcrypt", "glib2", "pixman", "SDL2", "libslirp"],
+            Some("emerge") => vec![
+                "dev-libs/libgcrypt",
+                "dev-libs/glib",
+                "x11-libs/pixman",
+                "media-libs/libsdl2",
+                "net-libs/libslirp",
+            ],
             Some("pacman") => vec!["libgcrypt", "glib", "pixman", "sdl2", "libslirp"],
             Some("zypper") => vec![
                 "libgcrypt20",
@@ -428,12 +449,31 @@ fn check_tools_installed(tools: Vec<&'static str>) -> Result<Vec<&'static str>, 
                         }
                     }
                 }
-
                 Some("dnf") => {
                     for tool in list_of_required_tools {
                         let output = command_executor::execute_command(
                             "sh",
                             &["-c", &format!("rpm -qa | grep -i {}", tool)],
+                        );
+                        match output {
+                            Ok(o) => {
+                                if o.status.success() {
+                                    debug!("{} is already installed: {:?}", tool, o);
+                                } else {
+                                    unsatisfied.push(tool);
+                                }
+                            }
+                            Err(_e) => {
+                                unsatisfied.push(tool);
+                            }
+                        }
+                    }
+                }
+                Some("emerge") => {
+                    for tool in list_of_required_tools {
+                        let output = command_executor::execute_command(
+                            "sh",
+                            &["-c", &format!("emerge --info {0} | grep \".*{0}.* was built with the following:\"", tool)],
                         );
                         match output {
                             Ok(o) => {
@@ -662,7 +702,12 @@ pub fn get_scoop_git_path() -> Option<String> {
                 return None;
             }
         };
-        let scoop_git_path = home_dir.join("scoop").join("apps").join("git").join("current").join("bin");
+        let scoop_git_path = home_dir
+            .join("scoop")
+            .join("apps")
+            .join("git")
+            .join("current")
+            .join("bin");
         Some(scoop_git_path.to_string_lossy().to_string())
     } else {
         None
@@ -740,7 +785,9 @@ pub fn ensure_scoop_package_manager() -> Result<(), String> {
             add_to_path(&path_with_scoop).unwrap();
 
             let executor = command_executor::get_executor();
-            let output = executor.run_script_from_string("if (Get-Command scoop -ErrorAction SilentlyContinue) { exit 0 } else { exit 1 }");
+            let output = executor.run_script_from_string(
+                "if (Get-Command scoop -ErrorAction SilentlyContinue) { exit 0 } else { exit 1 }",
+            );
             match output {
                 Ok(o) => {
                     let stdout = String::from_utf8_lossy(&o.stdout);
@@ -811,6 +858,20 @@ pub fn install_prerequisites(packages_list: Vec<String>) -> Result<(), String> {
                         }
                     }
                 }
+                Some("emerge") => {
+                    for package in packages_list {
+                        let output = command_executor::execute_command_direct(
+                            "sudo",
+                            &["emerge", "--verbose", &package],
+                        );
+                        match output {
+                            Ok(_) => {
+                                debug!("Successfully installed {}", package);
+                            }
+                            Err(e) => panic!("Failed to install {}: {}", package, e),
+                        }
+                    }
+                }
                 Some("pacman") => {
                     for package in packages_list {
                         let output = command_executor::execute_command_direct(
@@ -849,7 +910,8 @@ pub fn install_prerequisites(packages_list: Vec<String>) -> Result<(), String> {
         }
         "macos" => {
             for package in packages_list {
-                let output = command_executor::execute_command_direct("brew", &["install", &package]);
+                let output =
+                    command_executor::execute_command_direct("brew", &["install", &package]);
                 match output {
                     Ok(_) => {
                         debug!("Successfully installed {}", package);
@@ -890,7 +952,10 @@ pub fn install_prerequisites(packages_list: Vec<String>) -> Result<(), String> {
                         } else {
                             let stderr = String::from_utf8_lossy(&o.stderr);
                             let stdout = String::from_utf8_lossy(&o.stdout);
-                            debug!("Failed to add versions bucket to scoop: {} {}", stderr, stdout);
+                            debug!(
+                                "Failed to add versions bucket to scoop: {} {}",
+                                stderr, stdout
+                            );
                         }
                     }
                     Err(e) => {
@@ -916,7 +981,10 @@ pub fn install_prerequisites(packages_list: Vec<String>) -> Result<(), String> {
                             let stderr = String::from_utf8_lossy(&o.stderr);
                             debug!("Failed to install {}: {}", package, stderr);
                             debug!("Output: {}", stdout);
-                            return Err(format!("Failed to install {}: {} {}", package, stderr, stdout));
+                            return Err(format!(
+                                "Failed to install {}: {} {}",
+                                package, stderr, stdout
+                            ));
                         }
                     }
                     Err(e) => panic!("Failed to install {}: {}", package, e),
@@ -933,13 +1001,16 @@ pub fn install_prerequisites(packages_list: Vec<String>) -> Result<(), String> {
 pub fn get_correct_powershell_command() -> String {
     match command_executor::execute_command_direct("pwsh", &["--version"]) {
         Ok(o) => {
-          if (o.status.success()) {
-            debug!("Powershell core is available: {:?}", o.stdout);
-            "pwsh".to_string()
-          } else {
-            debug!("Powershell core check failed: {:?}, {:?}", o.stdout, o.stderr);
-            "powershell".to_string()
-          }
+            if (o.status.success()) {
+                debug!("Powershell core is available: {:?}", o.stdout);
+                "pwsh".to_string()
+            } else {
+                debug!(
+                    "Powershell core check failed: {:?}, {:?}",
+                    o.stdout, o.stderr
+                );
+                "powershell".to_string()
+            }
         }
         Err(_) => {
             debug!("Powershell core not found, using powershell");


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

Updates 'src-tauri/src/lib/system_dependencies.rs' to support Portage-based Linux distros (e.g. Gentoo). 

Adds 'emerge' (Portage's binary) as a known package manager binary.
Adds support for '/etc/os-release' containing 'ID=gentoo'.
Adds Portage equivalent package names for libffi, libusb, libssl:
 - dev-libs/libffi
 - dev-libs/libusb
 - dev-libs/openssl

Adds Portage equivalent package names for libcrypt, glib, pixman, SDL2, libslirp:
 - dev-libs/libgcrypt
 - dev-libs/glib
 - x11-libs/pixman
 - media-libs/libsdl2
 - net-libs/libslirp

Adds support for package installation detection via Portage's 'emerge' command.
Adds support for package installation via Portage's 'emerge' command.

Various formatting changes from running 'cargo fmt'.

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

Fixes #634.

Gentoo's Portage documentation - https://wiki.gentoo.org/wiki/Portage
Oracle's JDK APT documentation - https://docs.oracle.com/javase/7/docs/technotes/guides/apt/GettingStarted.html

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

I ran all tests and validated on my Gentoo system with all of EIM's package dependencies installed.

<img width="1252" height="1052" alt="Screenshot From 2026-03-24 23-23-31" src="https://github.com/user-attachments/assets/03367837-98cd-4bad-850e-8bc20744919a" />

Additionally, I validated by removing the 'dfu-util' dependency (Portage package app-mobilephone/dfu-uti) and ensuring EIM reported the dependency as requiring installation.

<img width="1252" height="1052" alt="Screenshot From 2026-03-24 23-20-51" src="https://github.com/user-attachments/assets/5e0f50a9-bcaa-4ff5-ac31-3e9b1454e6d5" />


---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes. (As far as I can tell)
- [ ] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary. (I saw no existing tests for system_dependencies.rs)
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
