### PR TITLE
Fix invalid PowerShell syntax in Register-IdfCompletions (EIM-807)

### DIFF
--- a/src-tauri/powershell_scripts/idf_tools_profile_template.ps1
+++ b/src-tauri/powershell_scripts/idf_tools_profile_template.ps1
@@ -72,16 +72,16 @@ function Print-EnvVariables {
 function Register-IdfCompletions {
     try {
         # Set env var only for the duration of this call.
-        $previous = $env:'_IDF.PY_COMPLETE'
-        $env:'_IDF.PY_COMPLETE' = 'powershell_source'
+        $previous = ${env:_IDF.PY_COMPLETE}
+        ${env:_IDF.PY_COMPLETE} = 'powershell_source'
 
         $completionScript = & "{{python_bin_path}}" "{{idf_path}}\tools\idf.py" 2>$null | Out-String
 
         # Restore previous value (or remove if unset).
         if ($null -eq $previous) {
-            Remove-Item Env:'_IDF.PY_COMPLETE' -ErrorAction SilentlyContinue
+            Remove-Item 'Env:_IDF.PY_COMPLETE' -ErrorAction SilentlyContinue
         } else {
-            $env:'_IDF.PY_COMPLETE' = $previous
+            ${env:_IDF.PY_COMPLETE} = $previous
         }
 
         if (-not [string]::IsNullOrWhiteSpace($completionScript)) {


### PR DESCRIPTION
## Summary

- Fix invalid PowerShell syntax in `Register-IdfCompletions` inside [`idf_tools_profile_template.ps1`](https://github.com/espressif/idf-im-ui/blob/master/src-tauri/powershell_scripts/idf_tools_profile_template.ps1#L75)
- Replace `$env:'_IDF.PY_COMPLETE'` with `${env:_IDF.PY_COMPLETE}` and use `'Env:_IDF.PY_COMPLETE'` for `Remove-Item`
- Generated profiles such as `Microsoft.v6.0.1.PowerShell_profile.ps1` currently fail to parse on Windows, preventing the ESP-IDF PowerShell environment from loading

## Problem

See Issue: https://github.com/espressif/idf-im-ui/issues/814

## Test plan

- [ ] Regenerate a Windows PowerShell profile from the template
- [ ] Run the generated profile with `PowerShell -NoProfile -Command` and confirm it loads without parser errors
- [ ] Confirm `idf.py` is available after sourcing the profile
- [ ] Confirm tab completion registration still works when Click supports `powershell_source`
