### PR TITLE
EIM-661: Read hardcoded string directly from vue i18n files for tests

### DIFF
--- a/tests/helpers/i18n.js
+++ b/tests/helpers/i18n.js
@@ -1,57 +1,64 @@
 /**
  * i18n helper for GUI tests.
  *
- * Reads the same vue-i18n JSON locale files the production GUI uses
- * (src/locales/{en,cn}.json) so tests assert against a single source of
- * truth: change a string in the locale file and the test follows
- * automatically.
+ * Resolves UI strings through the same `vue-i18n` library the production
+ * GUI uses, fed from the same locale files (`src/locales/{en,cn}.json`),
+ * so tests assert against a single source of truth: change a string in
+ * the locale file and the tests follow automatically.
  *
  * Exports:
- *   - tGui(path, vars?, locale?) — resolve a dotted i18n path to its
- *     rendered string, substituting {var} placeholders from `vars`.
- *     Throws if the path is missing, if the path does not resolve to a
- *     string, or if any {var} placeholder has no matching entry in
- *     `vars`.
- *   - matchable(path, locale?) — return the portion of the translated
- *     string that precedes the first {var} placeholder, trimmed. Useful
- *     for substring assertions (findByText / .include(...)) when the
- *     dynamic value is unknown or noisy.
+ *   - tGui(path, vars?, locale?) — translate a dotted i18n path via
+ *     `vue-i18n`'s `t()`. Throws if the key is missing (i.e. `t()`
+ *     returned the path verbatim).
+ *   - matchable(path, locale?) — returns the portion of the *raw*
+ *     locale value that precedes the first `{var}` placeholder or
+ *     `<tag>`, trimmed. Used for substring assertions when Selenium's
+ *     `getText()` strips inline HTML or when the dynamic value is
+ *     unknown at assert time.
+ *   - xpathText(path, locale?) — returns the longest apostrophe-free
+ *     segment of the raw locale value. `GUITestRunner` builds XPath 1.0
+ *     `contains(text(), '...')` expressions, whose single-quoted literal
+ *     cannot embed a real `'`.
  *
- * Uses fs.readFileSync + JSON.parse (instead of `import ... with
- * { type: "json" }`) so the helper works on every Node 20.x release our
- * CI currently pins to, without relying on the JSON import attributes
- * stabilization (Node 20.10+).
+ * Notes:
+ *   - Lookup + interpolation are delegated to `vue-i18n`. We do not
+ *     reimplement them.
+ *   - Locale JSON is loaded with `fs.readFileSync` + `JSON.parse` (not
+ *     `import ... with { type: "json" }`) so the helper works on every
+ *     Node 20.x release CI pins, without depending on JSON-import
+ *     attributes (Node 20.10+).
+ *   - We retain a reference to the parsed objects (`RAW`) for
+ *     `matchable` / `xpathText`, which need the un-interpolated template
+ *     string. `vue-i18n` may compile messages internally, so we don't
+ *     read them back through `getLocaleMessage`.
  */
 
 import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
+import { createI18n } from "vue-i18n";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const LOCALES_DIR = path.resolve(HERE, "..", "..", "src", "locales");
 
 function loadLocale(name) {
   const file = path.join(LOCALES_DIR, `${name}.json`);
-  const raw = fs.readFileSync(file, "utf8");
-  return JSON.parse(raw);
+  return JSON.parse(fs.readFileSync(file, "utf8"));
 }
 
