### PR TITLE
EIM-376: Fixing the restriction bypass for the powershell execution policy

### DIFF
--- a/docs/src/faq.md
+++ b/docs/src/faq.md
@@ -179,6 +179,10 @@ Reasons to use PowerShell:
 
 To use PowerShell, simply run the generated PowerShell profile script - it is created automatically during installation.
 
+### Open IDF Terminal fails with "running scripts is disabled on this system" on Windows
+
+If clicking **Open IDF Terminal** in an older EIM build shows `File ... cannot be loaded because running scripts is disabled on this system` (`PSSecurityException` / `UnauthorizedAccess`), your PowerShell execution policy is `Restricted` or `AllSigned`. Either run once per user `Set-ExecutionPolicy -Scope CurrentUser RemoteSigned`, or launch the profile manually with `powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -NoExit -File "<path-to>\Microsoft.{version}.PowerShell_profile.ps1"`. Newer EIM builds pass `-ExecutionPolicy Bypass` automatically, and the desktop shortcut and Windows Terminal profile created by EIM already do so.
+
 ## More Questions?
 
 If you have additional questions, you can:

--- a/src-tauri/src/gui/commands/utils_commands.rs
+++ b/src-tauri/src/gui/commands/utils_commands.rs
@@ -325,17 +325,17 @@ pub async fn track_event_command(app_handle: AppHandle,name: &str, additional_da
 pub fn open_terminal_with_script(script_path: String) -> Result<bool,String> {
     #[cfg(target_os = "windows")]
     {
-        // Windows: Open PowerShell and dot-source the script
-        let ps_command = format!(
-            "$scriptPath = '{}'; if (Test-Path $scriptPath) {{ . $scriptPath }} else {{ Write-Host \"Script not found: $scriptPath\" }}",
-            script_path.replace("\\", "\\\\").replace("'", "''")
-        );
+        if !std::path::Path::new(&script_path).exists() {
+            return Err(format!("Script not found: {}", script_path));
+        }
 
         let mut cmd = Command::new("powershell");
-        cmd.args(&[
+        cmd.args([
+            "-NoLogo",
+            "-NoProfile",
+            "-ExecutionPolicy", "Bypass",
             "-NoExit",
-            "-Command",
-            &ps_command
+            "-File", &script_path,
         ]);
 
         #[cfg(windows)]


### PR DESCRIPTION
# EIM-376 — "Open IDF Terminal" blocked by PowerShell execution policy

**Ticket:** [EIM-376](https://jira.espressif.com:8443/browse/EIM-376)

---

## Problem

On Windows machines where `Get-ExecutionPolicy` is `Restricted` (default on many client / corporate images) or `AllSigned`, clicking **Open IDF Terminal** in EIM's Version Management view failed with:

```
File C:\Espressif\tools\Microsoft.v5.5.1.PowerShell_profile.ps1 cannot be loaded
because running scripts is disabled on this system.
CategoryInfo: SecurityError: (:) [], PSSecurityException
FullyQualifiedErrorId: UnauthorizedAccess
```

Root cause: the Tauri command `open_terminal_with_script` spawned `powershell.exe -NoExit -Command "<dot-source the profile>"` without `-ExecutionPolicy Bypass`, so PowerShell's policy blocked dot-sourcing the locally generated `Microsoft.{version}.PowerShell_profile.ps1`.

The two other places EIM launches the same profile script (desktop shortcut and Windows Terminal profile) were already passing `-ExecutionPolicy Bypass -NoProfile`, so the GUI button was the lone outlier.

---

## What changed

### 1. `src-tauri/src/gui/commands/utils_commands.rs` — Windows branch of `open_terminal_with_script`

Replaced the brittle in-PowerShell `$scriptPath = '...'; if (Test-Path) { . $scriptPath }` `format!()` (with manual `\\` and `''` escaping) with:

- Rust-side existence check via `std::path::Path::new(&script_path).exists()`, returning a real `Err(...)` so the GUI's existing `versionManagement.messages.error.openTerminal` toast still fires.
- A direct invocation that matches the user-verified-working command on a Restricted machine:

```text
powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -NoExit -File <script_path>
```

Using `-File` instead of `-Command "& {. '...'}"` removes all the path quoting / backslash escaping — PowerShell receives the path as an argv entry. Top-level `function global:...`, `New-Alias -Scope Global`, and `$env:...` from `idf_tools_profile_template.ps1` remain visible at the interactive prompt, matching prior behavior.

`CREATE_NEW_CONSOLE` (`0x00000010`) and the existing `#[cfg(target_os = "windows")] / #[cfg(windows)]` structure were preserved. macOS and Linux branches were not touched (ExecutionPolicy is Windows-only).

### 2. `docs/src/faq.md` — new FAQ entry

Added one section under the existing PowerShell FAQ explaining the `running scripts is disabled on this system` error for users on older EIM builds, with the manual workaround:

- `Set-ExecutionPolicy -Scope CurrentUser RemoteSigned`, or
- `powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -NoExit -File "<path-to>\Microsoft.{version}.PowerShell_profile.ps1"`.

---

## Areas reviewed and intentionally left alone

A repo-wide audit of every place EIM spawns PowerShell with a `.ps1` was performed. Only the GUI button was broken; everything else already had correct ExecutionPolicy handling and was deliberately untouched to keep the diff minimal.

| Site | File / Line | Status | Why no change |
|---|---|---|---|
| Install-time script runner | [`src-tauri/src/lib/command_executor.rs`](../../../src-tauri/src/lib/command_executor.rs) L132–L160 (`WindowsExecutor::prepare_powershell_script`) | Already correct | Spawns `powershell -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File <temp.ps1>`, and the wrapper script body also runs `Set-ExecutionPolicy Bypass -Scope Process -Force`. Used by `run_powershell_script` for `install_scoop.ps1`, `create_desktop_shortcut_template.ps1`, etc. |
| `get_powershell_version` | [`src-tauri/src/lib/command_executor.rs`](../../../src-tauri/src/lib/command_executor.rs) L109–L128 | N/A | Runs an inline `-Command "$PSVersionTable.PSVersion.Major"` expression, never loads a `.ps1` from disk, so ExecutionPolicy doesn't apply. |
| Desktop shortcut Arguments | [`src-tauri/powershell_scripts/create_desktop_shortcut_template.ps1`](../../../src-tauri/powershell_scripts/create_desktop_shortcut_template.ps1) L6 | Already correct | Generated `.lnk` already passes `-NoExit -ExecutionPolicy Bypass -NoProfile -Command "& {. '...'}"`. Cosmetic `-NoLogo` deferred. |
| Windows Terminal profile `commandline` | [`src-tauri/src/lib/mod.rs`](../../../src-tauri/src/lib/mod.rs) L497–L500 | Already correct | Profile registered via `add_windows_terminal_profile` already uses `powershell.exe -NoExit -ExecutionPolicy Bypass -NoProfile -Command "& {. '...'}"`. Cosmetic `-NoLogo` deferred. |
| Generated PowerShell profile | [`src-tauri/powershell_scripts/idf_tools_profile_template.ps1`](../../../src-tauri/powershell_scripts/idf_tools_profile_template.ps1) | No change | Uses `function global:...`, `Set-Item env:...`, `New-Alias -Scope Global`, all of which remain available when the script is launched via `-NoExit -File`. |
| `install_scoop.ps1` / `install_scoop_offline.ps1` | [`src-tauri/powershell_scripts/`](../../../src-tauri/powershell_scripts/) | Out of scope | These are scripts that *generate scoop shim files* on disk, not EIM-driven PowerShell launches. They embed `pwsh -noprofile -ex unrestricted -file ...` for the shims they produce. |
| Mocha test harness | `tests/package.json`, `tests/classes/CLITestRunner.class.js` | Out of scope | CI/test plumbing only; not part of the user-facing EIM flow. |

---

### Manual verification checklist for reviewers (Windows)

On a Windows machine with `Get-ExecutionPolicy` = `Restricted`:

1. Install an ESP-IDF version via EIM.
2. Click **Open IDF Terminal** on the Version Management page — a new PowerShell opens with the IDF environment, no `UnauthorizedAccess` error.
3. Confirm `idf.py --version`, `esptool --version`, and `$env:IDF_PATH` print expected values.
4. Delete the profile `.ps1` from the tools folder and click **Open IDF Terminal** again — the GUI shows the existing "IDF terminal could not be opened" toast (no panic, no PowerShell window).
5. Regression: the EIM-created **desktop shortcut** and the **Windows Terminal "ESP-IDF" profile** still launch successfully (their code paths were unchanged).
6. E2E: [`tests/scripts/GUIVersionManagement.test.js`](../../../tests/scripts/GUIVersionManagement.test.js) (L113) and the "Open IDF Terminal" sections in [`tests/scripts/installationVerification.test.js`](../../../tests/scripts/installationVerification.test.js) still pass.

---

## Out of scope (deliberately deferred)

- Code-signing the generated `Microsoft.{version}.PowerShell_profile.ps1` (would require a certificate + pipeline changes; not needed once `-ExecutionPolicy Bypass` is consistently applied at the call site).
- Changing the profile file's generation path or filename.
- macOS / Linux terminal spawning (unrelated to ExecutionPolicy).
- Cosmetic `-NoLogo` addition to the already-working desktop shortcut and Windows Terminal `commandline` (kept the diff minimal; can be a follow-up).
