### PR TITLE
Fix  tests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -165,6 +165,10 @@ jobs:
           ZLIB_STATIC: 1
           LZMA_API_STATIC: 1
           APP_INSIGHTS_CONNECTION_STRING: ${{ secrets.APP_INSIGHTS_CONNECTION_STRING }}
+          # gix-specific environment variables
+          GIX_HTTP_TIMEOUT: "60"
+          GIX_MAX_CONNECTIONS: "1"
+          RUST_HTTP_PROTOCOL: "http/1.1"  # Disable HTTP/2 which can have issues on ARM
         run: |
           cd src-tauri
           unset PKG_CONFIG_PATH && export ZLIB_STATIC=1 && export LZMA_API_STATIC=1 && export LIBZ_SYS_STATIC=1 && cargo build --release --no-default-features --features cli ${{ matrix.target && format('--target {0}', matrix.target) || '' }}
@@ -348,6 +352,9 @@ jobs:
           ZLIB_STATIC: 1
           LZMA_API_STATIC: 1
           APP_INSIGHTS_CONNECTION_STRING: ${{ secrets.APP_INSIGHTS_CONNECTION_STRING }}
+          GIX_HTTP_TIMEOUT: "60"
+          GIX_MAX_CONNECTIONS: "1"
+          RUST_HTTP_PROTOCOL: "http/1.1"  # Disable HTTP/2 which can have issues on ARM
         run: |
           cd src-tauri
           cross build --release --no-default-features --features cli --target ${{ env.CROSS_TARGET }}
@@ -411,6 +418,9 @@ jobs:
           LIBZ_SYS_STATIC: 1
           ZLIB_STATIC: 1
           LZMA_API_STATIC: 1
+          GIX_HTTP_TIMEOUT: "60"
+          GIX_MAX_CONNECTIONS: "1"
+          RUST_HTTP_PROTOCOL: "http/1.1"  # Disable HTTP/2 which can have issues on ARM
         run: |
           cd src-tauri
           cross build --release --no-default-features --features offline --bin offline_installer_builder --target ${{ env.CROSS_TARGET }}
@@ -728,6 +738,9 @@ jobs:
           LIBZ_SYS_STATIC: 1
           ZLIB_STATIC: 1
           APP_INSIGHTS_CONNECTION_STRING: ${{ secrets.APP_INSIGHTS_CONNECTION_STRING }}
+          GIX_HTTP_TIMEOUT: "60"
+          GIX_MAX_CONNECTIONS: "1"
+          RUST_HTTP_PROTOCOL: "http/1.1"  # Disable HTTP/2 which can have issues on ARM
         run: |
           cd src-tauri
           unset PKG_CONFIG_PATH && export ZLIB_STATIC=1 && export LZMA_API_STATIC=1 && export LIBZ_SYS_STATIC=1 && cargo build --release --no-default-features --features cli ${{ matrix.target && format('--target {0}', matrix.target) || '' }}
@@ -807,54 +820,6 @@ jobs:
           notarization-username: ${{ secrets.MACOS_CS_APPLE_ID }}
           notarization-password: ${{ secrets.MACOS_CS_APP_SPECIFIC_PASSWORD }}
           notarization-team-id: ${{ secrets.MACOS_CS_APPLE_TEAM_ID }}
-
-      # - name: Codesign macOS Binary
-      #   if: startsWith(matrix.os, 'macos')
-      #   env:
-      #     MACOS_CERTIFICATE: ${{ secrets.MACOS_CS_CERTIFICATE }}
-      #     MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CS_CERTIFICATE_PWD }}
-      #     APPLE_TEAM_ID: ${{ secrets.MACOS_CS_APPLE_TEAM_ID }}
-      #   run: |
-      #     set -euo pipefail
-
-      #     echo "$MACOS_CERTIFICATE" | base64 --decode > certificate.p12
-
-      #     # Create (if needed) and configure the keychain
-      #     security list-keychains | grep -q "build.keychain" || security create-keychain -p espressif build.keychain
-      #     security default-keychain -s build.keychain
-      #     security unlock-keychain -p espressif build.keychain
-      #     security set-keychain-settings -lut 21600 build.keychain
-
-      #     # Make sure codesign actually searches this keychain
-      #     security list-keychains -d user -s build.keychain login.keychain
-
-      #     # Import cert and allow codesign to use it non-interactively
-      #     security import certificate.p12 -k build.keychain -P "$MACOS_CERTIFICATE_PWD" -T /usr/bin/codesign
-      #     security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k espressif build.keychain
-
-      #     # Verify the identity is actually present before signing (fails fast with a clearer error)
-      #     security find-identity -v -p codesigning build.keychain
-
-      #     codesign --entitlements eim.entitlement --options runtime --force \
-      #       -s "ESPRESSIF SYSTEMS (SHANGHAI) CO., LTD. ($APPLE_TEAM_ID)" \
-      #       release_cli/${{ matrix.package_name }}/eim -v
-      #     codesign -v -vvv --deep release_cli/${{ matrix.package_name }}/eim
-
-      # - name: Notarize macOS Binary
-      #   if: startsWith(matrix.os, 'macos') && github.event_name == 'release'
-      #   env:
-      #     NOTARIZATION_USERNAME: ${{ secrets.MACOS_CS_APPLE_ID }}
-      #     NOTARIZATION_PASSWORD: ${{ secrets.MACOS_CS_APP_SPECIFIC_PASSWORD }}
-      #     NOTARIZATION_TEAM_ID: ${{ secrets.MACOS_CS_APPLE_TEAM_ID }}
-      #   run: |
-      #     cd release_cli/${{ matrix.package_name }}
-      #     zip -r eim.zip eim
-      #     security create-keychain -p espressif notary.keychain
-      #     security default-keychain -s notary.keychain
-      #     security unlock-keychain -p espressif notary.keychain
-      #     xcrun notarytool store-credentials "eim-notarytool-profile" --apple-id $NOTARIZATION_USERNAME --team-id $NOTARIZATION_TEAM_ID --password $NOTARIZATION_PASSWORD
-      #     xcrun notarytool submit eim.zip --keychain-profile "eim-notarytool-profile" --wait
-      #     unzip -o eim.zip -d .
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
@@ -962,21 +927,6 @@ jobs:
           notarization-username: ${{ secrets.MACOS_CS_APPLE_ID }}
           notarization-password: ${{ secrets.MACOS_CS_APP_SPECIFIC_PASSWORD }}
           notarization-team-id: ${{ secrets.MACOS_CS_APPLE_TEAM_ID }}
