### PR TITLE
EIM-707: generate shell completions before logging setup

### DIFF
--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -117,6 +117,15 @@ pub async fn run_cli(cli: Cli) -> anyhow::Result<()> {
     }
     #[cfg(not(feature = "gui"))]
     let command = cli.clone().command.unwrap();
+    // Handle completions first, before any logging or output setup.
+    // This ensures shell completion scripts are pure without any log messages.
+    if let Commands::Completions { shell } = &command {
+        let mut cmd = Cli::command();
+        let bin_name = env!("CARGO_PKG_NAME");
+        generate(*shell, &mut cmd, bin_name, &mut std::io::stdout());
+        return Ok(());
+    }
+
     match command {
         #[cfg(feature = "gui")]
         Commands::Gui(_) => {
@@ -145,12 +154,7 @@ pub async fn run_cli(cli: Cli) -> anyhow::Result<()> {
         }))).await;
     }
     match command {
-        Commands::Completions { shell } => {
-            let mut cmd = Cli::command();
-            let bin_name = env!("CARGO_PKG_NAME");
-            generate(shell, &mut cmd, bin_name, &mut std::io::stdout());
-            return Ok(());
-        }
+        Commands::Completions { .. } => unreachable!(),
         Commands::Install(install_args) => {
             let settings = Settings::new(
                 install_args.config.clone(),


### PR DESCRIPTION
# Fix leaked terminal garbage in shell completions

## Summary

Fixes issue where shell completion scripts (bash/zsh/fish/elvish) contained terminal log messages when generated during elevated (sudo/root) execution, causing shell syntax errors.

- Move `Commands::Completions` handling before CLI logging setup to ensure clean output
- Shell completions now generate pure scripts without any log contamination

Closes #691

## Problem

When running `eim completions <shell>` as an elevated user (e.g., during RPM package builds with `sudo`), warning messages were being written to stdout before the completion script:

```
2026-04-07 07:10:28 -  7 - 04 - WARN - Running as elevated user. This is not recommended but it is required if you want to install drivers.
Running as elevated user. This is not recommended.
# Print an optspec for argparse to handle cmd's options that are independent of any subcommand.
function __fish_eim_global_optspecs
...
```

Since the build pipeline captures stdout to generate completion files (`"$BIN" completions fish > "$OUTDIR/eim.fish"`), these warnings ended up in the packaged completion scripts, causing syntax errors in users' shells.

## Root Cause

In `src-tauri/src/cli/mod.rs`, the `run_cli` function was structured as:

1. Setup CLI logging (which outputs to stdout)
2. Check if running as elevated user and print warnings
3. **Then** handle commands including `Completions`

This meant any stdout output from steps 1-2 would contaminate the completion script output.