### PR TITLE
EIM-705: Fix for the welcome page skip

### DIFF
--- a/src/components/Welcome.vue
+++ b/src/components/Welcome.vue
@@ -242,7 +242,7 @@ export default {
         try {
           await invoke('save_app_settings', {
             firstRun: false,
-            skipWelcome: true,
+            skipWelcome: dontShowAgain.value,
             usageStatistics: allowUsageTracking.value
           })
         } catch (error) {


### PR DESCRIPTION
## Summary
- Decouple welcome-screen visibility from telemetry preference in the welcome flow.
- Fix a bug where launching with `--do-not-track true` could unintentionally persist `skip_welcome=true`.
- Keep persistence behavior minimal by updating only how `skipWelcome` is computed in `savePreferences()`.

## Problem
When telemetry is disabled, `savePreferences()` previously persisted:
- `skipWelcome: true`
- `usageStatistics: allowUsageTracking.value`

This coupled two unrelated settings and caused the welcome screen to be skipped on later launches, even when the user did not check "Don't show this welcome screen again".

## Root Cause
In `src/components/Welcome.vue`, `savePreferences()` used a combined condition for saving and always wrote:
- `skipWelcome: true`

As a result, telemetry-off state could force welcome skip.

## Fix
In `src/components/Welcome.vue` (`savePreferences()`):
- Keep existing save condition.
- Change persisted `skipWelcome` from `true` to `dontShowAgain.value`.
- Keep `usageStatistics` mapped to `allowUsageTracking.value`.

This preserves independence between:
- welcome visibility (`dontShowAgain`)
- telemetry preference (`allowUsageTracking`)

## Files Changed
- `src/components/Welcome.vue`