-const LOCALES = {
+const RAW = {
   en: loadLocale("en"),
   cn: loadLocale("cn"),
 };
 
-function walk(obj, dottedPath) {
-  const parts = dottedPath.split(".");
-  let node = obj;
-  for (const key of parts) {
-    if (node == null || typeof node !== "object" || !(key in node)) {
-      throw new Error(`i18n key missing: "${dottedPath}"`);
-    }
-    node = node[key];
-  }
-  return node;
-}
+const i18n = createI18n({
+  legacy: false,
+  locale: "en",
+  fallbackLocale: false,
+  missingWarn: false,
+  fallbackWarn: false,
+  messages: { en: RAW.en, cn: RAW.cn },
+});
 
 /**
  * Resolve a vue-i18n dotted path to a rendered string.
@@ -62,46 +69,45 @@ function walk(obj, dottedPath) {
  * @returns {string}
  */
 export function tGui(keyPath, vars = {}, locale = "en") {
-  if (!(locale in LOCALES)) {
+  const out = i18n.global.t(keyPath, vars, { locale });
+  if (out === keyPath) {
+    throw new Error(`i18n key missing: "${keyPath}" (locale=${locale})`);
+  }
+  return out;
+}
+
+function rawMessage(keyPath, locale) {
+  if (!(locale in RAW)) {
     throw new Error(`i18n locale not loaded: "${locale}"`);
   }
-  const raw = walk(LOCALES[locale], keyPath);
-  if (typeof raw !== "string") {
+  const node = keyPath
+    .split(".")
+    .reduce(
+      (acc, k) =>
+        acc != null && typeof acc === "object" && k in acc ? acc[k] : undefined,
+      RAW[locale]
+    );
+  if (typeof node !== "string") {
     throw new Error(
-      `i18n path "${keyPath}" did not resolve to a string (got ${typeof raw})`
+      `i18n path "${keyPath}" did not resolve to a string (got ${typeof node})`
     );
   }
-  return raw.replace(/\{(\w+)\}/g, (_, name) => {
-    if (!(name in vars)) {
-      throw new Error(
-        `i18n missing var "${name}" for "${keyPath}" (locale=${locale})`
-      );
-    }
-    return String(vars[name]);
-  });
+  return node;
 }
 
 /**
  * Return the portion of a translation that precedes the first `{var}`
- * placeholder or HTML tag, with trailing whitespace trimmed. Useful
- * for substring assertions (findByText / .include(...)) when the
- * dynamic value is unknown or when the rendered DOM strips inline
- * tags from the locale value (e.g. `<strong>{name}</strong>`).
+ * placeholder or HTML tag, with trailing whitespace trimmed. Useful for
+ * substring assertions (findByText / .include(...)) when the dynamic
+ * value is unknown or when the rendered DOM strips inline tags from the
+ * locale value (e.g. `<strong>{name}</strong>`).
  *
  * @param {string} keyPath
  * @param {"en"|"cn"} [locale="en"]
  * @returns {string}
  */
 export function matchable(keyPath, locale = "en") {
-  if (!(locale in LOCALES)) {
-    throw new Error(`i18n locale not loaded: "${locale}"`);
-  }
-  const raw = walk(LOCALES[locale], keyPath);
-  if (typeof raw !== "string") {
-    throw new Error(
-      `i18n path "${keyPath}" did not resolve to a string (got ${typeof raw})`
-    );
-  }
+  const raw = rawMessage(keyPath, locale);
   const brace = raw.indexOf("{");
   const tag = raw.indexOf("<");
   const candidates = [brace, tag].filter((i) => i !== -1);
@@ -126,16 +132,11 @@ export function matchable(keyPath, locale = "en") {
  * @returns {string}
  */
 export function xpathText(keyPath, locale = "en") {
-  if (!(locale in LOCALES)) {
-    throw new Error(`i18n locale not loaded: "${locale}"`);
-  }
-  const raw = walk(LOCALES[locale], keyPath);
-  if (typeof raw !== "string") {
-    throw new Error(
-      `i18n path "${keyPath}" did not resolve to a string (got ${typeof raw})`
-    );
-  }
-  const segments = raw.split("'").map((s) => s.trim()).filter(Boolean);
+  const raw = rawMessage(keyPath, locale);
+  const segments = raw
+    .split("'")
+    .map((s) => s.trim())
+    .filter(Boolean);
   if (segments.length === 0) {
     throw new Error(`i18n path "${keyPath}" has no XPath-safe text`);
   }

--- a/tests/helpers/i18n.js
+++ b/tests/helpers/i18n.js
@@ -1,0 +1,143 @@
+/**
+ * i18n helper for GUI tests.
+ *
+ * Reads the same vue-i18n JSON locale files the production GUI uses
+ * (src/locales/{en,cn}.json) so tests assert against a single source of
+ * truth: change a string in the locale file and the test follows
+ * automatically.
+ *
+ * Exports:
+ *   - tGui(path, vars?, locale?) — resolve a dotted i18n path to its
+ *     rendered string, substituting {var} placeholders from `vars`.
+ *     Throws if the path is missing, if the path does not resolve to a
+ *     string, or if any {var} placeholder has no matching entry in
+ *     `vars`.
+ *   - matchable(path, locale?) — return the portion of the translated
+ *     string that precedes the first {var} placeholder, trimmed. Useful
+ *     for substring assertions (findByText / .include(...)) when the
+ *     dynamic value is unknown or noisy.
+ *
+ * Uses fs.readFileSync + JSON.parse (instead of `import ... with
+ * { type: "json" }`) so the helper works on every Node 20.x release our
+ * CI currently pins to, without relying on the JSON import attributes
+ * stabilization (Node 20.10+).
+ */
+
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const LOCALES_DIR = path.resolve(HERE, "..", "..", "src", "locales");
+
+function loadLocale(name) {
+  const file = path.join(LOCALES_DIR, `${name}.json`);
+  const raw = fs.readFileSync(file, "utf8");
+  return JSON.parse(raw);
+}
+
+const LOCALES = {
+  en: loadLocale("en"),
+  cn: loadLocale("cn"),
+};
+
+function walk(obj, dottedPath) {
+  const parts = dottedPath.split(".");
+  let node = obj;
+  for (const key of parts) {
+    if (node == null || typeof node !== "object" || !(key in node)) {
+      throw new Error(`i18n key missing: "${dottedPath}"`);
+    }
+    node = node[key];
+  }
+  return node;
+}
+
+/**
+ * Resolve a vue-i18n dotted path to a rendered string.
+ *
+ * @param {string} keyPath - e.g. "welcome.title"
+ * @param {Object<string, string|number>} [vars] - values for {placeholders}
+ * @param {"en"|"cn"} [locale="en"]
+ * @returns {string}
+ */
+export function tGui(keyPath, vars = {}, locale = "en") {
+  if (!(locale in LOCALES)) {
+    throw new Error(`i18n locale not loaded: "${locale}"`);
+  }
+  const raw = walk(LOCALES[locale], keyPath);
+  if (typeof raw !== "string") {
+    throw new Error(
+      `i18n path "${keyPath}" did not resolve to a string (got ${typeof raw})`
+    );
+  }
+  return raw.replace(/\{(\w+)\}/g, (_, name) => {
+    if (!(name in vars)) {
+      throw new Error(
+        `i18n missing var "${name}" for "${keyPath}" (locale=${locale})`
+      );
+    }
+    return String(vars[name]);
+  });
+}
+
+/**
+ * Return the portion of a translation that precedes the first `{var}`
+ * placeholder or HTML tag, with trailing whitespace trimmed. Useful
+ * for substring assertions (findByText / .include(...)) when the
+ * dynamic value is unknown or when the rendered DOM strips inline
+ * tags from the locale value (e.g. `<strong>{name}</strong>`).
+ *
+ * @param {string} keyPath
+ * @param {"en"|"cn"} [locale="en"]
+ * @returns {string}
+ */
+export function matchable(keyPath, locale = "en") {
+  if (!(locale in LOCALES)) {
+    throw new Error(`i18n locale not loaded: "${locale}"`);
+  }
+  const raw = walk(LOCALES[locale], keyPath);
+  if (typeof raw !== "string") {
+    throw new Error(
+      `i18n path "${keyPath}" did not resolve to a string (got ${typeof raw})`
+    );
+  }
+  const brace = raw.indexOf("{");
+  const tag = raw.indexOf("<");
+  const candidates = [brace, tag].filter((i) => i !== -1);
+  if (candidates.length === 0) return raw;
+  return raw.slice(0, Math.min(...candidates)).trimEnd();
+}
+
+/**
+ * Return an XPath-safe substring of a translation.
+ *
+ * GUITestRunner uses `contains(text(), '...')` XPath expressions, whose
+ * single-quoted literal cannot embed a real apostrophe. Many English
+ * copies contain apostrophes (e.g. "Don't show..."), so we return the
+ * longest apostrophe-free segment of the translated value. The segment
+ * still comes from the locale file, so the key remains the source of
+ * truth.
+ *
+ * Throws if the segment is empty (nothing useful to match on).
+ *
+ * @param {string} keyPath
+ * @param {"en"|"cn"} [locale="en"]
+ * @returns {string}
+ */
+export function xpathText(keyPath, locale = "en") {
+  if (!(locale in LOCALES)) {
+    throw new Error(`i18n locale not loaded: "${locale}"`);
+  }
+  const raw = walk(LOCALES[locale], keyPath);
+  if (typeof raw !== "string") {
+    throw new Error(
+      `i18n path "${keyPath}" did not resolve to a string (got ${typeof raw})`
+    );
+  }
+  const segments = raw.split("'").map((s) => s.trim()).filter(Boolean);
+  if (segments.length === 0) {
+    throw new Error(`i18n path "${keyPath}" has no XPath-safe text`);
+  }
+  return segments.reduce((a, b) => (a.length >= b.length ? a : b));
+}

--- a/tests/package-lock.json
+++ b/tests/package-lock.json
@@ -15,7 +15,55 @@
         "node-pty": "^1.0.0",
         "selenium-webdriver": "^4.29.0",
         "strip-ansi": "^7.1.0",
+        "vue": "^3.5.29",
+        "vue-i18n": "^11.2.8",
         "winston": "^3.17.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@bazel/runfiles": {
@@ -44,6 +92,67 @@
         "kuler": "^2.0.0"
       }
     },
+    "node_modules/@intlify/core-base": {
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-11.4.0.tgz",
+      "integrity": "sha512-nlxFOnmjJgVkL1PsuSMagyh3qIHTwc2KlO2R3qQQV1ydrcwh1XpM7opWUGqvGaLlktttopDzbLBpr/k5tvbNmA==",
+      "license": "MIT",
+      "dependencies": {
+        "@intlify/devtools-types": "11.4.0",
+        "@intlify/message-compiler": "11.4.0",
+        "@intlify/shared": "11.4.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
+    "node_modules/@intlify/devtools-types": {
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/@intlify/devtools-types/-/devtools-types-11.4.0.tgz",
+      "integrity": "sha512-LtQ04kG8/2Nv6AbuINpkjODuhKHdd+MGLlXKW3I0GTCeDsDIBZUot82nnyK7D6+qersF08FqSvoN/eGPcL3c7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@intlify/core-base": "11.4.0",
+        "@intlify/shared": "11.4.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
+    "node_modules/@intlify/message-compiler": {
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-11.4.0.tgz",
+      "integrity": "sha512-v455gVZqMb0er63Wd/akX8DXTnwSubgrgQaRigLB60V3xpnq3B99oPvGXW+N4G/5QFt8Ls84FJ8qHJUVnRCs1A==",
+      "license": "MIT",
+      "dependencies": {
+        "@intlify/shared": "11.4.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
+    "node_modules/@intlify/shared": {
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-11.4.0.tgz",
+      "integrity": "sha512-r9qUeLeO0TMZmUZ+mXS6IGQ6xwzZJaVMK6j4CdoA3eQP8xp3JtCfwkZ30gB4+knlN40pmBdDXgx85SWhMCzHng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -60,6 +169,12 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
     },
     "node_modules/@npmcli/agent": {
       "version": "2.2.2",
@@ -103,6 +218,112 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
       "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
+      "license": "MIT"
+    },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.33.tgz",
+      "integrity": "sha512-3PZLQwFw4Za3TC8t0FvTy3wI16Kt+pmwcgNZca4Pj9iWL2E72a/gZlpBtAJvEdDMdCxdG/qq0C7PN0bsJuv0Rw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.2",
+        "@vue/shared": "3.5.33",
+        "entities": "^7.0.1",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.33.tgz",
+      "integrity": "sha512-PXq0yrfCLzzL07rbXO4awtXY1Z06LG2eu6Adg3RJFa/j3Cii217XxxLXG22N330gw7GmALCY0Z8RgXEviwgpjA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-core": "3.5.33",
+        "@vue/shared": "3.5.33"
+      }
+    },
+    "node_modules/@vue/compiler-sfc": {
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.33.tgz",
+      "integrity": "sha512-UTUvRO9cY+rROrx/pvN9P5Z7FgA6QGfokUCfhQE4EnmUj3rVnK+CHI0LsEO1pg+I7//iRYMUfcNcCPe7tg0CoA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.2",
+        "@vue/compiler-core": "3.5.33",
+        "@vue/compiler-dom": "3.5.33",
+        "@vue/compiler-ssr": "3.5.33",
+        "@vue/shared": "3.5.33",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.21",
+        "postcss": "^8.5.10",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.33.tgz",
+      "integrity": "sha512-IErjYdnj1qIupG5xxiVIYiiRvDhGWV4zuh/RCrwfYpuL+HWQzeU6lCk/nF9r7olWMnjKxCAkOctT2qFWFkzb1A==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.33",
+        "@vue/shared": "3.5.33"
+      }
+    },
+    "node_modules/@vue/devtools-api": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
+      "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
+      "license": "MIT"
+    },
+    "node_modules/@vue/reactivity": {
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.33.tgz",
+      "integrity": "sha512-p8UfIqyIhb0rYGlSgSBV+lPhF2iUSBcRy7enhTmPqKWadHy9kcOFYF1AejYBP9P+avnd3OBbD49DU4pLWX/94A==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/shared": "3.5.33"
+      }
+    },
+    "node_modules/@vue/runtime-core": {
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.33.tgz",
+      "integrity": "sha512-UpFF45RI9//a7rvq7RdOQblb4tup7hHG9QsmIrxkFQLzQ7R8/iNQ5LE15NhLZ1/WcHMU2b47u6P33CPUelHyIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.33",
+        "@vue/shared": "3.5.33"
+      }
+    },
+    "node_modules/@vue/runtime-dom": {
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.33.tgz",
+      "integrity": "sha512-IOxMsAOwquhfITgmOgaPYl7/j8gKUxUFoflRc+u4LxyD3+783xne8vNta1PONVCvCV9A0w7hkyEepINDqfO0tw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.33",
+        "@vue/runtime-core": "3.5.33",
+        "@vue/shared": "3.5.33",
+        "csstype": "^3.2.3"
+      }
+    },
+    "node_modules/@vue/server-renderer": {
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.33.tgz",
+      "integrity": "sha512-0xylq/8/h44lVG0pZFknv1XIdEgymq2E9n59uTWJBG+dIgiT0TMCSsxrN7nO16Z0MU0MPjFcguBbZV8Itk52Hw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-ssr": "3.5.33",
+        "@vue/shared": "3.5.33"
+      },
+      "peerDependencies": {
+        "vue": "3.5.33"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.33.tgz",
+      "integrity": "sha512-5vR2QIlmaLG77Ygd4pMP6+SGQ5yox9VhtnbDWTy9DzMzdmeLxZ1QqxrywEZ9sa1AVubfIJyaCG3ytyWU81ufcQ==",
       "license": "MIT"
     },
     "node_modules/abbrev": {
@@ -536,6 +757,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
@@ -611,6 +838,18 @@
         "iconv-lite": "^0.6.2"
       }
     },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/env-paths": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
@@ -646,6 +885,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "license": "MIT"
     },
     "node_modules/exponential-backoff": {
       "version": "3.1.2",
@@ -1170,6 +1415,15 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "license": "ISC"
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/make-fetch-happen": {
       "version": "13.0.1",
       "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-13.0.1.tgz",
@@ -1399,6 +1653,24 @@
       "integrity": "sha512-DANghxFkS1plDdRsX0X9pm0Z6SJNN6gBdtXfanwoZ8hooC5gosGFSBGRYHUVPz1asKA/kMRqDRdHrluZ61SpBQ==",
       "license": "MIT"
     },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/negotiator": {
       "version": "0.6.4",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
@@ -1599,6 +1871,12 @@
         "node": ">= 14.16"
       }
     },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -1609,6 +1887,34 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/proc-log": {