-
-      # - name: Codesign macOS offline_installer_builder Binary
-      #   if: startsWith(matrix.os, 'macos')
-      #   env:
-      #     MACOS_CERTIFICATE: ${{ secrets.MACOS_CS_CERTIFICATE }}
-      #     MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CS_CERTIFICATE_PWD }}
-      #   run: |
-      #     echo $MACOS_CERTIFICATE | base64 --decode > certificate_offline.p12
-      #     security create-keychain -p espressif build_offline.keychain
-      #     security default-keychain -s build_offline.keychain
-      #     security unlock-keychain -p espressif build_offline.keychain
-      #     security import certificate_offline.p12 -k build_offline.keychain -P $MACOS_CERTIFICATE_PWD -T /usr/bin/codesign
-      #     security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k espressif build_offline.keychain
-      #     codesign --entitlements eim.entitlement --options runtime --force -s "ESPRESSIF SYSTEMS (SHANGHAI) CO., LTD. (QWXF6GB4AV)" release_cli/${{ matrix.package_name }}/offline_installer_builder -v
-      #     codesign -v -vvv --deep release_cli/${{ matrix.package_name }}/offline_installer_builder
 
       - name: Upload offline_installer_builder build artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -795,36 +795,66 @@ jobs:
           /pa `
           "$exePath"
 
-      - name: Codesign macOS Binary
-        if: startsWith(matrix.os, 'macos')
-        env:
-          MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
-          MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
-        run: |
-          echo $MACOS_CERTIFICATE | base64 --decode > certificate.p12
-          security list-keychains | grep -q "build.keychain" || security create-keychain -p espressif build.keychain
-          security default-keychain -s build.keychain
-          security unlock-keychain -p espressif build.keychain
-          security import certificate.p12 -k build.keychain -P $MACOS_CERTIFICATE_PWD -T /usr/bin/codesign
-          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k espressif build.keychain
-          codesign --entitlements eim.entitlement --options runtime --force -s "ESPRESSIF SYSTEMS (SHANGHAI) CO., LTD. (QWXF6GB4AV)" release_cli/${{ matrix.package_name }}/eim -v
-          codesign -v -vvv --deep release_cli/${{ matrix.package_name }}/eim
+      - name: Sign files
+        uses: espressif/release-sign@master
+        if: startsWith(matrix.os, 'macos') && github.event_name == 'release' && github.event.action == 'created'
+        with:
+          path: ./release_cli/${{ matrix.package_name }}
+          macos-signing-identity: ${{ secrets.MACOS_CS_IDENTITY_ID }}
+          macos-certificate: ${{ secrets.MACOS_CS_CERTIFICATE }}
+          macos-certificate-pwd: ${{ secrets.MACOS_CS_CERTIFICATE_PWD }}
+          macos-entitlements: eim.entitlement   # optional
+          notarization-username: ${{ secrets.MACOS_CS_APPLE_ID }}
+          notarization-password: ${{ secrets.MACOS_CS_APP_SPECIFIC_PASSWORD }}
+          notarization-team-id: ${{ secrets.MACOS_CS_APPLE_TEAM_ID }}
 
-      - name: Notarize macOS Binary
-        if: startsWith(matrix.os, 'macos') && github.event_name == 'release'
-        env:
-          NOTARIZATION_USERNAME: ${{ secrets.NOTARIZATION_USERNAME }}
-          NOTARIZATION_PASSWORD: ${{ secrets.NOTARIZATION_PASSWORD }}
-          NOTARIZATION_TEAM_ID: ${{ secrets.NOTARIZATION_TEAM_ID }}
-        run: |
-          cd release_cli/${{ matrix.package_name }}
-          zip -r eim.zip eim
-          security create-keychain -p espressif notary.keychain
-          security default-keychain -s notary.keychain
-          security unlock-keychain -p espressif notary.keychain
-          xcrun notarytool store-credentials "eim-notarytool-profile" --apple-id $NOTARIZATION_USERNAME --team-id $NOTARIZATION_TEAM_ID --password $NOTARIZATION_PASSWORD
-          xcrun notarytool submit eim.zip --keychain-profile "eim-notarytool-profile" --wait
-          unzip -o eim.zip -d .
+      # - name: Codesign macOS Binary
+      #   if: startsWith(matrix.os, 'macos')
+      #   env:
+      #     MACOS_CERTIFICATE: ${{ secrets.MACOS_CS_CERTIFICATE }}
+      #     MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CS_CERTIFICATE_PWD }}
+      #     APPLE_TEAM_ID: ${{ secrets.MACOS_CS_APPLE_TEAM_ID }}
+      #   run: |
+      #     set -euo pipefail
+
+      #     echo "$MACOS_CERTIFICATE" | base64 --decode > certificate.p12
+
+      #     # Create (if needed) and configure the keychain
+      #     security list-keychains | grep -q "build.keychain" || security create-keychain -p espressif build.keychain
+      #     security default-keychain -s build.keychain
+      #     security unlock-keychain -p espressif build.keychain
+      #     security set-keychain-settings -lut 21600 build.keychain
+
+      #     # Make sure codesign actually searches this keychain
+      #     security list-keychains -d user -s build.keychain login.keychain
+
+      #     # Import cert and allow codesign to use it non-interactively
+      #     security import certificate.p12 -k build.keychain -P "$MACOS_CERTIFICATE_PWD" -T /usr/bin/codesign
+      #     security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k espressif build.keychain
+
+      #     # Verify the identity is actually present before signing (fails fast with a clearer error)
+      #     security find-identity -v -p codesigning build.keychain
+
+      #     codesign --entitlements eim.entitlement --options runtime --force \
+      #       -s "ESPRESSIF SYSTEMS (SHANGHAI) CO., LTD. ($APPLE_TEAM_ID)" \
+      #       release_cli/${{ matrix.package_name }}/eim -v
+      #     codesign -v -vvv --deep release_cli/${{ matrix.package_name }}/eim
+
+      # - name: Notarize macOS Binary
+      #   if: startsWith(matrix.os, 'macos') && github.event_name == 'release'
+      #   env:
+      #     NOTARIZATION_USERNAME: ${{ secrets.MACOS_CS_APPLE_ID }}
+      #     NOTARIZATION_PASSWORD: ${{ secrets.MACOS_CS_APP_SPECIFIC_PASSWORD }}
+      #     NOTARIZATION_TEAM_ID: ${{ secrets.MACOS_CS_APPLE_TEAM_ID }}
+      #   run: |
+      #     cd release_cli/${{ matrix.package_name }}
+      #     zip -r eim.zip eim
+      #     security create-keychain -p espressif notary.keychain
+      #     security default-keychain -s notary.keychain
+      #     security unlock-keychain -p espressif notary.keychain
+      #     xcrun notarytool store-credentials "eim-notarytool-profile" --apple-id $NOTARIZATION_USERNAME --team-id $NOTARIZATION_TEAM_ID --password $NOTARIZATION_PASSWORD
+      #     xcrun notarytool submit eim.zip --keychain-profile "eim-notarytool-profile" --wait
+      #     unzip -o eim.zip -d .
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
@@ -921,19 +951,32 @@ jobs:
           "$exePath"
 
       - name: Codesign macOS offline_installer_builder Binary
-        if: startsWith(matrix.os, 'macos')
-        env:
-          MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
-          MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
-        run: |
-          echo $MACOS_CERTIFICATE | base64 --decode > certificate_offline.p12
-          security create-keychain -p espressif build_offline.keychain
-          security default-keychain -s build_offline.keychain
-          security unlock-keychain -p espressif build_offline.keychain
-          security import certificate_offline.p12 -k build_offline.keychain -P $MACOS_CERTIFICATE_PWD -T /usr/bin/codesign
-          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k espressif build_offline.keychain
-          codesign --entitlements eim.entitlement --options runtime --force -s "ESPRESSIF SYSTEMS (SHANGHAI) CO., LTD. (QWXF6GB4AV)" release_cli/${{ matrix.package_name }}/offline_installer_builder -v
-          codesign -v -vvv --deep release_cli/${{ matrix.package_name }}/offline_installer_builder
+        uses: espressif/release-sign@master
+        if: startsWith(matrix.os, 'macos') && github.event_name == 'release' && github.event.action == 'created'
+        with:
+          path: ./release_cli/${{ matrix.package_name }}/offline_installer_builder
+          macos-signing-identity: ${{ secrets.MACOS_CS_IDENTITY_ID }}
+          macos-certificate: ${{ secrets.MACOS_CS_CERTIFICATE }}
+          macos-certificate-pwd: ${{ secrets.MACOS_CS_CERTIFICATE_PWD }}
+          macos-entitlements: eim.entitlement   # optional
+          notarization-username: ${{ secrets.MACOS_CS_APPLE_ID }}
+          notarization-password: ${{ secrets.MACOS_CS_APP_SPECIFIC_PASSWORD }}
+          notarization-team-id: ${{ secrets.MACOS_CS_APPLE_TEAM_ID }}
+
+      # - name: Codesign macOS offline_installer_builder Binary
+      #   if: startsWith(matrix.os, 'macos')
+      #   env:
+      #     MACOS_CERTIFICATE: ${{ secrets.MACOS_CS_CERTIFICATE }}
+      #     MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CS_CERTIFICATE_PWD }}
+      #   run: |
+      #     echo $MACOS_CERTIFICATE | base64 --decode > certificate_offline.p12
+      #     security create-keychain -p espressif build_offline.keychain
+      #     security default-keychain -s build_offline.keychain
+      #     security unlock-keychain -p espressif build_offline.keychain
+      #     security import certificate_offline.p12 -k build_offline.keychain -P $MACOS_CERTIFICATE_PWD -T /usr/bin/codesign
+      #     security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k espressif build_offline.keychain
+      #     codesign --entitlements eim.entitlement --options runtime --force -s "ESPRESSIF SYSTEMS (SHANGHAI) CO., LTD. (QWXF6GB4AV)" release_cli/${{ matrix.package_name }}/offline_installer_builder -v
+      #     codesign -v -vvv --deep release_cli/${{ matrix.package_name }}/offline_installer_builder
 
       - name: Upload offline_installer_builder build artifacts
         uses: actions/upload-artifact@v4
@@ -1046,8 +1089,8 @@ jobs:
         if: startsWith(matrix.os, 'macos')
         uses: apple-actions/import-codesign-certs@v3
         with:
-          p12-file-base64: ${{ secrets.MACOS_CERTIFICATE }}
-          p12-password: ${{ secrets.MACOS_CERTIFICATE_PWD }}
+          p12-file-base64: ${{ secrets.MACOS_CS_CERTIFICATE }}
+          p12-password: ${{ secrets.MACOS_CS_CERTIFICATE_PWD }}
           keychain: build
 
       - name: Remove offline_installer_builder from Cargo.toml for GUI build (Linux/macOS)
@@ -1076,9 +1119,9 @@ jobs:
       - name: Build GUI (macOS) - release
         if: startsWith(matrix.os, 'macos') && github.event_name == 'release'
         env:
-          APPLE_ID: ${{ secrets.NOTARIZATION_USERNAME }}
-          APPLE_PASSWORD: ${{ secrets.NOTARIZATION_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.NOTARIZATION_TEAM_ID }}
+          APPLE_ID: ${{ secrets.MACOS_CS_APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.MACOS_CS_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.MACOS_CS_APPLE_TEAM_ID }}
           LIBZ_SYS_STATIC: 1
           ZLIB_STATIC: 1
           APP_INSIGHTS_CONNECTION_STRING: ${{ secrets.APP_INSIGHTS_CONNECTION_STRING }}

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1348,7 +1348,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1649,7 +1649,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2225,9 +2225,9 @@ dependencies = [
 
 [[package]]
 name = "gix"
-version = "0.81.0"
+version = "0.82.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0473c64d9ccbcfb9953a133b47c8b9a335b87ac6c52b983ee4b03d49000b0f3f"
+checksum = "62786b0500a7b8dfd998b5c9fc343e1133dc3804293db98e787f5442e8003591"
 dependencies = [
  "gix-actor",
  "gix-archive",
@@ -2285,21 +2285,21 @@ dependencies = [
 
 [[package]]
 name = "gix-actor"
-version = "0.40.0"
+version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e5e5b518339d5e6718af108fd064d4e9ba33caf728cf487352873d76411df35"
+checksum = "552ddba0ea986ef262ee3296a6464194181f20882902c8a7669515eaf1b0891e"
 dependencies = [
  "bstr",
  "gix-date",
  "gix-error",
- "winnow 0.7.15",
+ "winnow 1.0.2",
 ]
 
 [[package]]
 name = "gix-archive"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "651c99be11aac9b303483193ae50b45eb6e094da4f5ed797019b03948f51aad6"
+checksum = "af31eddd8d8842dc05e0ae1f35721f12484d2eaab7d989f183182280f2cc04af"
 dependencies = [
  "bstr",
  "gix-date",
@@ -2310,9 +2310,9 @@ dependencies = [
 
 [[package]]
 name = "gix-attributes"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c233d6eaa098c0ca5ce03236fd7a96e27f1abe72fad74b46003fbd11fe49563c"
+checksum = "4ac00bd435a36fcc518640dad4eca4045e1a2f0b33f74a2bbff58245f8e3744d"
 dependencies = [
  "bstr",
  "gix-glob",
@@ -2327,18 +2327,18 @@ dependencies = [
 
 [[package]]
 name = "gix-bitmap"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7add20f40d060db8c9b1314d499bac6ed7480f33eb113ce3e1cf5d6ff85d989"
+checksum = "1ecbfc77ec6852294e341ecc305a490b59f2813e6ca42d79efda5099dcab1894"
 dependencies = [
  "gix-error",
 ]
 
 [[package]]
 name = "gix-blame"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c77aaf9f7348f4da3ebfbfbbc35fa0d07155d98377856198dde6f695fd648705"
+checksum = "9d5789a39b8638b73e5c1210375910145bcf688f1786b7f71fbb1ff4cd51dc7d"
 dependencies = [
  "gix-commitgraph",
  "gix-date",
@@ -2356,18 +2356,18 @@ dependencies = [
 
 [[package]]
 name = "gix-chunk"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1096b6608fbe5d27fb4984e20f992b4e76fb8c613f6acb87d07c5831b53a6959"
+checksum = "edf288be9b60fe7231de03771faa292be1493d84786f68727e33ad1f91764320"
 dependencies = [
  "gix-error",
 ]
 
 [[package]]
 name = "gix-command"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b849c65a609f50d02f8a2774fe371650b3384a743c79c2a070ce0da49b7fb7da"
+checksum = "ae4bb9fa74c44c93f7238b08255f7f9afc158bafea4b95af665fa535352cd73c"
 dependencies = [
  "bstr",
  "gix-path",
@@ -2378,9 +2378,9 @@ dependencies = [
 
 [[package]]
 name = "gix-commitgraph"
-version = "0.35.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3196655fd1443f3c58a48c114aa480be3e4e87b393d7292daaa0d543862eb445"
+checksum = "c9dd13b8254d36049e9d1758657e74918a49de0286ec053d02497448fa215246"
 dependencies = [
  "bstr",
  "gix-chunk",
@@ -2392,9 +2392,9 @@ dependencies = [
 
 [[package]]
 name = "gix-config"
-version = "0.54.0"
+version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08939b4c4ed7a663d0e64be9e1e9bdf23a1fb4fcee1febdf449f12229542e50d"
+checksum = "f84ecbd673d9223a46e6bb766e0802ad9921de3541d95d121a9d05de5e23c8de"
 dependencies = [
  "bstr",
  "gix-config-value",
@@ -2407,14 +2407,14 @@ dependencies = [
  "smallvec",
  "thiserror 2.0.18",
  "unicode-bom",
- "winnow 0.7.15",
+ "winnow 1.0.2",
 ]
 
 [[package]]
 name = "gix-config-value"
-version = "0.17.1"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "441a300bc3645a1f45cba495b9175f90f47256ce43f2ee161da0031e3ac77c92"
+checksum = "4378c53ec3db049919edf91ff76f56f28886a8b4b4a5a9dc633108d84afc3675"
 dependencies = [
  "bitflags 2.11.1",
  "bstr",
@@ -2425,9 +2425,9 @@ dependencies = [
 
 [[package]]
 name = "gix-credentials"
-version = "0.37.1"
+version = "0.37.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b2a34b8715e3bbd514f3d1705f5d51c4b250e5bfe506b9fb60b133c85c93d9"
+checksum = "0493f25da3ce9e8f7d925e5b64dc6d0b6109c96add422a6bcada52416448147d"
 dependencies = [
  "bstr",
  "gix-command",
@@ -2443,9 +2443,9 @@ dependencies = [
 
 [[package]]
 name = "gix-date"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39acf819aa9fee65e4838a2eec5cb2506e47ebb89e02a5ab9918196e491571ea"
+checksum = "5cc99523b8bf32561b9abf72c878fbff3854d806ed46c1198e57899f9f3c7f05"
 dependencies = [
  "bstr",
  "gix-error",
@@ -2456,31 +2456,30 @@ dependencies = [
 
 [[package]]
 name = "gix-diff"
-version = "0.61.0"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88f3b3475e5d3877d7c30c40827cc2441936ce890efc226e5ba4afe3a7ae33f0"
+checksum = "709e2b8c52e027d553e200d07f39865b8d9799004160ea609459dc73c48f357a"
 dependencies = [
  "bstr",
  "gix-command",
  "gix-filter",
  "gix-fs",
  "gix-hash",
+ "gix-imara-diff",
  "gix-object",
  "gix-path",
  "gix-tempfile",
  "gix-trace",
  "gix-traverse",
  "gix-worktree",
- "imara-diff 0.1.8",
- "imara-diff 0.2.0",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gix-dir"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5da4604a360988f0ba8efe6f90093ca5a844f4a7f8e1a3dcda501ec44e600ea9"
+checksum = "9e5590f35265d28cc65faa0d36896ae467836e989b0e790dd94d51d2417e768c"
 dependencies = [
  "bstr",
  "gix-discover",
@@ -2498,9 +2497,9 @@ dependencies = [
 
 [[package]]
 name = "gix-discover"
-version = "0.49.0"
+version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c65bd3330fe0cb9d40d875bf862fd5e8ad6fa4164ddbc4842fbeb889c3f0b2c6"
+checksum = "31885140cb036e25742275f9848b9266a54d553103caec9f3546c62126214f45"
 dependencies = [
  "bstr",
  "dunce",
@@ -2513,18 +2512,18 @@ dependencies = [
 
 [[package]]
 name = "gix-error"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e86d01da904d4a9265def43bd42a18c5e6dc7000a73af512946ba14579c9fbd"
+checksum = "c998bf10447f0797e579567382b5e22a19c22435d2df091e25857728c6d9af8d"
 dependencies = [
  "bstr",
 ]
 
 [[package]]
 name = "gix-features"
-version = "0.46.2"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "752493cd4b1d5eaaa0138a7493f65c96863fefa990fc021e0e519579e389ab20"
+checksum = "5c0f40b8c98b4b592a7e9c83fe79eacbfcdae8485aa6148ff15e52a4b6e9fe30"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -2543,9 +2542,9 @@ dependencies = [
 
 [[package]]
 name = "gix-filter"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d37598282a6566da6fb52667570c7fe0aedcb122ac886724a9e62a2180523e35"
+checksum = "fdb4376a18f26bdc0fe88a719574c749a678074beda924571e24c5a83bb26e65"
 dependencies = [
  "bstr",
  "encoding_rs",
@@ -2564,9 +2563,9 @@ dependencies = [
 
 [[package]]
 name = "gix-fs"
-version = "0.19.2"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a964b4aec683eb0bacb87533defa80805bb4768056371a47ab38b00a2d377b72"
+checksum = "7464e9f4167e98d202c7cfb0b5ccbc170c6069870afc52bfd533ad265ce19872"
 dependencies = [
  "bstr",
  "fastrand",
@@ -2578,9 +2577,9 @@ dependencies = [
 
 [[package]]
 name = "gix-glob"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b03e6cd88cc0dc1eafa1fddac0fb719e4e74b6ea58dd016e71125fde4a326bee"
+checksum = "76beed0974ea539df93e44d10a6c7df0a9554f6e184dd730c33e65dc0e089614"
 dependencies = [
  "bitflags 2.11.1",
  "bstr",
@@ -2590,9 +2589,9 @@ dependencies = [
 
 [[package]]
 name = "gix-hash"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fb896a02d9ab96fa518475a5f30ad3952010f801a8de5840f633f4a6b985dfb"
+checksum = "0e3c92d6aa7a81bde221f3448e62b0e8d81a7d8086e85ccc24b3a4d54e315f30"
 dependencies = [
  "faster-hex",
  "gix-features",
@@ -2602,9 +2601,9 @@ dependencies = [
 
 [[package]]
 name = "gix-hashtable"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2664216fc5e89b51e756a4a3ac676315602ce2dac07acf1da959a22038d69b33"
+checksum = "08fe1e638b9b84b11eadfe60bdf5523bf46c40b3ef297e612a4a365832d3c8d3"
 dependencies = [
  "gix-hash",
  "hashbrown 0.16.1",
@@ -2613,9 +2612,9 @@ dependencies = [
 
 [[package]]
 name = "gix-ignore"
-version = "0.19.1"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f915dcf6911e3027537166d34e13f0fe101ed12225178d2ae29cd1272cff26"
+checksum = "f72fe2033f4cf8f784fb413c15c8d1124e84f1ddf4d292ffc8468b05d329a047"
 dependencies = [
  "bstr",
  "gix-glob",
@@ -2625,10 +2624,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "gix-index"
-version = "0.49.0"
+name = "gix-imara-diff"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bae54ab14e4e74d5dda60b82ea7afad7c8eb3be68283d6d5f29bd2e6d47fff7"
+checksum = "cfef60ebcd45e0fad3007d15b45a305e6a25af9a0fdffbca0b02bf8b0f91f83c"
+dependencies = [
+ "bstr",
+ "hashbrown 0.16.1",
+ "memchr",
+]
+
+[[package]]
+name = "gix-index"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806c10a84ef9e0e2955ec678b7ba157b9bec1185e6d5c200e14d3496f44e3874"
 dependencies = [
  "bitflags 2.11.1",
  "bstr",
@@ -2654,9 +2664,9 @@ dependencies = [
 
 [[package]]
 name = "gix-lock"
-version = "21.0.2"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054fbd0989700c69dc5aa80bc66944f05df1e15aa7391a9e42aca7366337905f"
+checksum = "75e30507ef152e30cec1d0f70cd00199fac746e3d448c3b39c9dade8446fa1da"
 dependencies = [
  "gix-tempfile",
  "gix-utils",
@@ -2665,9 +2675,9 @@ dependencies = [
 
 [[package]]
 name = "gix-merge"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4606747466512d22c2dffc019142e1941238f543987ea51353c938cca80c500"
+checksum = "c8305849c022c954af46029756ffb3afcabcaf0be13a3cf3e8bfd204f1fc2b48"
 dependencies = [
  "bstr",
  "gix-command",
@@ -2675,6 +2685,7 @@ dependencies = [
  "gix-filter",
  "gix-fs",
  "gix-hash",
+ "gix-imara-diff",
  "gix-index",
  "gix-object",
  "gix-path",
@@ -2684,16 +2695,15 @@ dependencies = [
  "gix-tempfile",
  "gix-trace",
  "gix-worktree",
- "imara-diff 0.1.8",
  "nonempty",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gix-negotiate"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea064c7595eea08fdd01c70748af747d9acc40f727b61f4c8a2145a5c5fc28c"
+checksum = "c7cfa5d5f56dea56f96ced9ea55976b66ce8580e7fbdd23f25e9c99bd3e90927"
 dependencies = [
  "bitflags 2.11.1",
  "gix-commitgraph",
@@ -2705,9 +2715,9 @@ dependencies = [
 
 [[package]]
 name = "gix-object"
-version = "0.58.0"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cafb802bb688a7c1e69ef965612ff5ff859f046bfb616377e4a0ba4c01e43d47"
+checksum = "710b16fe38cd3654ec218dd89911100648cd3f495e3997a1bbdc2af69ebf525a"
 dependencies = [
  "bstr",
  "gix-actor",
@@ -2715,20 +2725,19 @@ dependencies = [
  "gix-features",
  "gix-hash",
  "gix-hashtable",
- "gix-path",
  "gix-utils",
  "gix-validate",
  "itoa",
  "smallvec",
  "thiserror 2.0.18",
- "winnow 0.7.15",
+ "winnow 1.0.2",
 ]
 
 [[package]]
 name = "gix-odb"
-version = "0.78.0"
+version = "0.79.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24833ae9323b4f7079575fb9f961cf9c414b0afbec428a536ab8e7dd93bc002b"
+checksum = "7080f6ebcb0597c2c8bf7e3e0fd02c4df80260c4bfc50a8427f659129a9067b5"
 dependencies = [
  "arc-swap",
  "gix-features",
@@ -2739,6 +2748,7 @@ dependencies = [
  "gix-pack",
  "gix-path",
  "gix-quote",
+ "memmap2 0.9.10",
  "parking_lot",
  "tempfile",
  "thiserror 2.0.18",
@@ -2746,9 +2756,9 @@ dependencies = [
 
 [[package]]
 name = "gix-pack"
-version = "0.68.0"
+version = "0.69.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3484119cd19859d7d7639413c27e192478fa354d3f4ff5f7e3c041e8040f0f4"
+checksum = "d3f76daacd0e91a523dc741c4ef7b9355da67fd73167db831db1edd4720768b4"
 dependencies = [
  "clru",
  "gix-chunk",
@@ -2768,9 +2778,9 @@ dependencies = [
 
 [[package]]
 name = "gix-packetline"
-version = "0.21.2"
+version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be19313dcdb7dff75a3ce2f99be00878458295bcc3b6c7f0005591597573345c"
+checksum = "362246df440ee691699f0664cbf7006a6ece477db6734222be95e4198e5656e6"
 dependencies = [
  "bstr",
  "faster-hex",
@@ -2780,9 +2790,9 @@ dependencies = [
 
 [[package]]
 name = "gix-path"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09c31d4373bda7fab9eb01822927b55185a378d6e1bf737e0a54c743ad806658"
+checksum = "c8fd1fe596dc393b538e1d5492c5585971a9311475b3255f7b889023df208476"
 dependencies = [
  "bstr",
  "gix-trace",
@@ -2792,9 +2802,9 @@ dependencies = [
 
 [[package]]
 name = "gix-pathspec"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f89611f13544ca5ebeb68a502673814ef57200df60c24a61c2ce7b96f612f08b"
+checksum = "9d902b0cafb2b691738c585f0be98b1b73fad63644c6a612b9b2708bb7b1d17d"
 dependencies = [
  "bitflags 2.11.1",
  "bstr",
@@ -2807,9 +2817,9 @@ dependencies = [
 
 [[package]]
 name = "gix-prompt"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f61f6264e1f6c5a951531fe127722c7522bc02ebda80c4528286bda4642055f"
+checksum = "1de52c2570684db3eb8cebda77c1d0e3d03ddaad2d9bbb5055eba31fb9f8292a"
 dependencies = [
  "gix-command",
  "gix-config-value",
@@ -2820,9 +2830,9 @@ dependencies = [
 
 [[package]]
 name = "gix-protocol"
-version = "0.59.0"
+version = "0.60.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f38666350736b5877c79f57ddae02bde07a4ce186d889adc391e831cddcbe76"
+checksum = "565eaa4df8438f2919135284410284c99100a2f9836d89efd918292107a80165"
 dependencies = [
  "bstr",
  "gix-credentials",
@@ -2842,14 +2852,14 @@ dependencies = [
  "maybe-async",
  "nonempty",
  "thiserror 2.0.18",
- "winnow 0.7.15",
+ "winnow 1.0.2",
 ]
 
 [[package]]
 name = "gix-quote"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68533db71259c8776dd4e770d2b7b98696213ecdc1f5c9e3507119e274e0c578"
+checksum = "6e97b73791a64bc0fa7dd2c5b3e551136115f97750b876ed1c952c7a7dbaf8be"
 dependencies = [
  "bstr",
  "gix-error",
@@ -2858,9 +2868,9 @@ dependencies = [
 
 [[package]]
 name = "gix-ref"
-version = "0.61.0"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2159978abb99b7027c8579d15211e262ef0ef2594d5cecb3334fbcbdfe2997c"
+checksum = "9a4367b66548864dd16873c6c86220b81960994deb63965803d773e377e3fce4"
 dependencies = [
  "gix-actor",
  "gix-features",
@@ -2874,14 +2884,14 @@ dependencies = [
  "gix-validate",
  "memmap2 0.9.10",
  "thiserror 2.0.18",
- "winnow 0.7.15",
+ "winnow 1.0.2",
 ]
 
 [[package]]
 name = "gix-refspec"
-version = "0.39.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc806ee13f437428f8a1ba4c72ecfaa3f20e14f5f0d4c2bc17d0b33e794aa6ac"
+checksum = "5c2b2756c9ea849bf63d01c0407be7006ebff78e6893e1845a56446eaeada359"
 dependencies = [
  "bstr",
  "gix-error",
@@ -2895,9 +2905,9 @@ dependencies = [
 
 [[package]]
 name = "gix-revision"
-version = "0.43.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c08f1ec5d1e6a524f8ba291c41f0ccaef64e48ed0e8cf790b3461cae45f6d3d"
+checksum = "35c130f74ac580ef8d37d723576b776674fdeb405f8b6126692c28346fdb85ac"
 dependencies = [
  "bitflags 2.11.1",
  "bstr",
@@ -2913,9 +2923,9 @@ dependencies = [
 
 [[package]]
 name = "gix-revwalk"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4b2b87772b21ca449249e86d32febadba5cba32b0fcce804ab9cefc6f2111c"
+checksum = "b96e8ba5213c036d064034cefa6349cba3628498bccd8eca3e22a121b1a6e726"
 dependencies = [
  "gix-commitgraph",
  "gix-date",
@@ -2929,9 +2939,9 @@ dependencies = [
 
 [[package]]
 name = "gix-sec"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf82ae037de9c62850ce67beaa92ec8e3e17785ea307cdde7618edc215603b4f"
+checksum = "283f4a746c9bde8550be63e6f961ff4651f412ca12666e8f5615f39464960ab9"
 dependencies = [
  "bitflags 2.11.1",
  "gix-path",
@@ -2941,9 +2951,9 @@ dependencies = [
 
 [[package]]
 name = "gix-shallow"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf60711c9083b2364b3fac8a352444af76b17201f3682fdebe74fa66d89a772"
+checksum = "3290e102e9375812e6baddf3354357f07f04baeaece97e045f9dad2c7ce6a033"
 dependencies = [
  "bstr",
  "gix-hash",
@@ -2954,9 +2964,9 @@ dependencies = [
 
 [[package]]
 name = "gix-status"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d6c598e3fdbc352fba1c5ba7e709e69402fafbc44d9295edad2e3c4738996b"
+checksum = "a444038e1bd06039464990f0653265d0707c5d92dda283cdf7cecd1b1f3182ba"
 dependencies = [
  "bstr",
  "filetime",
@@ -2977,9 +2987,9 @@ dependencies = [
 
 [[package]]
 name = "gix-submodule"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce5c3929c5e6821f651d35e8420f72fea3cfafe9fc1e928a61e718b462c72a5"
+checksum = "5099295499844e2d9d06d3e9be91d3db67fe322b9bdacaa4009769059affec02"
 dependencies = [
  "bstr",
  "gix-config",
@@ -2992,9 +3002,9 @@ dependencies = [
 
 [[package]]
 name = "gix-tempfile"
-version = "21.0.2"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d22227f6b203f511ff451c33c89899e87e4f571fc596b06f68e6e613a6508528"
+checksum = "f30bb168ab673020410158264e21b267dae3b89d248e901400b1cba788fcba7a"
 dependencies = [
  "dashmap",
  "gix-fs",
@@ -3005,15 +3015,15 @@ dependencies = [
 
 [[package]]
 name = "gix-trace"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f69a13643b8437d4ca6845e08143e847a36ca82903eed13303475d0ae8b162e0"
+checksum = "6f23569e55f2ffaf958617353b9734a7d52a7c19c439eeaa5e3efc217fd2270e"
 
 [[package]]
 name = "gix-transport"
-version = "0.55.1"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a521e39c6235ce63ed6c001e2dd79818c830b82c3b7b59247ee7b229c39ec9bb"
+checksum = "70f7cc0a5f8ff289c2d18077740efbad216d8c85b949c40827cd5bff00e457df"
 dependencies = [
  "base64 0.22.1",
  "bstr",
@@ -3030,9 +3040,9 @@ dependencies = [
 
 [[package]]
 name = "gix-traverse"
-version = "0.55.0"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "963dc2afcdb611092aa587c3f9365e749ac0a0892ff27662dbc75f26c953fbec"
+checksum = "ef81f53b86d0cb1588768aaea171241fb98818c8893dd43aa3343fff49600e09"
 dependencies = [
  "bitflags 2.11.1",
  "gix-commitgraph",
@@ -3047,9 +3057,9 @@ dependencies = [
 
 [[package]]
 name = "gix-url"
-version = "0.35.2"
+version = "0.35.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d28e8af3d42581190da884f013caf254d2fd4d6ab102408f08d21bfa11de6c8d"
+checksum = "1a61ead12e33fa52ae92b207ee27554f646a8e7a3dad8b78da1582ec91eda0a6"
 dependencies = [
  "bstr",
  "gix-path",
@@ -3059,9 +3069,9 @@ dependencies = [
 
 [[package]]
 name = "gix-utils"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "befcdbdfb1238d2854591f760a48711bed85e72d80a10e8f2f93f656746ef7c5"
+checksum = "4e477b4f07a6e8da4ba791c53c858102959703c60d70f199932010d5b94adb2c"
 dependencies = [
  "bstr",
  "fastrand",
@@ -3070,18 +3080,18 @@ dependencies = [
 
 [[package]]
 name = "gix-validate"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec1eff98d91941f47766367cba1be746bab662bad761d9891ae6f7882f7840b"
+checksum = "e26ac2602b43eadfdca0560b81d3341944162a3c9f64ccdeef8fc501ad80dad5"
 dependencies = [
  "bstr",
 ]
 
 [[package]]
 name = "gix-worktree"
-version = "0.50.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6bd5830cbc43c9c00918b826467d2afad685b195cb82329cde2b2d116d2c578"
+checksum = "9f16b89b6195beba7e5517fea8ba20ca6fca67143fb1b070560ce0a4a866c87a"
 dependencies = [
  "bstr",
  "gix-attributes",
@@ -3097,9 +3107,9 @@ dependencies = [
 
 [[package]]
 name = "gix-worktree-state"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "644a1681f96e1be43c2a8384337d9d220e7624f50db54beda70997052aebf707"
+checksum = "acaa094bfbba896270a83b19585a0ee4ee83a0a64ab0ed3027302a3425436b3f"
 dependencies = [
  "bstr",
  "gix-features",
@@ -3115,9 +3125,9 @@ dependencies = [
 
 [[package]]
 name = "gix-worktree-stream"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24e3fb70a1f650a5cec7d5b8d10d6d6fe86daf3cf15bde08ba0c70988a2932c3"
+checksum = "22e0dc22458124d74729003a95225bd63236652671d660a8134843bedc1d4600"
 dependencies = [
  "gix-attributes",
  "gix-error",
@@ -3569,7 +3579,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration 0.7.0",
  "tokio",
  "tower-service",
@@ -3770,25 +3780,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "imara-diff"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17d34b7d42178945f775e84bc4c36dde7c1c6cdfea656d3354d009056f2bb3d2"
-dependencies = [
- "hashbrown 0.15.5",
-]
-
-[[package]]
-name = "imara-diff"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f01d462f766df78ab820dd06f5eb700233c51f0f4c2e846520eaf4ba6aa5c5c"
-dependencies = [
- "hashbrown 0.15.5",
- "memchr",
-]
-
-[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3955,7 +3946,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4096,7 +4087,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cfc352a66ba903c23239ef51e809508b6fc2b0f90e3476ac7a9ff47e863ae95"
 dependencies = [
  "scopeguard",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5091,7 +5082,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -5689,7 +5680,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -5727,9 +5718,9 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6232,7 +6223,7 @@ dependencies = [
  "errno 0.3.14",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6289,7 +6280,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7116,7 +7107,7 @@ version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
- "errno 0.3.14",
+ "errno 0.2.8",
  "libc",
 ]
 
@@ -7899,7 +7890,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9071,7 +9062,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -94,7 +94,7 @@ reqwest = {version = "0.13.2", features = ["json", "blocking", "stream"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_derive = "1.0"
 serde_json = "1.0"
-gix = { version = "0.81", default-features = false, features = [
+gix = { version = "0.82", default-features = false, features = [
     "sha1",
     "blocking-network-client",
     "blocking-http-transport-reqwest-rust-tls",

--- a/src-tauri/src/cli/wizard.rs
+++ b/src-tauri/src/cli/wizard.rs
@@ -600,7 +600,9 @@ pub async fn run_wizzard_run(mut config: Settings) -> Result<(), String> {
                 );
             }
         }
-        if !using_existing_idf {
+        if offline_mode && !using_existing_idf {
+          error!("THIS SHOULD NOT HAPPEN: offline mode should be using existing IDF copied from offline archive, but it seems like the IDF is not present at the expected location. This likely means that the copy from offline archive failed. Please check previous logs for any errors related to copying IDF from offline archive.");
+        } else if !using_existing_idf {
             // download idf
             let download_config = DownloadConfig {
                 idf_path: paths.idf_path.to_str().unwrap().to_string(),

--- a/src-tauri/src/lib/offline_installer.rs
+++ b/src-tauri/src/lib/offline_installer.rs
@@ -565,7 +565,11 @@ pub fn copy_idf_from_offline_archive(
                     }
                     Err(rename_err) => {
                         debug!("fs::rename failed (likely cross-filesystem): {}, falling back to mtime-preserving copy", rename_err);
-                        match copy_dir_contents_preserving_mtime(&src_path, &dst_path) {
+                        // For copy, we need to copy the esp-idf subdirectory specifically
+                        // since the archive structure is: version/esp-idf/...
+                        let src_idf_path = src_path.join("esp-idf");
+                        let dst_idf_path = dst_path.join("esp-idf");
+                        match copy_dir_contents_preserving_mtime(&src_idf_path, &dst_idf_path) {
                             Ok(_) => {
                                 info!("Successfully copied IDF version with preserved timestamps: {}", archive_version);
                             }

--- a/tests/CLIRunner.test.js
+++ b/tests/CLIRunner.test.js
@@ -283,7 +283,7 @@ function testRun(jsonScript) {
       });
     } else if (test.type === "existing-git-clone") {
       const gitRepoUrl = test.data.gitRepoUrl ?? "https://github.com/espressif/esp-idf.git";
-      const gitRepoBranch = test.data.gitRepoBranch ?? "v5.5.3";
+      const gitRepoBranch = test.data.gitRepoBranch ?? "v5.5.4";
       const installFolder = test.data.installFolder
         ? path.join(os.homedir(), test.data.installFolder)
         : INSTALLFOLDER;

--- a/tests/scripts/CLICloneIDFRepo.test.js
+++ b/tests/scripts/CLICloneIDFRepo.test.js
@@ -18,13 +18,13 @@ import { execSync } from "child_process";
  * @param {string} [options.id=0] - Sub-id for the describe title
  * @param {string} options.path - Full path where the repo will be cloned (will be created/cleaned)
  * @param {string} [options.gitRepoUrl] - Git repo URL (default: esp-idf upstream)
- * @param {string} [options.gitRepoBranch] - Branch or tag to clone (default: v5.5.3)
+ * @param {string} [options.gitRepoBranch] - Branch or tag to clone (default: v5.5.4)
  */
 export function runCLIClonedIDFRepo({
   id = 0,
   path: clonePath,
   gitRepoUrl = "https://github.com/espressif/esp-idf.git",
-  gitRepoBranch = "v5.5.3",
+  gitRepoBranch = "v5.5.4",
 }) {
   describe(`${id}- Clone IDF repo |`, function () {
     before(async function () {

--- a/tests/suites/CLI-basic.json
+++ b/tests/suites/CLI-basic.json
@@ -22,9 +22,9 @@
   {
     "id": 4,
     "type": "custom",
-    "name": "CLI Non-Interactive v5.4.3",
+    "name": "CLI Non-Interactive v5.4.4",
     "data": {
-      "idfList": "v5.4.3"
+      "idfList": "v5.4.4"
     },
     "deleteAfterTest": false,
     "testProxyMode": false
@@ -34,7 +34,7 @@
     "type": "version-management",
     "name": "CLI Version Management",
     "data": {
-      "idfList": "default|v5.4.3"
+      "idfList": "default|v5.4.4"
     }
   },
   {
@@ -44,7 +44,7 @@
     "data": {
       "installFolder": ".espext1",
       "gitRepoUrl": "https://github.com/espressif/esp-idf.git",
-      "gitRepoBranch": "v5.5.3"
+      "gitRepoBranch": "v5.5.4"
     },
     "deleteAfterTest": true,
     "testProxyMode": false

--- a/tests/suites/CLI-extended.json
+++ b/tests/suites/CLI-extended.json
@@ -2,10 +2,10 @@
   {
     "id": 1,
     "type": "custom",
-    "name": "CLI Non-Interactive v5.3.4 and v5.4.3",
+    "name": "CLI Non-Interactive v5.3.4 and v5.4.4",
     "data": {
       "targetList": "esp32s2|esp32h2",
-      "idfList": "v5.3.4|v5.4.3",
+      "idfList": "v5.3.4|v5.4.4",
       "installFolder": ".espext1",
       "idfMirror": "github",
       "toolsMirror": "github",

--- a/tests/suites/CLI-mirrors-extended.json
+++ b/tests/suites/CLI-mirrors-extended.json
@@ -2,9 +2,9 @@
   {
     "id": 3,
     "type": "custom",
-    "name": "Mirrors jihulab and dl_com v5.4.3",
+    "name": "Mirrors jihulab and dl_com v5.4.4",
     "data": {
-      "idfList": "v5.4.3",
+      "idfList": "v5.4.4",
       "idfMirror": "jihulab",
       "toolsMirror": "dl_com",
       "pypiMirror": "pypi_aliyun",
@@ -17,9 +17,9 @@
   {
     "id": 4,
     "type": "custom",
-    "name": "Mirrors jihulab and dl_cn v5.4.3",
+    "name": "Mirrors jihulab and dl_cn v5.4.4",
     "data": {
-      "idfList": "v5.4.3",
+      "idfList": "v5.4.4",
       "idfMirror": "jihulab",
       "toolsMirror": "dl_cn",
       "pypiMirror": "pypi_aliyun",

--- a/tests/suites/CLI-scoop-windows.json
+++ b/tests/suites/CLI-scoop-windows.json
@@ -22,9 +22,9 @@
   {
     "id": 4,
     "type": "custom",
-    "name": "CLI Non-Interactive v5.4.3",
+    "name": "CLI Non-Interactive v5.4.4",
     "data": {
-      "idfList": "v5.4.3"
+      "idfList": "v5.4.4"
     },
     "deleteAfterTest": false,
     "testProxyMode": false
@@ -34,7 +34,7 @@
     "type": "version-management",
     "name": "CLI Version Management",
     "data": {
-      "idfList": "default|v5.4.3"
+      "idfList": "default|v5.4.4"
     }
   },
   {

--- a/tests/suites/GUI-basic.json
+++ b/tests/suites/GUI-basic.json
@@ -23,10 +23,10 @@
   {
     "id": 4,
     "type": "custom",
-    "name": "GUI Expert v5.4.3",
+    "name": "GUI Expert v5.4.4",
     "data": {
       "targetList": "All",
-      "idfList": "v5.4.3",
+      "idfList": "v5.4.4",
       "installFolder": ".espcustom",
       "idfMirror": "github",
       "toolsMirror": "github"
@@ -39,7 +39,7 @@
     "type": "version-management",
     "name": "GUI Version Management",
     "data": {
-      "idfList": "default|v5.4.3",
+      "idfList": "default|v5.4.4",
       "installFolder": ".espcustom"
     }
   },

--- a/tests/suites/GUI-extended.json
+++ b/tests/suites/GUI-extended.json
@@ -2,10 +2,10 @@
   {
     "id": 1,
     "type": "custom",
-    "name": "GUI Expert v5.3.4 & v5.4.3",
+    "name": "GUI Expert v5.3.4 & v5.4.4",
     "data": {
       "targetList": "esp32s2|esp32h2",
-      "idfList": "v5.3.4|v5.4.3",
+      "idfList": "v5.3.4|v5.4.4",
       "installFolder": ".espext1",
       "idfMirror": "github",
       "toolsMirror": "github"


### PR DESCRIPTION
1) we were testing that some no longer supported IDF version shows in the offered list

2) this change (https://github.com/espressif/idf-im-ui/pull/556/changes#diff-7e1c5d8b19f459fcec8e9c9fa3fd47249198d8fd7d8b1eb8aa16fb6a6a949a08R588) caused relocation of IDF in case of offline installation:
that lead to redownloading it from online sources and failing of offline installation in tests.

3) migration to company wide macos signing secrets
