### PR TITLE
EIM-616: update dependency to new streaming approach

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4071,8 +4071,7 @@ dependencies = [
 [[package]]
 name = "lzma-rs"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e"
+source = "git+https://github.com/Hahihula/lzma-rs?rev=e6336615af1dcc28276dbcfa4ab0c2d0917ada0a#e6336615af1dcc28276dbcfa4ab0c2d0917ada0a"
 dependencies = [
  "byteorder",
  "crc",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -114,7 +114,8 @@ flate2 = { version = "1.0", default-features = false, features = ["rust_backend"
 tar = { version = "0.4", default-features = false }
 filetime = "0.2"
 zip = { version = "8.1", default-features = true }
-lzma-rs = "0.3.0"
+lzma-rs = { git = "https://github.com/Hahihula/lzma-rs", rev="e6336615af1dcc28276dbcfa4ab0c2d0917ada0a" }
+
 thiserror = "2.0"
 rust-i18n = "3.0.1"
 tokio = { version = "1.49", features = ["full"] }


### PR DESCRIPTION
this should redoce memory usage while decompressing xz archives to 64mb tops