@@ -1858,6 +2164,15 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/sprintf-js": {
@@ -2134,6 +2449,48 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/vue": {
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.33.tgz",
+      "integrity": "sha512-1AgChhx5w3ALgT4oK3acm2Es/7jyZhWSVUfs3rOBlGQC0rjEDkS7G4lWlJJGGNQD+BV3reCwbQrOe1mPNwKHBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.33",
+        "@vue/compiler-sfc": "3.5.33",
+        "@vue/runtime-dom": "3.5.33",
+        "@vue/server-renderer": "3.5.33",
+        "@vue/shared": "3.5.33"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue-i18n": {
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-11.4.0.tgz",
+      "integrity": "sha512-gxLVtcwdvOgwKSzkdb7nHKlW0N85A6aDNmHLnq6V+3w2/BXy/os5l71P7TIlgIQTxX0zJjiz89iImoHi51GieQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@intlify/core-base": "11.4.0",
+        "@intlify/devtools-types": "11.4.0",
+        "@intlify/shared": "11.4.0",
+        "@vue/devtools-api": "^6.5.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      },
+      "peerDependencies": {
+        "vue": "^3.0.0"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/tests/package.json
+++ b/tests/package.json
@@ -20,6 +20,8 @@
     "node-pty": "^1.0.0",
     "selenium-webdriver": "^4.29.0",
     "strip-ansi": "^7.1.0",
+    "vue": "^3.5.29",
+    "vue-i18n": "^11.2.8",
     "winston": "^3.17.0"
   }
 }

--- a/tests/scripts/GUIAfterInstall.test.js
+++ b/tests/scripts/GUIAfterInstall.test.js
@@ -3,6 +3,7 @@ import { describe, it, before, after, afterEach } from "mocha";
 import GUITestRunner from "../classes/GUITestRunner.class.js";
 import logger from "../classes/logger.class.js";
 import { By } from "selenium-webdriver";
+import { tGui, matchable } from "../helpers/i18n.js";
 
 // This function verifies the presence of the installed IDF versions in the dashboard
 export function runGUIAfterInstallTest({ id = 0, pathToEIM, idfList }) {
@@ -56,18 +57,22 @@ export function runGUIAfterInstallTest({ id = 0, pathToEIM, idfList }) {
       expect(header, "Expected welcome header").to.not.be.false;
       const text = await header.getText();
       expect(text, "Expected welcome text").to.equal(
-        "Welcome to ESP-IDF Installation Manager"
+        `${tGui("welcome.welcome")} ESP-IDF ${tGui("welcome.title")}`
       );
     });
 
     it("2- Should show option to manage installations", async function () {
       this.timeout(10000);
-      const dashboardCard = await eimRunner.findByText("Manage Installations");
+      const dashboardCard = await eimRunner.findByText(
+        tGui("welcome.cards.manage.title")
+      );
       expect(
         dashboardCard,
         "Expected dashboard card to be shown on welcome page"
       ).to.not.be.false;
-      const dashboardContent = await eimRunner.findByText("View and manage");
+      const dashboardContent = await eimRunner.findByText(
+        matchable("welcome.cards.manage.description")
+      );
       const text = await dashboardContent.getText();
       const numberMatch = text.match(/\d+/);
       totalInstallations = numberMatch ? parseInt(numberMatch[0], 10) : 0;
@@ -75,7 +80,9 @@ export function runGUIAfterInstallTest({ id = 0, pathToEIM, idfList }) {
         totalInstallations,
         "Expected at least one installation"
       ).to.be.gte(1);
-      const click = await eimRunner.clickButton("Open Dashboard");
+      const click = await eimRunner.clickButton(
+        tGui("welcome.cards.manage.button")
+      );
       expect(click, "Expected to click on Open Dashboard button").to.be.true;
     });
 

--- a/tests/scripts/GUICustomInstall.test.js
+++ b/tests/scripts/GUICustomInstall.test.js
@@ -11,6 +11,7 @@ import {
   availableTargets,
 } from "../config.js";
 import { getAvailableFeatures, getAvailableTools } from "../helper.js";
+import { tGui } from "../helpers/i18n.js";
 import logger from "../classes/logger.class.js";
 import os from "os";
 
