### PR TITLE
Fixes an installation error caused by setting mtime on symbolic links (EIM-678)

### DIFF
--- a/src-tauri/src/lib/utils.rs
+++ b/src-tauri/src/lib/utils.rs
@@ -9,7 +9,7 @@ use rust_search::SearchBuilder;
 use serde::{Deserialize, Serialize};
 use tar::Archive;
 use zstd::{decode_all, Decoder};
-use filetime::{FileTime, set_file_mtime};
+use filetime::{FileTime, set_file_mtime, set_symlink_file_times};
 #[cfg(not(windows))]
 use std::os::unix::fs::MetadataExt;
 use std::{
@@ -893,7 +893,11 @@ pub fn copy_dir_contents_preserving_mtime(src: &Path, dst: &Path) -> io::Result<
             debug!("Symlink entry: {:?} -> {:?}", path, dest_path);
             create_symlink_rewritten(&path, &dest_path, src, dst)?;
             debug!("Symlink entry rewritten: {:?} -> {:?}", path, dest_path);
-            set_file_mtime(&dest_path, FileTime::from_last_modification_time(&meta))?;
+            set_symlink_file_times(
+                &dest_path,
+                FileTime::now(),
+                FileTime::from_last_modification_time(&meta)
+            )?;
         } else if meta.is_dir() {
             debug!("Directory entry: {:?} -> {:?}", path, dest_path);
             copy_dir_contents_preserving_mtime(&path, &dest_path)?;


### PR DESCRIPTION
### Fixes an installation error caused by setting mtime on symbolic links during the copy phase.

### Description

I noticed this problem when trying to use the latest version of eim 10.4-10.5 with a offline cross-volume installation (/tmp is not on the same volume as the destination path).

While searching for the cause of the problem, I found the point of origin in this line [0], and the problem is that this method cannot be used on symbolic links.

As can be seen here [1], it passes the third parameter as "false", which in turn causes the flags to be passed to libc without nofollow [2].

Considering that the filesystem can return entries in an order in which the link appears first (depending on the filesystem and possibly being random), creating an dangling link, the absence of nofollow causes the system call to terminate with an error.

To correct this, PR uses the appropriate method for symbolic links.

### Testing

Tested in a clean, containerized environment.

[0] https://github.com/espressif/idf-im-ui/blob/05b96e78c14b08078949e82e0605d2c1ca12e54f/src-tauri/src/lib/utils.rs#L896
[1] https://github.com/alexcrichton/filetime/blob/75abafa8a6db579ce973afe78b4262efacbb4694/src/unix/linux.rs#L20
[2] https://github.com/alexcrichton/filetime/blob/75abafa8a6db579ce973afe78b4262efacbb4694/src/unix/linux.rs#L93

### For reference, the log and strace when the error occurs:

#### Installation log:
```
2026-03-28 19:20:04 -  7 - 03 - DEBUG - Symlink entry rewritten: "/tmp/.tmpLoCqgV/v6.0/esp-idf/examples/build_system/cmake/idf_as_lib/build-esp32c3.sh" -> "/install_path/v6.0/esp-idf/examples/build_system/cmake/idf_as_lib/build-esp32c3.sh"
2026-03-28 19:20:04 -  7 - 03 - ERROR - Failed to copy IDF version v6.0: No such file or directory (os error 2)
Error executing CLI: Failed to copy some IDF versions
```

#### Installation strace:
```
symlink("build.sh", "/install_path/v6.0/esp-idf/examples/build_system/cmake/idf_as_lib/build-esp32c3.sh") = 0
write(9, "2026-03-28 19:20:04 -  7 - 03 - "..., 280) = 280
write(1, "2026-03-28 19:20:04 -  7 - 03 - "..., 280) = 280
utimensat(AT_FDCWD, "/install_path/v6.0/esp-idf/examples/build_system/cmake/idf_as_lib/build-esp32c3.sh", [UTIME_OMIT, {tv_sec=1774358727, tv_nsec=0} /* 2026-03-24T10:25:27-0300 */], 0) = -1 ENOENT (No such file or directory)
close(16)                               = 0
close(15)                               = 0
munmap(0x7f9ebc156000, 12288)           = 0
```