### PR TITLE
docs: use eim repository name for Arch pacman setup (EIM-784)

### DIFF
--- a/docs/src/cli_installation.md
+++ b/docs/src/cli_installation.md
@@ -30,7 +30,7 @@ Or on Arch Linux via pacman:
 # Check if repository already exists, then add if not
 if ! grep -q "\[eim\]" /etc/pacman.conf; then
   sudo tee -a /etc/pacman.conf << 'EOF'
-[espressif]
+[eim]
 SigLevel = Optional TrustAll
 Server = https://dl.espressif.com/dl/eim/pacman/$arch
 EOF

--- a/docs/src/general_info.md
+++ b/docs/src/general_info.md
@@ -227,19 +227,19 @@ sudo dnf upgrade eim
 
 <a id="arch-linux-installation-via-pacman-repository"></a>
 
-For **Arch-based** distributions (Arch Linux, Manjaro, EndeavourOS, CachyOS, etc.), use the official Espressif pacman repository:
+For **Arch-based** distributions (Arch Linux, Manjaro, EndeavourOS, CachyOS, etc.), use the official EIM pacman repository:
 
 ```bash
-# Add the Espressif pacman repository
+# Add the EIM pacman repository
 # Edit /etc/pacman.conf and add the following at the end:
 
-[espressif]
+[eim]
 SigLevel = Optional TrustAll
 Server = https://dl.espressif.com/dl/eim/pacman/$arch
 
 # Or use the shell command below (requires sudo):
 sudo tee -a /etc/pacman.conf << 'EOF'
-[espressif]
+[eim]
 SigLevel = Optional TrustAll
 Server = https://dl.espressif.com/dl/eim/pacman/$arch
 EOF
@@ -259,12 +259,12 @@ sudo pacman -S eim-gui
 To update EIM later:
 ```bash
 # Update the entire system (recommended for Arch Linux)
-+sudo pacman -Syu
-+
-+# Or update specific EIM package
-+sudo pacman -Syu eim-cli
-+# or
-+sudo pacman -Syu eim-gui
+sudo pacman -Syu
+
+# Or update specific EIM package
+sudo pacman -Syu eim-cli
+# or
+sudo pacman -Syu eim-gui
 ```
 
 ---


### PR DESCRIPTION
## Description

  Fixes the Arch Linux pacman installation docs to use the `eim` repository name instead of `espressif`.

  The pacman repository database is published as `eim.db`, so the repo section in `/etc/pacman.conf` must be `[eim]`. Using `[espressif]` makes pacman look for `espressif.db`, which is not present.

Pacman gives this error: `error: failed retrieving file 'espressif.db' from dl.espressif.com : The requested URL returned error: 404`

  Also removes stray `+` characters from the Arch update command examples.

  ## Related

  Related to the Arch pacman installation instructions added in EIM-762.

  ## Testing

  - Verified the published pacman repo exposes `eim.db`.
  - Checked docs for remaining stale `[espressif]` pacman examples.
  - Ran `git diff --check`.

  ---

  ## Checklist

  Before submitting a Pull Request, please ensure the following:

  - [x] 🚨 This PR does not introduce breaking changes.
  - [ ] All CI checks (GH Actions) pass.
  - [x] Documentation is updated as needed.
  - [x] Tests are updated or added as necessary.
  - [x] Code is well-commented, especially in complex areas.
  - [x] Git history is clean — commits are squashed to the minimum necessary.