@@ -102,20 +103,22 @@ export function runGUICustomInstallTest({
       expect(header, "Expected welcome header").to.not.be.false;
       const text = await header.getText();
       expect(text, "Expected welcome text").to.equal(
-        "Welcome to ESP-IDF Installation Manager",
+        `${tGui("welcome.welcome")} ESP-IDF ${tGui("welcome.title")}`,
       );
     });
 
     it("02- Should show expert installation option", async function () {
       this.timeout(10000);
-      await eimRunner.clickButton("Start Installation");
+      await eimRunner.clickButton(tGui("welcome.cards.new.button"));
       await new Promise((resolve) => setTimeout(resolve, 2000));
       const header = await eimRunner.findByCSS("h1");
       const text = await header.getText();
       expect(text, "Expected installation setup screen").to.equal(
-        "Install ESP-IDF",
+        tGui("basicInstaller.title"),
       );
-      const custom = await eimRunner.findByText("Custom Installation");
+      const custom = await eimRunner.findByText(
+        tGui("basicInstaller.cards.custom.title"),
+      );
       expect(custom, "Expected option for custom installation").to.not.be.false;
       expect(
         await custom.isDisplayed(),
@@ -125,14 +128,14 @@ export function runGUICustomInstallTest({
 
     it("03- Should show targets list", async function () {
       this.timeout(45000);
-      await eimRunner.clickButton("Start Configuration Wizard");
+      await eimRunner.clickButton(tGui("basicInstaller.cards.custom.button"));
       await new Promise((resolve) => setTimeout(resolve, 15000));
       const targetsList = await eimRunner.findByDataId("targets-grid", 20000);
       const targetsText = await targetsList.getText();
       for (let target of availableTargets) {
         expect(targetsText).to.include(target);
       }
-      let targetAll = await eimRunner.findByText("All");
+      let targetAll = await eimRunner.findByText(tGui("targetSelect.all"));
       expect(
         await targetAll.findElement(By.css("Div")).getAttribute("class"),
       ).to.include("checked");
@@ -149,7 +152,7 @@ export function runGUICustomInstallTest({
       expect(
         await targetAll.findElement(By.css("Div")).getAttribute("class"),
       ).to.include("checked");
-      await eimRunner.clickElement("All");
+      await eimRunner.clickElement(tGui("targetSelect.all"));
 
       for (let target of targetList) {
         await eimRunner.clickElement(target);
@@ -170,7 +173,7 @@ export function runGUICustomInstallTest({
 
     it("04- Should show IDF version list", async function () {
       this.timeout(15000);
-      await eimRunner.clickButton("Continue with Selected Targets");
+      await eimRunner.clickButton(tGui("targetSelect.continueButton"));
       await new Promise((resolve) => setTimeout(resolve, 4000));
 
       const IDFListStable = await eimRunner.findByDataId(
@@ -219,12 +222,12 @@ export function runGUICustomInstallTest({
 
     it("05- Should show IDF download mirrors", async function () {
       this.timeout(15000);
-      await eimRunner.clickButton("Continue Installation");
+      await eimRunner.clickButton(tGui("versionSelect.continueInstallation"));
       await new Promise((resolve) => setTimeout(resolve, 2000));
       const IDFMirrorsList = await eimRunner.findByRelation(
         "parent",
         "div",
-        "ESP-IDF Repository Mirror",
+        tGui("mirrorSelect.sections.idfMirror"),
       );
       let IDFMirrorsListText = await IDFMirrorsList.getText();
       for (let mirror of Object.values(IDFMIRRORS)) {
@@ -272,7 +275,7 @@ export function runGUICustomInstallTest({
       const toolsMirrorsList = await eimRunner.findByRelation(
         "parent",
         "div",
-        "ESP-IDF Tools Mirror",
+        tGui("mirrorSelect.sections.toolsMirror"),
       );
       let toolsMirrorsListText = await toolsMirrorsList.getText();
       for (let mirror of Object.values(TOOLSMIRRORS)) {
@@ -347,7 +350,7 @@ export function runGUICustomInstallTest({
       const pypiMirrorsList = await eimRunner.findByRelation(
         "parent",
         "div",
-        "PyPI Mirror",
+        tGui("mirrorSelect.sections.pypiMirror"),
       );
       let pypiMirrorsListText = await pypiMirrorsList.getText();
       for (let mirror of Object.values(PYPIMIRRORS)) {
@@ -427,7 +430,7 @@ export function runGUICustomInstallTest({
 
     it("08- Should show list of optional features", async function () {
       this.timeout(10000);
-      await eimRunner.clickButton("Continue with Selected Mirrors");
+      await eimRunner.clickButton(tGui("mirrorSelect.continueButton"));
       await new Promise((resolve) => setTimeout(resolve, 4000));
 
       for (let version of idfVersionList) {
@@ -461,7 +464,7 @@ export function runGUICustomInstallTest({
 
     it("09- Should show list of Tools", async function () {
       this.timeout(10000);
-      await eimRunner.clickButton("Continue to Tools selection");
+      await eimRunner.clickButton(tGui("featuresSelect.continueButton"));
       await new Promise((resolve) => setTimeout(resolve, 4000));
 
       for (let version of idfVersionList) {
@@ -485,11 +488,11 @@ export function runGUICustomInstallTest({
 
     it("10- Should show installation path", async function () {
       this.timeout(10000);
-      await eimRunner.clickButton("Continue");
+      await eimRunner.clickButton(tGui("installationPathSelect.continueButton"));
       await new Promise((resolve) => setTimeout(resolve, 2000));
       const installPath = await eimRunner.findByDataId("path-info-title");
       expect(await installPath.getText()).to.equal(
-        "ESP-IDF Installation Directory",
+        tGui("installationPathSelect.info.title"),
       );
       expect(await installPath.isDisplayed()).to.be.true;
       const pathInput = await eimRunner.findByDataId("installation-path-input");
@@ -506,11 +509,11 @@ export function runGUICustomInstallTest({
 
     it("11- Should show installation summary", async function () {
       this.timeout(10000);
-      await eimRunner.clickButton("Continue");
+      await eimRunner.clickButton(tGui("installationPathSelect.continueButton"));
       await new Promise((resolve) => setTimeout(resolve, 2000));
       const versionSummary = await eimRunner.findByDataId("versions-info");
       expect(await versionSummary.getText()).to.include(
-        "Installing ESP-IDF Versions",
+        tGui("installationProgress.normalMode.title"),
       );
       const selectedVersions = await eimRunner.findByDataId("version-chips");
       const selectedVersionsText = await selectedVersions.getText();
@@ -523,18 +526,32 @@ export function runGUICustomInstallTest({
       this.timeout(2730000);
 
       try {
-        await eimRunner.clickButton("Start Installation");
+        await eimRunner.clickButton(
+          tGui("installationProgress.buttons.startInstallation"),
+        );
         await new Promise((resolve) => setTimeout(resolve, 2000));
-        const installing = await eimRunner.findByText("Installation Progress");
+        const installing = await eimRunner.findByText(
+          tGui("installationProgress.title.installation"),
+        );
         expect(await installing.isDisplayed()).to.be.true;
         const startTime = Date.now();
 
+        // NOTE(EIM-661): the "Installation Failed" title is rendered via
+        // `installationProgress.error.title`, which is not present in
+        // `src/locales/en.json` today; `simpleSetup.error.title` holds the
+        // same literal string and is used here as a stand-in source of
+        // truth until the missing key is added in a follow-up.
         while (Date.now() - startTime < 2700000) {
-          if (await eimRunner.findByText("Installation Failed", 1000)) {
+          if (await eimRunner.findByText(tGui("simpleSetup.error.title"), 1000)) {
             logger.debug("failed!!!!");
             break;
           }
-          if (await eimRunner.findByText("Complete Installation", 1000)) {
+          if (
+            await eimRunner.findByText(
+              tGui("installationProgress.buttons.completeInstallation"),
+              1000,
+            )
+          ) {
             logger.debug("Completed!!!");
             break;
           }
@@ -543,7 +560,9 @@ export function runGUICustomInstallTest({
         if (Date.now() - startTime >= 2700000) {
           logger.info("Installation timed out after 45 minutes");
         }
-        const completed = await eimRunner.findByText("Complete Installation");
+        const completed = await eimRunner.findByText(
+          tGui("installationProgress.buttons.completeInstallation"),
+        );
         expect(completed).to.not.be.false;
         expect(await completed.isDisplayed()).to.be.true;
       } catch (error) {
@@ -556,14 +575,20 @@ export function runGUICustomInstallTest({
       this.timeout(15000);
 
       try {
-        await eimRunner.clickButton("Complete Installation");
+        await eimRunner.clickButton(
+          tGui("installationProgress.buttons.completeInstallation"),
+        );
         await new Promise((resolve) => setTimeout(resolve, 5000));
-        const completed = await eimRunner.findByText("Installation Complete!");
+        const completed = await eimRunner.findByText(tGui("complete.title"));
         expect(await completed.isDisplayed()).to.be.true;
-        const saveConfig = await eimRunner.findByText("Save Configuration");
+        const saveConfig = await eimRunner.findByText(
+          tGui("complete.buttons.saveConfiguration"),
+        );
         expect(saveConfig).to.not.be.false;
         expect(await saveConfig.isDisplayed()).to.be.true;
-        const exit = await eimRunner.findByText("Exit Installer");
+        const exit = await eimRunner.findByText(
+          tGui("complete.buttons.exitInstaller"),
+        );
         expect(exit).to.not.be.false;
       } catch (error) {
         logger.info("Failed to complete installation", error);

--- a/tests/scripts/GUIOfflineInstall.test.js
+++ b/tests/scripts/GUIOfflineInstall.test.js
@@ -3,6 +3,7 @@ import { describe, it, before, after, afterEach } from "mocha";
 import GUITestRunner from "../classes/GUITestRunner.class.js";
 import TestProxy from "../classes/TestProxy.class.js";
 import { downloadOfflineArchive } from "../helper.js";
+import { tGui } from "../helpers/i18n.js";
 import logger from "../classes/logger.class.js";
 import { By } from "selenium-webdriver";
 import path from "path";
@@ -107,21 +108,23 @@ export function runGUIOfflineInstallTest({
       expect(header, "Expected welcome header").to.not.be.false;
       const text = await header.getText();
       expect(text, "Expected welcome text").to.equal(
-        "Welcome to ESP-IDF Installation Manager",
+        `${tGui("welcome.welcome")} ESP-IDF ${tGui("welcome.title")}`,
       );
     });
 
     it("2- Should show offline installation option", async function () {
       this.timeout(10000);
 
-      await eimRunner.clickButton("Start Installation");
+      await eimRunner.clickButton(tGui("welcome.cards.new.button"));
       await new Promise((resolve) => setTimeout(resolve, 2000));
       const header = await eimRunner.findByCSS("h1");
       const text = await header.getText();
       expect(text, "Expected installation setup screen").to.equal(
-        "Install ESP-IDF",
+        tGui("basicInstaller.title"),
       );
-      const simplified = await eimRunner.findByText("Offline Installation");
+      const simplified = await eimRunner.findByText(
+        tGui("basicInstaller.cards.offline.title"),
+      );
       expect(simplified, "Expected option for offline installation").to.not.be
         .false;
       expect(
@@ -137,19 +140,19 @@ export function runGUIOfflineInstallTest({
         "document.querySelector('#eim_offline_installation_input').value = arguments[0]",
         `${pathToOfflineArchive}`,
       );
-      await eimRunner.clickButton("Browse Archive File");
+      await eimRunner.clickButton(tGui("basicInstaller.cards.offline.button"));
 
       await new Promise((resolve) => setTimeout(resolve, 2000));
       const header = await eimRunner.findByCSS("h1");
       const text = await header.getText();
       expect(text, "Expected offline installation summary screen").to.equal(
-        "Offline Installation",
+        tGui("offlineInstaller.title"),
       );
 
       const selectedFile = await eimRunner.findByRelation(
         "parent",
         "div",
-        "Selected Archive",
+        tGui("offlineInstaller.config.archive.title"),
       );
       const selectedFileText = await selectedFile.getText();
       expect(selectedFileText, "Expected file path to be shown").to.include(
@@ -164,7 +167,7 @@ export function runGUIOfflineInstallTest({
       expect(await pathInput.getAttribute("value")).to.include(defaultInput);
 
       const useDefault = await eimRunner.findByText(
-        "Use default installation path",
+        tGui("offlineInstaller.config.path.useDefault"),
       );
       const isDisplayed = await useDefault.isDisplayed();
       expect(isDisplayed, "Expected option to use default installation path").to
@@ -172,14 +175,16 @@ export function runGUIOfflineInstallTest({
       const checkBox = await eimRunner.findByRelation(
         "parent",
         "div",
-        "Use default installation path",
+        tGui("offlineInstaller.config.path.useDefault"),
       );
       const checked = await checkBox.getAttribute("class");
       expect(checked, "Expected checkbox to be unchecked").to.include(
         "checked",
       );
 
-      const startButton = await eimRunner.findByText("Start Installation");
+      const startButton = await eimRunner.findByText(
+        tGui("offlineInstaller.config.startButton"),
+      );
       expect(startButton, "Expected button to start installation").to.not.be
         .false;
       expect(
@@ -190,10 +195,10 @@ export function runGUIOfflineInstallTest({
 
     it("4- Should install IDF using offline file", async function () {
       this.timeout(2730000);
-      await eimRunner.clickButton("Start Installation");
+      await eimRunner.clickButton(tGui("offlineInstaller.config.startButton"));
       await new Promise((resolve) => setTimeout(resolve, 5000));
       const installing = await eimRunner.findByText(
-        "Installing ESP-IDF from Offline Archive",
+        tGui("offlineInstaller.installation.title"),
         20000,
       );
 
@@ -207,16 +212,28 @@ export function runGUIOfflineInstallTest({
       ).to.be.true;
 
       const startTime = Date.now();
+      // NOTE(EIM-661): the offline installer also surfaces a generic
+      // "Installation Failed" banner; no dedicated i18n key exists for
+      // the offline flow today, so `simpleSetup.error.title` is reused
+      // as the source of truth for the literal. Flag for follow-up if
+      // a dedicated key is added.
       while (Date.now() - startTime < 2700000) {
-        if (await eimRunner.findByText("Installation Failed", 1000)) {
+        if (await eimRunner.findByText(tGui("simpleSetup.error.title"), 1000)) {
           logger.debug("failed!!!!");
           break;
         }
-        if (await eimRunner.findByText("Installation Error", 1000)) {
+        if (
+          await eimRunner.findByText(tGui("installationProgress.alert.error"), 1000)
+        ) {
           logger.debug("failed!!!!");
           break;
         }
-        if (await eimRunner.findByText("Offline Installation Complete", 1000)) {
+        if (
+          await eimRunner.findByText(
+            tGui("offlineInstaller.installation.success.title"),
+            1000,
+          )
+        ) {
           logger.debug("Completed!!!");
           break;
         }
@@ -226,7 +243,7 @@ export function runGUIOfflineInstallTest({
         logger.info("Installation timed out after 45 minutes");
       }
       const completed = await eimRunner.findByText(
-        "Offline Installation Complete",
+        tGui("offlineInstaller.installation.success.title"),
       );
       expect(completed, "Expected installation to be completed").to.not.be
         .false;
@@ -238,7 +255,9 @@ export function runGUIOfflineInstallTest({
 
     it("5- Should return to dashboard once completed.", async function () {
       this.timeout(10000);
-      await eimRunner.clickButton("Complete Installation");
+      await eimRunner.clickButton(
+        tGui("offlineInstaller.installation.success.complete"),
+      );
       await new Promise((resolve) => setTimeout(resolve, 2000));
       const cards = await eimRunner.findMultipleByClass("n-card");
       let versionsList = [];

--- a/tests/scripts/GUIPrerequisite.test.js
+++ b/tests/scripts/GUIPrerequisite.test.js
@@ -3,6 +3,7 @@ import { describe, it, before, after, afterEach } from "mocha";
 import GUITestRunner from "../classes/GUITestRunner.class.js";
 import logger from "../classes/logger.class.js";
 import os from "os";
+import { tGui } from "../helpers/i18n.js";
 
 // This function verifies the EIM GUI properly lists the missing prerequisites
 // On Windows, the prerequisites are installed as part of the test.
@@ -46,10 +47,10 @@ export function runGUIPrerequisitesTest({ id = 0, pathToEIM, prerequisites = [] 
 
     it("1- Should check prerequisites", async function () {
       this.timeout(25000);
-      await new Promise((resolve) => setTimeout(resolve, 10000));      
-      await eimRunner.clickButton("Start Installation");
-      await new Promise((resolve) => setTimeout(resolve, 2000));      
-      await eimRunner.clickButton("Start Configuration Wizard");
+      await new Promise((resolve) => setTimeout(resolve, 10000));
+      await eimRunner.clickButton(tGui("welcome.cards.new.button"));
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+      await eimRunner.clickButton(tGui("basicInstaller.cards.custom.button"));
       await new Promise((resolve) => setTimeout(resolve, 5000));
       const prerequisitesList = await eimRunner.findByDataId(
         "prerequisites-items-list"
@@ -66,7 +67,9 @@ export function runGUIPrerequisitesTest({ id = 0, pathToEIM, prerequisites = [] 
       if (os.platform() !== "win32") {
         this.skip();
       }
-      const installReqButton = await eimRunner.findByText("Install Missing Prerequisites");
+      const installReqButton = await eimRunner.findByText(
+        tGui("prerequisitiesCheck.actions.installMissing")
+      );
       expect(installReqButton, "Expected Install Missing Prerequisites button to be present").to.not.be.false;
 
     });
@@ -76,9 +79,11 @@ export function runGUIPrerequisitesTest({ id = 0, pathToEIM, prerequisites = [] 
       if (os.platform() !== "win32") {
         this.skip();
       }
-      const checkReqButton = await eimRunner.findByText("Check Prerequisites");
+      const checkReqButton = await eimRunner.findByText(
+        tGui("prerequisitiesCheck.actions.checkPrerequisites")
+      );
       expect(checkReqButton, "Expected check Prerequisites button to be present").to.not.be.false;
-      await eimRunner.clickButton("Check Prerequisites");
+      await eimRunner.clickButton(tGui("prerequisitiesCheck.actions.checkPrerequisites"));
       await new Promise((resolve) => setTimeout(resolve, 10000));
       const prerequisitesList = await eimRunner.findByDataId(
         "prerequisites-items-list"
@@ -95,9 +100,12 @@ export function runGUIPrerequisitesTest({ id = 0, pathToEIM, prerequisites = [] 
       if (os.platform() !== "win32") {
         this.skip();
       }
-      await eimRunner.clickButton("Install Missing Prerequisites");
+      await eimRunner.clickButton(tGui("prerequisitiesCheck.actions.installMissing"));
       await new Promise((resolve) => setTimeout(resolve, 2000));
-      const result = await eimRunner.findByText("Python Setup Required", 60000);
+      const result = await eimRunner.findByText(
+        tGui("pythonSanitycheck.status.setupRequired.title"),
+        60000
+      );
       expect(result, "Expected python check screen").to.not.be.false;
     });
   });

--- a/tests/scripts/GUIPythonCheck.test.js
+++ b/tests/scripts/GUIPythonCheck.test.js
@@ -3,6 +3,7 @@ import { describe, it, before, after, afterEach } from "mocha";
 import GUITestRunner from "../classes/GUITestRunner.class.js";
 import logger from "../classes/logger.class.js";
 import os from "os";
+import { tGui } from "../helpers/i18n.js";
 
 // This function verifies the EIM GUI properly lists the missing python installation
 // On Windows, the python is installed as part of the test.
@@ -44,20 +45,24 @@ export function runGUIPythonCheckTest({ id = 0, pathToEIM}) {
 
     it("1- Should check python requirement", async function () {
       this.timeout(25000);
-      await new Promise((resolve) => setTimeout(resolve, 10000));      
-      await eimRunner.clickButton("Start Installation");
-      await new Promise((resolve) => setTimeout(resolve, 2000));      
-      await eimRunner.clickButton("Start Configuration Wizard");
-      await new Promise((resolve) => setTimeout(resolve, 5000));      
+      await new Promise((resolve) => setTimeout(resolve, 10000));
+      await eimRunner.clickButton(tGui("welcome.cards.new.button"));
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+      await eimRunner.clickButton(tGui("basicInstaller.cards.custom.button"));
+      await new Promise((resolve) => setTimeout(resolve, 5000));
       const result = await eimRunner.findByDataId("python-check-result");
-      expect(await result.getText()).to.include("Python Setup Required");
+      expect(await result.getText()).to.include(
+        tGui("pythonSanitycheck.status.setupRequired.title")
+      );
     });
 
     it("2- Should show option to install python on Windows", async function () {
       if (os.platform() !== "win32") {
         this.skip();
       }
-      const installpythonButton = await eimRunner.findByText("Install Python");
+      const installpythonButton = await eimRunner.findByText(
+        tGui("pythonSanitycheck.actions.installPython")
+      );
       expect(installpythonButton, "Expected Install Python button to be present").to.not.be.false;
     });
 
@@ -66,9 +71,9 @@ export function runGUIPythonCheckTest({ id = 0, pathToEIM}) {
       if (os.platform() !== "win32") {
         this.skip();
       }
-      await eimRunner.clickButton("Install Python");
+      await eimRunner.clickButton(tGui("pythonSanitycheck.actions.installPython"));
       await new Promise((resolve) => setTimeout(resolve, 2000));
-      const result = await eimRunner.findByText("Select Target Chips", 450000);
+      const result = await eimRunner.findByText(tGui("targetSelect.title"), 450000);
       expect(result, "Expected Select Target Chips text to be present").to.not.be.false;
     });
   });

--- a/tests/scripts/GUISimplifiedInstall.test.js
+++ b/tests/scripts/GUISimplifiedInstall.test.js
@@ -3,6 +3,7 @@ import { describe, it, before, after, afterEach } from "mocha";
 import GUITestRunner from "../classes/GUITestRunner.class.js";
 import TestProxy from "../classes/TestProxy.class.js";
 import logger from "../classes/logger.class.js";
+import { tGui } from "../helpers/i18n.js";
 
 // This function executes the simplified installation functionality of the EIM GUI
 // No parameter is changed as part of this test
@@ -84,21 +85,23 @@ export function runGUISimplifiedInstallTest({
       expect(header, "Expected welcome header").to.not.be.false;
       const text = await header.getText();
       expect(text, "Expected welcome text").to.equal(
-        "Welcome to ESP-IDF Installation Manager"
+        `${tGui("welcome.welcome")} ESP-IDF ${tGui("welcome.title")}`
       );
     });
 
     it("2- Should show installation options", async function () {
       this.timeout(10000);
 
-      await eimRunner.clickButton("Start Installation");
+      await eimRunner.clickButton(tGui("welcome.cards.new.button"));
       await new Promise((resolve) => setTimeout(resolve, 2000));
       const header = await eimRunner.findByCSS("h1");
       const text = await header.getText();
       expect(text, "Expected installation setup screen").to.equal(
-        "Install ESP-IDF"
+        tGui("basicInstaller.title")
       );
-      const simplified = await eimRunner.findByText("Easy Installation");
+      const simplified = await eimRunner.findByText(
+        tGui("basicInstaller.cards.easy.title")
+      );
       expect(simplified, "Expected option for simplified installation").to.not
         .be.false;
       expect(
@@ -110,14 +113,16 @@ export function runGUISimplifiedInstallTest({
     it("3- Should show installation summary", async function () {
       this.timeout(35000);
 
-      await eimRunner.clickButton("Start Easy Installation");
+      await eimRunner.clickButton(tGui("basicInstaller.cards.easy.button"));
       await new Promise((resolve) => setTimeout(resolve, 25000));
       const header = await eimRunner.findByCSS("h2");
       const text = await header.getText();
       expect(text, "Expected installation summary screen").to.equal(
-        "Ready to Install"
+        tGui("simpleSetup.ready.title")
       );
-      const startButton = await eimRunner.findByText("Start Installation");
+      const startButton = await eimRunner.findByText(
+        tGui("simpleSetup.ready.startButton")
+      );
       expect(startButton, "Expected button to start installation").to.not.be
         .false;
       expect(
@@ -128,10 +133,10 @@ export function runGUISimplifiedInstallTest({
 
     it("4- Should install IDF using simplified setup", async function () {
       this.timeout(2730000);
-      await eimRunner.clickButton("Start Installation");
+      await eimRunner.clickButton(tGui("simpleSetup.ready.startButton"));
       await new Promise((resolve) => setTimeout(resolve, 5000));
       const installing = await eimRunner.findByText(
-        "Downloading ESP-IDF",
+        tGui("simpleSetup.installation.steps.download.description"),
         20000
       );
 
@@ -144,11 +149,13 @@ export function runGUISimplifiedInstallTest({
 
       const startTime = Date.now();
       while (Date.now() - startTime < 2700000) {
-        if (await eimRunner.findByText("Installation Failed", 1000)) {
+        if (await eimRunner.findByText(tGui("simpleSetup.error.title"), 1000)) {
           logger.debug("failed!!!!");
           break;
         }
-        if (await eimRunner.findByText("Installation Complete!", 1000)) {
+        if (
+          await eimRunner.findByText(tGui("simpleSetup.complete.title"), 1000)
+        ) {
           logger.debug("Completed!!!");
           break;
         }
@@ -157,7 +164,9 @@ export function runGUISimplifiedInstallTest({
       if (Date.now() - startTime >= 2700000) {
         logger.info("Installation timed out after 45 minutes");
       }
-      const completed = await eimRunner.findByText("Installation Complete!");
+      const completed = await eimRunner.findByText(
+        tGui("simpleSetup.complete.title")
+      );
       expect(completed, "Expected installation to be completed").to.not.be
         .false;
       expect(
@@ -169,7 +178,7 @@ export function runGUISimplifiedInstallTest({
     it("5- Should show installation complete summary", async function () {
       this.timeout(10000);
       const documentationButton = await eimRunner.findByText(
-        "View Documentation"
+        tGui("simpleSetup.complete.buttons.documentation")
       );
       expect(documentationButton, "Expected button to show documentation").to
         .not.be.false;
@@ -177,7 +186,9 @@ export function runGUISimplifiedInstallTest({
         await documentationButton.isDisplayed(),
         "Expected Expected button to show documentation to be displayed"
       ).to.be.true;
-      const dashboardButton = await eimRunner.findByText("Go to Dashboard");
+      const dashboardButton = await eimRunner.findByText(
+        tGui("simpleSetup.complete.buttons.dashboard")
+      );
       expect(dashboardButton, "Expected button to return to dashboard").to.not
         .be.false;
       expect(

--- a/tests/scripts/GUIStartup.test.js
+++ b/tests/scripts/GUIStartup.test.js
@@ -3,6 +3,7 @@ import { describe, it, before, after, afterEach } from "mocha";
 import GUITestRunner from "../classes/GUITestRunner.class.js";
 import logger from "../classes/logger.class.js";
 import { getOSName, getArchitecture } from "../helper.js";
+import { tGui, xpathText } from "../helpers/i18n.js";
 
 // This function verifies the EIM GUI properly starts and displays the welcome page
 
@@ -46,7 +47,7 @@ export function runGUIStartupTest({ id = 0, pathToEIM, eimVersion }) {
       expect(header, "Expected welcome header").to.not.be.false;
       const text = await header.getText();
       expect(text, "Expected welcome text").to.equal(
-        "Welcome to ESP-IDF Installation Manager"
+        `${tGui("welcome.welcome")} ESP-IDF ${tGui("welcome.title")}`
       );
     });
 
@@ -54,15 +55,13 @@ export function runGUIStartupTest({ id = 0, pathToEIM, eimVersion }) {
       const footer = await eimRunner.findByClass("app-footer");
       const text = await footer.getText();
       expect(text, "Expected correct version shown on page").to.include(
-        `ESP-IDF Installation Manager v${eimVersion}`
+        tGui("footer.app.version", { version: eimVersion })
       );
     });
 
     it("3- Should show option to hide welcome page", async function () {
-      const hideWelcome = await eimRunner.findByText(
-        "show this welcome screen again",
-        20000
-      );
+      const dontShowText = xpathText("welcome.preferences.dontShow");
+      const hideWelcome = await eimRunner.findByText(dontShowText, 20000);
       expect(hideWelcome, "Expected option to hide welcome page").to.not.be
         .false;
       const isDisplayed = await hideWelcome.isDisplayed();
@@ -70,7 +69,7 @@ export function runGUIStartupTest({ id = 0, pathToEIM, eimVersion }) {
       const checkBox = await eimRunner.findByRelation(
         "parent",
         "div",
-        "show this welcome screen again"
+        dontShowText
       );
       const checked = await checkBox.getAttribute("class");
       expect(checked, "Expected checkbox to be unchecked").to.not.include(
@@ -80,7 +79,7 @@ export function runGUIStartupTest({ id = 0, pathToEIM, eimVersion }) {
 
     it("4- Should show usage statistics opt-in (off with do-not-track)", async function () {
       const allowStatistics = await eimRunner.findByText(
-        "Allow sending usage statistics",
+        tGui("welcome.preferences.allowTracking"),
         20000
       );
       expect(
@@ -103,7 +102,7 @@ export function runGUIStartupTest({ id = 0, pathToEIM, eimVersion }) {
       const documentationLink = await eimRunner.findByRelation(
         "parent",
         "a",
-        "Documentation"
+        tGui("footer.buttons.documentation")
       );
       expect(documentationLink, "Expected Documentation link in footer").to.not
         .be.false;
@@ -111,14 +110,14 @@ export function runGUIStartupTest({ id = 0, pathToEIM, eimVersion }) {
       const logsButton = await eimRunner.findByRelation(
         "parent",
         "button",
-        "Logs"
+        tGui("footer.buttons.logs")
       );
       expect(logsButton, "Expected Logs button in footer").to.not.be.false;
 
       const reportIssueButton = await eimRunner.findByRelation(
         "parent",
         "button",
-        "Report Issue"
+        tGui("footer.buttons.reportIssue")
       );
       expect(reportIssueButton, "Expected Report Issue button in footer").to.not
         .be.false;
@@ -126,16 +125,20 @@ export function runGUIStartupTest({ id = 0, pathToEIM, eimVersion }) {
       const aboutButton = await eimRunner.findByRelation(
         "parent",
         "button",
-        "About"
+        tGui("footer.buttons.about")
       );
       expect(aboutButton, "Expected About button in footer").to.not.be.false;
     });
 
     it("6 - Should allow reporting an issue from the footer link and attach OS information", async function () {
       this.timeout(10000);
-      await eimRunner.clickButton("Report Issue");
+      await eimRunner.clickButton(tGui("footer.buttons.reportIssue"));
       await new Promise((resolve) => setTimeout(resolve, 3000));
-      const OSData = await eimRunner.findByRelation("parent", "div", "OS");
+      const OSData = await eimRunner.findByRelation(
+        "parent",
+        "div",
+        tGui("footer.modal.report.labels.os")
+      );
       const osText = await OSData.getText();
       expect(osText, "Expected OS information to be present").to.include(
         getOSName()
@@ -144,7 +147,7 @@ export function runGUIStartupTest({ id = 0, pathToEIM, eimVersion }) {
       const architectureData = await eimRunner.findByRelation(
         "parent",
         "div",
-        "Architecture"
+        tGui("footer.modal.report.labels.arch")
       );
       const architectureText = await architectureData.getText();
       expect(
@@ -155,16 +158,18 @@ export function runGUIStartupTest({ id = 0, pathToEIM, eimVersion }) {
       const appVersionData = await eimRunner.findByRelation(
         "parent",
         "div",
-        "App Version"
+        tGui("footer.modal.report.labels.appVersion")
       );
       const appVersionText = await appVersionData.getText();
       expect(
         appVersionText,
         "Expected App Version information to be present"
       ).to.include(eimVersion);
-      await eimRunner.clickButton("Cancel");
+      await eimRunner.clickButton(tGui("footer.modal.report.buttons.cancel"));
       await new Promise((resolve) => setTimeout(resolve, 1000));
-      const generateButton = await eimRunner.findByText("Generate Report");
+      const generateButton = await eimRunner.findByText(
+        tGui("footer.modal.report.buttons.generate")
+      );
       expect(
         generateButton,
         "Expected Generate Report button to not be present after cancel"
@@ -173,10 +178,10 @@ export function runGUIStartupTest({ id = 0, pathToEIM, eimVersion }) {
 
     it("7- Should show application information when clicking on about", async function () {
       this.timeout(5000);
-      await eimRunner.clickButton("About");
+      await eimRunner.clickButton(tGui("footer.buttons.about"));
       await new Promise((resolve) => setTimeout(resolve, 3000));
       const aboutText = await eimRunner.findByText(
-        "A cross-platform tool for installing and managing ESP-IDF development environment"
+        tGui("footer.modal.about.description.line1")
       );
       expect(aboutText, "Expected about text to be present").to.not.be.false;
     });

--- a/tests/scripts/GUIVersionManagement.test.js
+++ b/tests/scripts/GUIVersionManagement.test.js
@@ -2,6 +2,7 @@ import { expect } from "chai";
 import { describe, it, before, after, afterEach } from "mocha";
 import GUITestRunner from "../classes/GUITestRunner.class.js";
 import logger from "../classes/logger.class.js";
+import { tGui, matchable } from "../helpers/i18n.js";
 import { By } from "selenium-webdriver";
 import fs from "fs";
 import path from "path";
@@ -70,18 +71,22 @@ export function runGUIVersionManagementTest({
       expect(header, "Expected welcome header").to.not.be.false;
       const text = await header.getText();
       expect(text, "Expected welcome text").to.equal(
-        "Welcome to ESP-IDF Installation Manager"
+        `${tGui("welcome.welcome")} ESP-IDF ${tGui("welcome.title")}`
       );
     });
 
     it("2- Should show option to manage installations", async function () {
       this.timeout(10000);
-      const dashboardCard = await eimRunner.findByText("Manage Installations");
+      const dashboardCard = await eimRunner.findByText(
+        tGui("welcome.cards.manage.title")
+      );
       expect(
         dashboardCard,
         "Expected dashboard card to be shown on welcome page"
       ).to.not.be.false;
-      const dashboardContent = await eimRunner.findByText("View and manage");
+      const dashboardContent = await eimRunner.findByText(
+        matchable("welcome.cards.manage.description")
+      );
       const text = await dashboardContent.getText();
       const numberMatch = text.match(/\d+/);
       totalInstallations = numberMatch ? parseInt(numberMatch[0], 10) : 0;
@@ -89,7 +94,9 @@ export function runGUIVersionManagementTest({
         totalInstallations,
         "Expected at least one installation"
       ).to.be.gte(1);
-      const click = await eimRunner.clickButton("Open Dashboard");
+      const click = await eimRunner.clickButton(
+        tGui("welcome.cards.manage.button")
+      );
       await new Promise((resolve) => setTimeout(resolve, 1000));
       expect(click, "Expected to click on Open Dashboard button").to.be.true;
     });
@@ -161,7 +168,9 @@ export function runGUIVersionManagementTest({
       await input.sendKeys(Key.CONTROL + "a");
       await input.sendKeys(Key.BACK_SPACE);
       await input.sendKeys("NewName");
-      await eimRunner.clickElement("Rename");
+      await eimRunner.clickElement(
+        tGui("versionManagement.modals.rename.confirmButton")
+      );
       await new Promise((resolve) => setTimeout(resolve, 1000));
       let renameVersionsList = [];
       for (let card of cards) {
@@ -206,13 +215,17 @@ export function runGUIVersionManagementTest({
         removeButton
       );
       await new Promise((resolve) => setTimeout(resolve, 1000));
-      const confirmation = await eimRunner.findByText("Are you sure");
+      const confirmation = await eimRunner.findByText(
+        matchable("versionManagement.modals.remove.message")
+      );
       const confirmationText = await confirmation.getText();
       expect(
         confirmationText.includes(IDFToDeleteText),
         `Expected confirmation dialog to mention IDF version ${IDFToDeleteText}`
       ).to.be.true;
-      await eimRunner.clickElement("Remove");
+      await eimRunner.clickElement(
+        tGui("versionManagement.modals.remove.confirmButton")
+      );
       await new Promise((resolve) => setTimeout(resolve, 20000));
 
       const updatedCards = await eimRunner.findMultipleByClass("n-card");
@@ -263,8 +276,9 @@ export function runGUIVersionManagementTest({
       const quickActions = await eimRunner.findByClass("quick-actions");
       expect(quickActions, "Expected to find quick actions section").to.not.be
         .false;
+      const purgeAllText = tGui("versionManagement.quickActions.purgeAll");
       const purgeButton = await quickActions
-        .findElement(By.xpath(`//*[contains(text(), 'Purge All')]`))
+        .findElement(By.xpath(`//*[contains(text(), '${purgeAllText}')]`))
         .catch(() => false);
       await eimRunner.driver.executeScript(
         "arguments[0].click();",
@@ -273,13 +287,13 @@ export function runGUIVersionManagementTest({
       await new Promise((resolve) => setTimeout(resolve, 500));
 
       const confirmation = await eimRunner.findByText(
-        "This will remove ALL ESP-IDF installations!"
+        tGui("versionManagement.modals.purge.warning")
       );
       expect(confirmation, "Expected to find confirmation dialog for purge all")
         .to.not.be.false;
 
       const confirmationIDFList = await eimRunner.findByText(
-        "The following installations will be deleted"
+        matchable("versionManagement.modals.purge.listMessage")
       );
       const confirmationIDFListText = await confirmationIDFList.getText();
       for (let idfVersion of purgeVersionsList) {
@@ -289,12 +303,14 @@ export function runGUIVersionManagementTest({
         ).to.be.true;
       }
 
-      await eimRunner.clickElement("I understand this action cannot be undone");
+      await eimRunner.clickElement(
+        tGui("versionManagement.modals.purge.confirmation")
+      );
       await new Promise((resolve) => setTimeout(resolve, 500));
       const buttons = await eimRunner.driver.wait(
         until.elementsLocated(
           By.xpath(
-            `//*[contains(text(), 'Purge All')]/ancestor-or-self::button`
+            `//*[contains(text(), '${purgeAllText}')]/ancestor-or-self::button`
           )
         )
       );
@@ -302,7 +318,7 @@ export function runGUIVersionManagementTest({
       await new Promise((resolve) => setTimeout(resolve, 500));
 
       const noInstalls = await eimRunner.findByText(
-        "No ESP-IDF versions installed",
+        tGui("versionManagement.sections.noVersions"),
         45000
       );
       expect(noInstalls, "Expected to find no installations message").to.not.be


### PR DESCRIPTION
## Summary

GUI tests no longer hardcode UI copy. They now resolve strings through a thin test-only helper (`tests/helpers/i18n.js`) that reads the same `src/locales/{en,cn}.json` files the production app loads via `vue-i18n`. Change a string in the locale file and the tests follow automatically.

## Why a helper (and not `vue-i18n` directly)

- **No prod helper to reuse.** The app just renders translations via `vue-i18n`'s `t()` / `$t()`; nothing in `src/` resolves keys for comparison. That's a test-only need.
- **`vue-i18n` could do the lookup, but lookup isn't the hard part.** The helper's value is the two wrappers that sit *on top of* lookup:
  - `matchable(key)` — returns the portion before the first `{var}` or `<tag>`. Needed because Selenium's `getText()` strips HTML and dynamic values are unknown at assert time.
  - `xpathText(key)` — returns the longest apostrophe-free segment. Needed because `GUITestRunner` builds XPath 1.0 expressions with single-quoted literals, which can't contain `'` (e.g. "Don't show…").
  Neither is something `vue-i18n` offers; they'd live in a test wrapper regardless.
- **Fail-loud is a feature in tests.** Prod has `fallbackLocale: "en"` and silently returns the key on miss. Tests *want* a missing/renamed key to throw immediately thats what catches locale drift. The helper throws on missing keys and missing `{var}` values.
- **Node 20.x CI compatibility.** Uses `fs.readFileSync` + `JSON.parse` instead of `import … with { type: "json" }`, which isn't stable on every Node 20.x minor we run.

Net: the lookup slice of the helper is ~20 lines of boring code; the Selenium-specific bits are the actual payoff.

## What changed

- **New:** `tests/helpers/i18n.js`exports `tGui`, `matchable`, `xpathText`.
- **Refactored (8 files):** all `GUI*.test.js` scripts under `tests/scripts/` to resolve UI assertions through the helper instead of inline string literals.
- **No production code changes** beyond flagging a couple of missing/hardcoded strings in components for follow-up (noted inline as `NOTE(EIM-661)`).

## Scope notes

- GUI/Vue side only. Rust/CLI strings are not touched yet