### PR TITLE
abandoning actions/download-artifact because they are so stupid that they have hardcoded limit to 100 artifacts so you will never get the ones on the end of the alphabet

### DIFF
--- a/.github/workflows/build_offline_installer_archives.yaml
+++ b/.github/workflows/build_offline_installer_archives.yaml
@@ -107,13 +107,20 @@ jobs:
 
       # ── Download builder binary (needed only to list versions) ─────────────
       - name: Download offline_installer_builder (linux-x64)
-        uses: actions/download-artifact@v5
-        with:
-          pattern: offline_installer_builder-linux-x64-*
-          merge-multiple: true
-          path: ./
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          run-id: ${{ steps.resolve-run-id.outputs.run_id }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh run download ${{ steps.resolve-run-id.outputs.run_id }} \
+            --repo ${{ github.repository }} \
+            --pattern "offline_installer_builder-linux-x64-*" \
+            --dir ./downloaded
+
+          echo "--- Downloaded files ---"
+          find ./downloaded -type f
+
+          # gh creates a subdirectory per artifact, flatten it
+          find ./downloaded -type f -name "offline_installer_builder" -exec cp {} ./ \;
 
       - name: Make binary executable
         run: chmod +x ./offline_installer_builder

--- a/.github/workflows/build_single_offline_installer_version.yml
+++ b/.github/workflows/build_single_offline_installer_version.yml
@@ -84,13 +84,20 @@ jobs:
           ref: ${{ inputs.ref }}
 
       - name: Download offline_installer_builder artifact
-        uses: actions/download-artifact@v5
-        with:
-          pattern: offline_installer_builder-${{ matrix.package_name }}-*
-          merge-multiple: true
-          path: ./
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          run-id: ${{ inputs.resolved_run_id }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh run download ${{ inputs.resolved_run_id }} \
+            --repo ${{ github.repository }} \
+            --pattern "offline_installer_builder-${{ matrix.package_name }}-*" \
+            --dir ./downloaded
+
+          echo "--- Downloaded files ---"
+          find ./downloaded -type f
+
+          # gh creates a subdirectory per artifact, flatten it
+          find ./downloaded -type f \( -name "offline_installer_builder" -o -name "offline_installer_builder.exe" \) -exec cp {} ./ \;
 
       - name: Make binary executable (Unix)
         if: runner.os != 'Windows'

--- a/.github/workflows/test_offline.yml
+++ b/.github/workflows/test_offline.yml
@@ -72,23 +72,36 @@ jobs:
           python-version: ${{ matrix.version }}
 
       - name: Download Build Info files from another run_id
-        uses: actions/download-artifact@v5
         if: inputs.build_info_run_id != 'release'
-        with:
-          pattern: build-info-*-${{ matrix.package_name }}
-          path: ./artifacts
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          run-id: ${{ inputs.build_info_run_id }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh run download ${{ inputs.build_info_run_id }} \
+            --repo ${{ github.repository }} \
+            --pattern "build-info-*-${{ matrix.package_name }}" \
+            --dir ./artifacts
+
+          echo "--- Downloaded files ---"
+          find ./artifacts -type f
 
       - name: Download EIM-CLI artifacts from another run id
-        uses: actions/download-artifact@v4
         if: inputs.eim_cli_run_id != 'release'
-        with:
-          pattern: eim-cli-${{ matrix.package_name }}-*
-          path: ./artifacts
-          merge-multiple: true
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          run-id: ${{ inputs.eim_cli_run_id }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh run download ${{ inputs.eim_cli_run_id }} \
+            --repo ${{ github.repository }} \
+            --pattern "eim-cli-${{ matrix.package_name }}-*" \
+            --dir ./artifacts/downloaded
+
+          echo "--- Downloaded files ---"
+          find ./artifacts/downloaded -type f
+
+          # flatten subdirectories gh creates into ./artifacts
+          find ./artifacts/downloaded -type f \
+            -exec cp {} ./artifacts/ \;
 
       # Non-Windows steps
 


### PR DESCRIPTION
abandoning actions/download-artifact because they are so stupid that they have hardcoded limit to 100 artifacts so you will never get the ones on the end of the alphabet