### PR TITLE
EIM-767: Fixing nightly notification for pkg manager tests

### DIFF
--- a/.github/workflows/test_pkg_managers.yml
+++ b/.github/workflows/test_pkg_managers.yml
@@ -263,7 +263,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           JOBS=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs \
-            --paginate --jq '.jobs[] | select(.name | startswith("PkgMgr")) | "\(.name)|\(.conclusion // "unknown")|\(.html_url)"')
+            --paginate --jq '.jobs[] | select(.name | contains("PkgMgr")) | "\(.name)|\(.conclusion // "unknown")|\(.html_url)"')
 
           VERSION="${{ needs.resolve-version.outputs.stripped }}"
           RUN_MODE="${{ inputs.run_mode }}"


### PR DESCRIPTION
The `build-notification` job in `test_pkg_managers.yml` uses this jq filter to find test jobs:

```bash
gh api repos/.../actions/runs/${{ github.run_id }}/jobs \
  --paginate --jq '.jobs[] | select(.name | startswith("PkgMgr")) | ...'
```

The filter uses **`startswith("PkgMgr")`** to match jobs.

When `test_pkg_managers.yml` runs directly (triggered by `pull_request` or `workflow_dispatch`), GitHub reports job names exactly as declared.

When the "Unified Build Workflow" calls `test_pkg_managers.yml` as a **reusable workflow** via `workflow_call`, GitHub **prefixes** every child job name with the caller's job name.

Simple fix changing `startsWith` and `contains`