### PR TITLE
EIM-712: fix typos in CLI wizard and version manager

### DIFF
--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -198,7 +198,7 @@ pub async fn run_cli(cli: Cli) -> anyhow::Result<()> {
                         "versions": format!("{:?}", settings.idf_versions),
                       }))).await;
                   }
-                    let result = wizard::run_wizzard_run(settings).await;
+                    let result = wizard::run_wizard_run(settings).await;
                     match result {
                         Ok(r) => {
                             info!("{}", t!("install.wizard_result", r = "Ok".to_string()));
@@ -526,7 +526,7 @@ pub async fn run_cli(cli: Cli) -> anyhow::Result<()> {
                     if !do_not_track {
                       track_cli_event("CLI wizard started", Some(json!({}))).await;
                     }
-                    let result = wizard::run_wizzard_run(settings).await;
+                    let result = wizard::run_wizard_run(settings).await;
                     match result {
                         Ok(r) => {
                             info!("{}", t!("install.wizard_result"));
@@ -591,9 +591,9 @@ pub async fn run_cli(cli: Cli) -> anyhow::Result<()> {
             }
           };
           info!("{}", t!("fix.fixing", path = path_to_fix.display()));
-          // The fix logic is just instalation with use of existing repository
+          // The fix logic is just installation with use of existing repository
           let settings = prepare_settings_for_fix_idf_installation(path_to_fix.clone()).await?;
-          let result = wizard::run_wizzard_run(settings).await;
+          let result = wizard::run_wizard_run(settings).await;
           match result {
             Ok(r) => {
               info!("{}", t!("fix.result"));

--- a/src-tauri/src/cli/wizard.rs
+++ b/src-tauri/src/cli/wizard.rs
@@ -324,7 +324,7 @@ async fn download_and_extract_tools(
     .await
 }
 
-pub async fn run_wizzard_run(mut config: Settings) -> Result<(), String> {
+pub async fn run_wizard_run(mut config: Settings) -> Result<(), String> {
     debug!(
         "{}",
         t!(
@@ -389,14 +389,14 @@ pub async fn run_wizzard_run(mut config: Settings) -> Result<(), String> {
         let archive_dir = offline_archive_dir.as_ref().unwrap();
         // copy IDFs
         copy_idf_from_offline_archive(archive_dir, &config)?;
-        let compoments_dir = PathBuf::from(config.tool_install_folder_name.clone().expect("Tools install folder not defined"));
-        match copy_components_from_offline_archive(archive_dir, &compoments_dir) {
+        let components_dir = PathBuf::from(config.tool_install_folder_name.clone().expect("Tools install folder not defined"));
+        match copy_components_from_offline_archive(archive_dir, &components_dir) {
             Ok(_) => {
                 info!("{}", t!("wizard.components_copy.success"));
             }
             Err(err) => {
                 warn!("{}: {}", t!("wizard.components_copy.failure"), err);
-                // The component will be donwloaded during first build and not all of them are actually needed but most importantly this is for backward compatibility with old IDF not supporting the new component manager, so we don't want to block the installation if the copy fails
+                // The component will be downloaded during first build and not all of them are actually needed but most importantly this is for backward compatibility with old IDF not supporting the new component manager, so we don't want to block the installation if the copy fails
             }
         }
     }
@@ -453,7 +453,7 @@ pub async fn run_wizzard_run(mut config: Settings) -> Result<(), String> {
                 Ok(files) => files,
                 Err(err) => {
                   warn!("{}: {}. {}", t!("wizard.requirements.read_failure"), err, t!("wizard.features.selection_unavailable"));
-                  // Missing option for feature selction should not block installation
+                  // Missing option for feature selection should not block installation
                   // This is exceptionally important for headless run against private repos
                   RequirementsMetadata {
                     version: 1,

--- a/src-tauri/src/lib/version_manager.rs
+++ b/src-tauri/src/lib/version_manager.rs
@@ -446,7 +446,7 @@ pub fn run_command_using_activation_script(activation_script: &str, command: &st
 
 pub async fn prepare_settings_for_fix_idf_installation(path_to_fix: PathBuf) -> anyhow::Result<Settings> {
     info!("Fixing IDF installation at path: {}", path_to_fix.display());
-    // The fix logic is just instalation with use of existing repository
+    // The fix logic is just installation with use of existing repository
     let mut version_name = None;
     match list_installed_versions() {
         Ok(versions) => {


### PR DESCRIPTION
## Summary
Resolves spell-check failures from the `typos` job (e.g. misspelled `run_wizzard_run`, `instalation` in comments).

## Changes
- Rename `run_wizzard_run` → `run_wizard_run` and update call sites.
- Fix comment typos: `instalation` → `installation` in `mod.rs` and `version_manager.rs`.
- In `wizard.rs`, correct additional identifiers/comments flagged when checking the file (`components_dir`, `downloaded`, `selection`).

## Verification
- `cargo check` (src-tauri)
- `typos --config .typos.toml` on the modified Rust files

Refs: EIM-712
