### PR TITLE
EIM-323: Fixing esp-idf-json-path param

### DIFF
--- a/docs/src/cli_commands.md
+++ b/docs/src/cli_commands.md
@@ -16,6 +16,7 @@ These options can be used with any command:
 - `-v, --verbose`: Increase verbosity level (can be used multiple times)
 - `--log-file <LOG_FILE>`: File in which logs will be stored (default: eim.log)
 - `--do-not-track <DO_NOT_TRACK>`: If set to true, the installer will not send any usage data. Default is false. [possible values: true, false]
+- `--esp-idf-json-path <PATH>`: Path to the directory for `eim_idf.json`. During install, the configuration file is saved here. For version management commands (list, select, rename, remove, etc.), it specifies where to read the file. Defaults to `~/.espressif/tools` on POSIX, `C:\Espressif\tools` on Windows.
 - `-h, --help`: Print help information
 - `-V, --version`: Print version information
 
@@ -50,7 +51,6 @@ eim install [OPTIONS]
 
 Options:
 - `-p, --path <PATH>`: Base path to which all files and folders will be installed
-- `--esp-idf-json-path <ESP_IDF_JSON_PATH>`: Absolute path to save eim_idf.json file
 - `-c, --config <FILE>`: Path to configuration file
 - `-t, --target <TARGET>`: Target platforms (comma-separated)
 - `-i, --idf-versions <IDF_VERSIONS>`: ESP-IDF versions to install (comma-separated)

--- a/docs/src/faq.md
+++ b/docs/src/faq.md
@@ -63,7 +63,15 @@ To install to a completely custom location, configure **all** relevant paths:
 eim install -p D:\YourCustomPath\.espressif \
   --tool-install-folder-name D:\YourCustomPath\tools \
   --tool-download-folder-name D:\YourCustomPath\dist \
-  --activation-script-path-override D:\YourCustomPath\tools
+  --activation-script-path-override D:\YourCustomPath\tools \
+  --esp-idf-json-path D:\YourCustomPath\tools
+```
+
+If you use `--esp-idf-json-path` during installation, you must also pass it to subsequent version management commands so they can find your `eim_idf.json`:
+
+```bash
+eim list --esp-idf-json-path D:\YourCustomPath\tools
+eim select --esp-idf-json-path D:\YourCustomPath\tools
 ```
 
 For a full list of configurable paths, see the [CLI Configuration](./cli_configuration.md) documentation.

--- a/man/eim.1
+++ b/man/eim.1
@@ -36,6 +36,10 @@ Print help information
 .BR \-V ", " \-\-version
 Print version information
 
+.TP
+.B \-\-esp\-idf\-json\-path \fIPATH\fR
+Path to the directory for eim_idf.json. During install, the configuration file is saved here. For version management commands (list, select, rename, remove, etc.), it specifies where to read the file. Defaults to ~/.espressif/tools on POSIX, C:\\Espressif\\tools on Windows.
+
 .SH COMMANDS
 
 .SS install
@@ -48,10 +52,6 @@ Non-interactive installation of ESP-IDF versions. This command runs in non-inter
 .TP
 .BR \-p ", " \-\-path " " \fIPATH\fR
 Base path to which all files and folders will be installed
-
-.TP
-.B \-\-esp\-idf\-json\-path \fIESP_IDF_JSON_PATH\fR
-Absolute path to save eim_idf.json file
 
 .TP
 .BR \-c ", " \-\-config " " \fIFILE\fR

--- a/src-tauri/locales/app.yml
+++ b/src-tauri/locales/app.yml
@@ -500,6 +500,9 @@ remove.prompt:
 remove.success:
   en: "Removed version: %{version}"
   cn: "已删除版本：%{version}"
+cli.hint.custom_json_path:
+  en: "Hint: if you installed ESP-IDF to a custom location, use --esp-idf-json-path <path> to point version management commands to your eim_idf.json."
+  cn: "提示：如果您将 ESP-IDF 安装到自定义位置，请使用 --esp-idf-json-path <路径> 指定 eim_idf.json 的位置。"
 purge.title:
   en: Purging all known IDF installations...
   cn: 正在清除所有已知的 IDF 安装...

--- a/src-tauri/src/cli/cli_args.rs
+++ b/src-tauri/src/cli/cli_args.rs
@@ -59,6 +59,13 @@ pub struct Cli {
         action = clap::ArgAction::Set
     )]
     pub do_not_track: bool,
+
+    #[arg(
+        long,
+        global = true,
+        help = "Path to directory for eim_idf.json. During install, the configuration file is saved here. For version management commands (list, select, rename, remove, etc.), it specifies where to read the file. Defaults to ~/.espressif/tools on POSIX, C:\\Espressif\\tools on Windows."
+    )]
+    pub esp_idf_json_path: Option<String>,
 }
 
 // todo: add fix command which will reinstall using the existing IDF repository
@@ -146,12 +153,6 @@ pub struct InstallArgs {
         }
     )]
     path: Option<String>,
-
-    #[arg(
-        long,
-        help = "Absolute path to save eim_idf.json file. Default is $HOME/.espressif/tools/eim_idf.json on POSIX systems and C:\\Espressif\\tools\\eim_idf.json on Windows systems"
-    )]
-    esp_idf_json_path: Option<String>,
 
     #[arg(short, long, value_name = "FILE")]
     pub config: Option<PathBuf>,
@@ -313,10 +314,6 @@ impl IntoIterator for InstallArgs {
     fn into_iter(self) -> Self::IntoIter {
         vec![
             ("path".to_string(), self.path.map(Into::into)),
-            (
-                "esp_idf_json_path".to_string(),
-                self.esp_idf_json_path.map(Into::into),
-            ),
             (
                 "config".to_string(),
                 self.config.map(|p| p.to_str().unwrap().into()),

--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -12,6 +12,7 @@ use helpers::generic_input;
 use helpers::generic_select;
 use idf_im_lib::get_log_directory;
 use idf_im_lib::logging::formatter;
+use idf_im_lib::idf_config::IDF_CONFIG_FILE_NAME;
 use idf_im_lib::settings::Settings;
 use idf_im_lib::utils::is_valid_idf_directory;
 use idf_im_lib::version_manager::get_selected_version;
@@ -208,6 +209,8 @@ pub async fn run_cli(cli: Cli) -> anyhow::Result<()> {
           "command": format!("{:?}", command)
         }))).await;
     }
+    let cli_esp_idf_json_path = cli.esp_idf_json_path;
+    let config_path = cli_esp_idf_json_path.as_ref().map(|p| PathBuf::from(p).join(IDF_CONFIG_FILE_NAME));
     match command {
         Commands::Completions { .. } => unreachable!(),
         Commands::HelpJson => unreachable!(),
@@ -220,13 +223,20 @@ pub async fn run_cli(cli: Cli) -> anyhow::Result<()> {
             match settings {
                 Ok(mut settings) => {
                   debug!("Settings before adjustments: {:?}", settings);
+                  if let Some(ref p) = cli_esp_idf_json_path {
+                    settings.esp_idf_json_path = Some(p.clone());
+                  }
                   if install_args.install_all_prerequisites.is_none() { // if cli argument is not set
                     settings.install_all_prerequisites = Some(true); // The non-interactive install will always install all prerequisites
+                  }
+                  match settings.initialize_esp_ide_json() {
+                    Ok(_) => debug!("ESP-IDF JSON initialized at configured path."),
+                    Err(e) => warn!("Failed to initialize ESP-IDF JSON: {}. IDE integration may not work correctly.", e),
                   }
                   debug!("Settings after adjustments: {:?}", settings);
                   // Check if the provided path is already an installed IDF
                   if let Some(ref path) = settings.path {
-                      match idf_im_lib::version_manager::list_installed_versions() {
+                      match idf_im_lib::version_manager::list_installed_versions(config_path.as_ref()) {
                           Ok(versions) => {
                             debug!("Checking provided path against installed versions. Provided path: '{}'", path.display());
                             if let Some(provided_path) = idf_im_lib::utils::normalize_path_for_comparison(&path.to_string_lossy()) {
@@ -283,7 +293,7 @@ pub async fn run_cli(cli: Cli) -> anyhow::Result<()> {
         }
         Commands::List => {
             info!("{}", t!("list.title"));
-            match idf_im_lib::version_manager::get_esp_ide_config() {
+            match idf_im_lib::version_manager::get_esp_ide_config(config_path.as_ref()) {
                 Ok(config) => {
                     if config.idf_installed.is_empty() {
                         warn!("{}", t!("list.no_versions"));
@@ -302,6 +312,7 @@ pub async fn run_cli(cli: Cli) -> anyhow::Result<()> {
                 }
                 Err(err) => {
                     info!("{}", t!("list.no_versions"));
+                    info!("{}", t!("cli.hint.custom_json_path"));
                     debug!("Error: {}", err);
                     Ok(())
                 }
@@ -309,7 +320,7 @@ pub async fn run_cli(cli: Cli) -> anyhow::Result<()> {
         }
         Commands::Select { version } => {
             if version.is_none() {
-                match idf_im_lib::version_manager::list_installed_versions() {
+                match idf_im_lib::version_manager::list_installed_versions(config_path.as_ref()) {
                     Ok(versions) => {
                         if versions.is_empty() {
                             warn!("{}", t!("select.no_versions"));
@@ -318,10 +329,10 @@ pub async fn run_cli(cli: Cli) -> anyhow::Result<()> {
                             println!("{}", t!("select.available_title"));
                             let options = versions.iter().map(|v| v.name.clone()).collect();
                             match generic_select(&t!("select.prompt"), &options) {
-                                Ok(selected) => match select_idf_version(&selected) {
+                                Ok(selected) => match select_idf_version(&selected, config_path.as_ref()) {
                                     Ok(_) => {
                                         println!("{}", t!("select.success", version = selected));
-                                        if let Some(selected) = get_selected_version() {
+                                        if let Some(selected) = get_selected_version(config_path.as_ref()) {
                                           println!("{}", t!("wizard.separator.line"));
                                           println!("{}", t!("cli.select.activation_instructions"));
                                           match std::env::consts::OS {
@@ -342,15 +353,16 @@ pub async fn run_cli(cli: Cli) -> anyhow::Result<()> {
                     }
                     Err(err) => {
                         error!("{}", t!("list.no_versions"));
+                        info!("{}", t!("cli.hint.custom_json_path"));
                         debug!("Error: {}", err);
                         Err(anyhow::anyhow!(err))
                     }
                 }
             } else {
-                match select_idf_version(&version.clone().unwrap()) {
+                match select_idf_version(&version.clone().unwrap(), config_path.as_ref()) {
                     Ok(_) => {
                         info!("{}", t!("select.success", version = version.clone().unwrap()));
-                        if let Some(selected) = get_selected_version() {
+                        if let Some(selected) = get_selected_version(config_path.as_ref()) {
                           info!("{}", t!("wizard.separator.line"));
                           info!("{}", t!("cli.select.activation_instructions"));
                           info!("source {}",selected.activation_script );
@@ -367,14 +379,14 @@ pub async fn run_cli(cli: Cli) -> anyhow::Result<()> {
         Commands::Run { command, idf } => {
             let idf_identifier = if let Some(idf_str) = idf {
                 idf_str
-            } else if let Some(selected) = get_selected_version() {
+            } else if let Some(selected) = get_selected_version(config_path.as_ref()) {
                 info!("{}", t!("run.using_selected", idf = selected.name));
                 selected.id
             } else {
                 return Err(anyhow::anyhow!(t!("run.no_idf_specified_no_selected")));
             };
 
-            match run_command_in_context(&idf_identifier, &command) {
+            match run_command_in_context(&idf_identifier, &command, config_path.as_ref()) {
                 Ok(status) => {
                     if !status.success() {
                         return Err(anyhow::anyhow!(t!("run.command_failed")));
@@ -386,7 +398,7 @@ pub async fn run_cli(cli: Cli) -> anyhow::Result<()> {
         }
         Commands::Rename { version, new_name } => {
             if version.is_none() {
-                match idf_im_lib::version_manager::list_installed_versions() {
+                match idf_im_lib::version_manager::list_installed_versions(config_path.as_ref()) {
                     Ok(versions) => {
                         if versions.is_empty() {
                             warn!("{}", t!("rename.no_versions"));
@@ -423,7 +435,7 @@ pub async fn run_cli(cli: Cli) -> anyhow::Result<()> {
                                 }
                             };
                             match idf_im_lib::version_manager::rename_idf_version(
-                                &version, new_name,
+                                &version, new_name, config_path.as_ref(),
                             ) {
                                 Ok(_) => {
                                     println!("{}", t!("rename.success"));
@@ -436,6 +448,7 @@ pub async fn run_cli(cli: Cli) -> anyhow::Result<()> {
                     Err(err) => {
                         debug!("Error: {}", err);
                         error!("{}", t!("list.no_versions"));
+                        info!("{}", t!("cli.hint.custom_json_path"));
                         Err(anyhow::anyhow!(err))
                     }
                 }
@@ -458,6 +471,7 @@ pub async fn run_cli(cli: Cli) -> anyhow::Result<()> {
                 match idf_im_lib::version_manager::rename_idf_version(
                     &version.clone().unwrap(),
                     new_name,
+                    config_path.as_ref(),
                 ) {
                     Ok(_) => {
                         println!("{}", t!("rename.success"));
@@ -469,6 +483,7 @@ pub async fn run_cli(cli: Cli) -> anyhow::Result<()> {
                 match idf_im_lib::version_manager::rename_idf_version(
                     &version.clone().unwrap(),
                     new_name.clone().unwrap(),
+                    config_path.as_ref(),
                 ) {
                     Ok(_) => {
                         println!("{}", t!("rename.success"));
@@ -491,7 +506,7 @@ pub async fn run_cli(cli: Cli) -> anyhow::Result<()> {
         Commands::Import { path } => match path {
             Some(config_file) => {
                 info!("{}", t!("import.using_config", config = format!("{:?}", config_file)));
-                match idf_im_lib::utils::parse_tool_set_config(&config_file) {
+                match idf_im_lib::utils::parse_tool_set_config(&config_file, config_path.as_ref()) {
                     Ok(_) => {
                         info!("{}", t!("import.success"));
                         Ok(())
@@ -507,7 +522,7 @@ pub async fn run_cli(cli: Cli) -> anyhow::Result<()> {
         Commands::Remove { version } => {
             // todo: add spinner
             if version.is_none() {
-                match idf_im_lib::version_manager::list_installed_versions() {
+                match idf_im_lib::version_manager::list_installed_versions(config_path.as_ref()) {
                     Ok(versions) => {
                         if versions.is_empty() {
                             info!("{}", t!("remove.no_versions"));
@@ -516,7 +531,7 @@ pub async fn run_cli(cli: Cli) -> anyhow::Result<()> {
                             println!("{}", t!("remove.available_title"));
                             let options = versions.iter().map(|v| v.name.clone()).collect();
                             match generic_select(&t!("remove.prompt"), &options) {
-                                Ok(selected) => match remove_single_idf_version(&selected, false) {
+                                Ok(selected) => match remove_single_idf_version(&selected, false, config_path.as_ref()) {
                                     Ok(_) => {
                                         info!("{}", t!("remove.success", version = selected));
                                         Ok(())
@@ -530,7 +545,7 @@ pub async fn run_cli(cli: Cli) -> anyhow::Result<()> {
                     Err(err) => Err(anyhow::anyhow!(err)),
                 }
             } else {
-                match remove_single_idf_version(&version.clone().unwrap(), false) {
+                match remove_single_idf_version(&version.clone().unwrap(), false, config_path.as_ref()) {
                     Ok(_) => {
                         println!("{}", t!("remove.success", version = version.clone().unwrap()));
                         Ok(())
@@ -542,7 +557,7 @@ pub async fn run_cli(cli: Cli) -> anyhow::Result<()> {
         Commands::Purge => {
             // Todo: offer to run discovery first
             println!("{}", t!("purge.title"));
-            match idf_im_lib::version_manager::list_installed_versions() {
+            match idf_im_lib::version_manager::list_installed_versions(config_path.as_ref()) {
                 Ok(versions) => {
                     if versions.is_empty() {
                         println!("{}", t!("purge.no_versions"));
@@ -551,7 +566,7 @@ pub async fn run_cli(cli: Cli) -> anyhow::Result<()> {
                         let mut failed = false;
                         for version in versions {
                             info!("{}", t!("purge.removing", version = version.name));
-                            match remove_single_idf_version(&version.name, false) {
+                            match remove_single_idf_version(&version.name, false, config_path.as_ref()) {
                                 Ok(_) => {
                                     info!("{}", t!("purge.removed", version = version.name));
                                 }
@@ -580,7 +595,14 @@ pub async fn run_cli(cli: Cli) -> anyhow::Result<()> {
             );
             match settings {
                 Ok(mut settings) => {
+                    if let Some(ref p) = cli_esp_idf_json_path {
+                      settings.esp_idf_json_path = Some(p.clone());
+                    }
                     settings.non_interactive = Some(false);
+                    match settings.initialize_esp_ide_json() {
+                      Ok(_) => debug!("ESP-IDF JSON initialized at configured path."),
+                      Err(e) => warn!("Failed to initialize ESP-IDF JSON: {}. IDE integration may not work correctly.", e),
+                    }
                     let time = std::time::SystemTime::now();
                     if !do_not_track {
                       track_cli_event("CLI wizard started", Some(json!({}))).await;
@@ -623,7 +645,7 @@ pub async fn run_cli(cli: Cli) -> anyhow::Result<()> {
                 return Err(anyhow::anyhow!(t!("fix.invalid_directory", path = path)));
                }
             } else {
-              match idf_im_lib::version_manager::list_installed_versions() {
+              match idf_im_lib::version_manager::list_installed_versions(config_path.as_ref()) {
                 Ok(versions) => {
                   if versions.is_empty() {
                       warn!("{}", t!("fix.no_versions"));
@@ -651,7 +673,7 @@ pub async fn run_cli(cli: Cli) -> anyhow::Result<()> {
           };
           info!("{}", t!("fix.fixing", path = path_to_fix.display()));
           // The fix logic is just instalation with use of existing repository
-          let settings = prepare_settings_for_fix_idf_installation(path_to_fix.clone()).await?;
+          let settings = prepare_settings_for_fix_idf_installation(path_to_fix.clone(), config_path.as_ref()).await?;
           let result = wizard::run_wizzard_run(settings).await;
           match result {
             Ok(r) => {
@@ -680,7 +702,12 @@ pub async fn run_cli(cli: Cli) -> anyhow::Result<()> {
                 install_args.config.clone(),
                 install_args.clone().into_iter(),
             ) {
-              Ok(settings) => Some(settings),
+              Ok(mut settings) => {
+                if let Some(ref p) = cli_esp_idf_json_path {
+                  settings.esp_idf_json_path = Some(p.clone());
+                }
+                Some(settings)
+              }
               Err(_) => None
             };
             gui::run(settings, Some(log_level), do_not_track);

--- a/src-tauri/src/gui/commands/installation.rs
+++ b/src-tauri/src/gui/commands/installation.rs
@@ -17,10 +17,10 @@ use anyhow::{anyhow, Context, Result};
 use idf_im_lib::{
   ensure_path,
   expand_tilde,
-  idf_config::IdfConfig,
+  idf_config::{IdfConfig, IDF_CONFIG_FILE_NAME},
   offline_installer::{copy_idf_from_offline_archive, install_prerequisites_offline, use_offline_archive},
   utils::{copy_dir_contents, extract_zst_archive, is_valid_idf_directory, parse_cmake_version},
-  version_manager::{get_default_config_path, prepare_settings_for_fix_idf_installation},
+  version_manager::prepare_settings_for_fix_idf_installation,
   git_tools::ProgressMessage};
 use log::{debug, error, info, warn};
 use serde_json::json;
@@ -1151,7 +1151,13 @@ pub async fn fix_installation(app_handle: AppHandle, id: String) -> Result<(), S
     emit_log_message(&app_handle, MessageLevel::Info,
         rust_i18n::t!("gui.fix.starting_repair", id = id.clone()).to_string());
 
-    let versions = get_installed_versions();
+    let fix_config_path = {
+        let settings = app_state::get_locked_settings(&app_handle)
+            .map_err(|e| format!("Failed to get settings: {}", e))?;
+        settings.esp_idf_json_path.as_ref().map(|p| PathBuf::from(p).join(IDF_CONFIG_FILE_NAME))
+    };
+
+    let versions = get_installed_versions(app_handle.clone());
     let installation = match versions.iter().find(|v| v.id == id) {
         Some(inst) => {
             emit_installation_event(&app_handle, InstallationProgress {
@@ -1194,7 +1200,7 @@ pub async fn fix_installation(app_handle: AppHandle, id: String) -> Result<(), S
         version: Some(installation.name.clone()),
     });
 
-    let mut settings = match prepare_settings_for_fix_idf_installation(PathBuf::from(installation.path.clone())).await {
+    let mut settings = match prepare_settings_for_fix_idf_installation(PathBuf::from(installation.path.clone()), fix_config_path.as_ref()).await {
         Ok(settings) => {
             emit_installation_event(&app_handle, InstallationProgress {
                 stage: InstallationStage::Prerequisites,
@@ -1227,8 +1233,8 @@ pub async fn fix_installation(app_handle: AppHandle, id: String) -> Result<(), S
         }
     };
 
-    // Get the config path for IDE configuration
-    let config_path = get_default_config_path();
+    let config_path = fix_config_path.clone()
+        .unwrap_or_else(idf_im_lib::version_manager::get_default_config_path);
 
     // Starting actual repair (reinstallation)
     emit_installation_event(&app_handle, InstallationProgress {

--- a/src-tauri/src/gui/commands/version_management.rs
+++ b/src-tauri/src/gui/commands/version_management.rs
@@ -1,11 +1,28 @@
-use idf_im_lib::idf_config::IdfInstallation;
+use std::path::PathBuf;
+
+use idf_im_lib::idf_config::{IdfInstallation, IDF_CONFIG_FILE_NAME};
 use idf_im_lib::settings::Settings;
 use log::{debug, error, info};
+use tauri::{AppHandle, Manager};
 
+use crate::gui::app_state::AppState;
+
+fn get_config_path_from_state(app_handle: &AppHandle) -> Option<PathBuf> {
+    let app_state = app_handle.state::<AppState>();
+    let guard = match app_state.settings.lock() {
+        Ok(g) => g,
+        Err(e) => {
+            error!("Failed to acquire settings lock: {}", e);
+            return None;
+        }
+    };
+    guard.esp_idf_json_path.as_ref().map(|p| PathBuf::from(p).join(IDF_CONFIG_FILE_NAME))
+}
 
 #[tauri::command]
-pub fn get_installed_versions() -> Vec<IdfInstallation>{
-  match idf_im_lib::version_manager::get_esp_ide_config() {
+pub fn get_installed_versions(app_handle: AppHandle) -> Vec<IdfInstallation>{
+  let config_path = get_config_path_from_state(&app_handle);
+  match idf_im_lib::version_manager::get_esp_ide_config(config_path.as_ref()) {
     Ok(config) => {
       if config.idf_installed.is_empty() {
         debug!(
@@ -25,10 +42,11 @@ pub fn get_installed_versions() -> Vec<IdfInstallation>{
 }
 
 #[tauri::command]
-pub fn rename_installation(id: String, new_name: String) -> bool {
+pub fn rename_installation(app_handle: AppHandle, id: String, new_name: String) -> bool {
   debug!("Renaming installation with id {} to {}", id, new_name);
+  let config_path = get_config_path_from_state(&app_handle);
 
-  match idf_im_lib::version_manager::rename_idf_version(&id, new_name) {
+  match idf_im_lib::version_manager::rename_idf_version(&id, new_name, config_path.as_ref()) {
     Ok(_) => {
         debug!("Successfully renamed installation {}", id);
         true
@@ -40,10 +58,11 @@ pub fn rename_installation(id: String, new_name: String) -> bool {
   }
 }
 #[tauri::command]
-pub fn remove_installation(id: String) -> bool {
+pub fn remove_installation(app_handle: AppHandle, id: String) -> bool {
   debug!("Removing installation with id {}", id);
+  let config_path = get_config_path_from_state(&app_handle);
 
-  match idf_im_lib::version_manager::remove_single_idf_version(&id, false) {
+  match idf_im_lib::version_manager::remove_single_idf_version(&id, false, config_path.as_ref()) {
     Ok(_) => {
         debug!("Successfully removed installation {}", id);
         true
@@ -56,10 +75,11 @@ pub fn remove_installation(id: String) -> bool {
 }
 
 #[tauri::command]
-pub fn purge_all_installations() -> bool {
+pub fn purge_all_installations(app_handle: AppHandle) -> bool {
   debug!("Purging all installations");
+  let config_path = get_config_path_from_state(&app_handle);
 
-  match idf_im_lib::version_manager::list_installed_versions() {
+  match idf_im_lib::version_manager::list_installed_versions(config_path.as_ref()) {
       Ok(versions) => {
         if versions.is_empty() {
           info!("No versions installed");
@@ -68,7 +88,7 @@ pub fn purge_all_installations() -> bool {
           let mut failed = false;
           for version in versions {
             info!("Removing version: {}", version.name);
-            match idf_im_lib::version_manager::remove_single_idf_version(&version.name, false) {
+            match idf_im_lib::version_manager::remove_single_idf_version(&version.name, false, config_path.as_ref()) {
               Ok(_) => {
                 info!("Removed version: {}", version.name);
               }
@@ -95,10 +115,11 @@ pub fn purge_all_installations() -> bool {
 }
 
 #[tauri::command]
-pub fn generate_installation_config_for_version(id: String) -> Option<String> {
+pub fn generate_installation_config_for_version(app_handle: AppHandle, id: String) -> Option<String> {
   debug!("Generating installation config for id {}", id);
+  let config_path = get_config_path_from_state(&app_handle);
 
-  let config = match idf_im_lib::version_manager::get_esp_ide_config() {
+  let config = match idf_im_lib::version_manager::get_esp_ide_config(config_path.as_ref()) {
     Ok(config) => config,
     Err(err) => {
       error!("Failed to get ESP ide config: {}", err);

--- a/src-tauri/src/gui/mod.rs
+++ b/src-tauri/src/gui/mod.rs
@@ -214,7 +214,11 @@ pub fn setup_gui_logging(
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
-pub fn run(settings: Option<Settings>, log_level_override: Option<log::LevelFilter>, do_not_track: bool) {
+pub fn run(
+    settings: Option<Settings>,
+    log_level_override: Option<log::LevelFilter>,
+    do_not_track: bool,
+) {
     // this is here because macos bundled .app does not inherit path
     #[cfg(target_os = "macos")]
     {
@@ -253,8 +257,17 @@ pub fn run(settings: Option<Settings>, log_level_override: Option<log::LevelFilt
             },
             None => AppState::default()
           };
+          // Initialize eim_idf.json at the configured path (not hardcoded default)
+          match app_state.settings.lock() {
+            Ok(settings) => {
+              match settings.initialize_esp_ide_json() {
+                Ok(_) => log::debug!("ESP-IDF JSON initialized at configured path."),
+                Err(e) => log::warn!("Failed to initialize ESP-IDF JSON: {}. IDE integration may not work correctly.", e),
+              }
+            }
+            Err(e) => log::warn!("Failed to lock settings: {}", e),
+          }
           app.manage(app_state);
-
           // Set usage_statistics based on do_not_track
           let config_dir = dirs::config_dir()
             .ok_or("Failed to get config directory")?

--- a/src-tauri/src/lib/utils.rs
+++ b/src-tauri/src/lib/utils.rs
@@ -589,7 +589,7 @@ fn extract_tools_path_from_python_env_path(path: &str) -> Option<PathBuf> {
 ///
 /// This function logs errors to the console if the configuration file cannot be read or parsed.
 /// It also logs errors if the IDF installation configuration cannot be updated.
-pub fn parse_tool_set_config(config_path: &str) -> Result<()> {
+pub fn parse_tool_set_config(config_path: &str, idf_json_path: Option<&PathBuf>) -> Result<()> {
     let config_path = Path::new(config_path);
     let json_str = std::fs::read_to_string(config_path).unwrap();
     let config: Vec<IdfToolsConfig> = match serde_json::from_str(&json_str) {
@@ -597,7 +597,7 @@ pub fn parse_tool_set_config(config_path: &str) -> Result<()> {
         Err(e) => return Err(anyhow!("Failed to parse config file: {}", e)),
     };
     let mut settings = crate::settings::Settings::default();
-    let config_path = get_default_config_path();
+    let config_path = idf_json_path.cloned().unwrap_or_else(get_default_config_path);
     let mut current_config = match IdfConfig::from_file(&config_path) {
       Ok(config) => config,
       Err(_e) => {

--- a/src-tauri/src/lib/version_manager.rs
+++ b/src-tauri/src/lib/version_manager.rs
@@ -66,10 +66,8 @@ pub fn get_default_config_path() -> PathBuf {
     PathBuf::from(default_settings.esp_idf_json_path.unwrap_or_default()).join("eim_idf.json")
 }
 
-// todo: add optional path parameter enabling the user to specify a custom config file
-// or to search for it in a different location ( or whole filesystem)
-pub fn list_installed_versions() -> Result<Vec<IdfInstallation>> {
-    let config_path = get_default_config_path();
+pub fn list_installed_versions(config_path: Option<&PathBuf>) -> Result<Vec<IdfInstallation>> {
+    let config_path = config_path.cloned().unwrap_or_else(get_default_config_path);
     get_installed_versions_from_config_file(&config_path)
 }
 
@@ -96,21 +94,21 @@ pub fn get_installed_versions_from_config_file(
 
 /// Retrieves the selected ESP-IDF installation from the configuration file.
 ///
-/// This function reads the ESP-IDF configuration from the default location specified by the
-/// `get_default_config_path` function and returns the selected installation. If no installation is
-/// selected, it logs a warning and returns `None`.
+/// Reads the ESP-IDF configuration from the given path (or the default location if `None`)
+/// and returns the selected installation. If no installation is selected, it logs a warning
+/// and returns `None`.
 ///
 /// # Parameters
 ///
-/// None.
+/// * `config_path` - Optional path to the ESP-IDF configuration file. Falls back to the default path when `None`.
 ///
 /// # Returns
 ///
 /// * `Option<IdfInstallation>` - Returns `Some(IdfInstallation)` if a selected installation is found in the
 ///   configuration file. Returns `None` if no installation is selected or if an error occurs while reading
 ///   the configuration file.
-pub fn get_selected_version() -> Option<IdfInstallation> {
-    let config_path = get_default_config_path();
+pub fn get_selected_version(config_path: Option<&PathBuf>) -> Option<IdfInstallation> {
+    let config_path = config_path.cloned().unwrap_or_else(get_default_config_path);
     let ide_config = IdfConfig::from_file(config_path).ok();
     if let Some(config) = ide_config {
         match config.get_selected_installation() {
@@ -123,21 +121,18 @@ pub fn get_selected_version() -> Option<IdfInstallation> {
     }
     None
 }
-/// Retrieves the ESP-IDF configuration from the default location.
-///
-/// This function reads the ESP-IDF configuration from the default location specified by the
-/// `get_default_config_path` function. The configuration is then returned as an `IdfConfig` struct.
+/// Retrieves the ESP-IDF configuration from the given path or the default location.
 ///
 /// # Parameters
 ///
-/// None.
+/// * `config_path` - Optional path to the ESP-IDF configuration file. Falls back to the default path when `None`.
 ///
 /// # Returns
 ///
 /// * `Result<IdfConfig, anyhow::Error>` - On success, returns a `Result` containing the `IdfConfig` struct
 ///   representing the ESP-IDF configuration. On error, returns an `anyhow::Error` with a description of the error.
-pub fn get_esp_ide_config() -> Result<IdfConfig> {
-    let config_path = get_default_config_path();
+pub fn get_esp_ide_config(config_path: Option<&PathBuf>) -> Result<IdfConfig> {
+    let config_path = config_path.cloned().unwrap_or_else(get_default_config_path);
     IdfConfig::from_file(&config_path)
 }
 
@@ -157,8 +152,8 @@ pub fn get_esp_ide_config() -> Result<IdfConfig> {
 ///
 /// * `Result<String, anyhow::Error>` - On success, returns a `Result` containing a string message indicating
 ///   that the version has been selected. On error, returns an `anyhow::Error` with a description of the error.
-pub fn select_idf_version(identifier: &str) -> Result<String> {
-    let config_path = get_default_config_path();
+pub fn select_idf_version(identifier: &str, config_path: Option<&PathBuf>) -> Result<String> {
+    let config_path = config_path.cloned().unwrap_or_else(get_default_config_path);
     let mut ide_config = IdfConfig::from_file(&config_path)?;
     if ide_config.select_installation(identifier) {
         ide_config.to_file(config_path, true, false)?;
@@ -185,8 +180,8 @@ pub fn select_idf_version(identifier: &str) -> Result<String> {
 ///
 /// * `Result<String, anyhow::Error>` - On success, returns a `Result` containing a string message indicating
 ///   that the version has been renamed. On error, returns an `anyhow::Error` with a description of the error.
-pub fn rename_idf_version(identifier: &str, new_name: String) -> Result<String> {
-    let config_path = get_default_config_path();
+pub fn rename_idf_version(identifier: &str, new_name: String, config_path: Option<&PathBuf>) -> Result<String> {
+    let config_path = config_path.cloned().unwrap_or_else(get_default_config_path);
     let mut ide_config = IdfConfig::from_file(&config_path)?;
     let res = ide_config.update_installation_name(identifier, new_name.to_string());
     if res {
@@ -262,9 +257,9 @@ pub fn find_shortcut_by_profile(custom_profile_filename: &str) -> anyhow::Result
 ///
 /// * `Result<String, anyhow::Error>` - On success, returns a `Result` containing a string message indicating
 ///   that the version has been removed. On error, returns an `anyhow::Error` with a description of the error.
-pub fn remove_single_idf_version(identifier: &str, keep_idf_folder: bool) -> Result<String> {
+pub fn remove_single_idf_version(identifier: &str, keep_idf_folder: bool, config_path: Option<&PathBuf>) -> Result<String> {
     //TODO: remove also from path
-    let config_path = get_default_config_path();
+    let config_path = config_path.cloned().unwrap_or_else(get_default_config_path);
     let mut ide_config = IdfConfig::from_file(&config_path)?;
     if let Some(installation) = ide_config
         .idf_installed
@@ -386,8 +381,8 @@ pub fn find_esp_idf_folders(path: &str) -> Vec<String> {
         .collect()
 }
 
-pub fn run_command_in_context(identifier: &str, command: &str) -> anyhow::Result<ExitStatus> {
-    let installation = match list_installed_versions() {
+pub fn run_command_in_context(identifier: &str, command: &str, config_path: Option<&PathBuf>) -> anyhow::Result<ExitStatus> {
+    let installation = match list_installed_versions(config_path) {
         Ok(versions) => versions.into_iter().find(|v| {
             v.id == identifier
                 || v.name == identifier
@@ -466,17 +461,17 @@ pub fn run_command_using_activation_script_headless(activation_script: &str, com
     }
   }
 
-pub async fn prepare_settings_for_fix_idf_installation(path_to_fix: PathBuf) -> anyhow::Result<Settings> {
+pub async fn prepare_settings_for_fix_idf_installation(path_to_fix: PathBuf, config_path: Option<&PathBuf>) -> anyhow::Result<Settings> {
     info!("Fixing IDF installation at path: {}", path_to_fix.display());
     // The fix logic is just instalation with use of existing repository
     let mut version_name = None;
-    match list_installed_versions() {
+    match list_installed_versions(config_path) {
         Ok(versions) => {
             for v in versions {
                 if v.path == path_to_fix.to_str().unwrap() {
                     info!("Found existing IDF version: {}", v.name);
                     // Remove the existing activation script and eim_idf.json entry
-                    match remove_single_idf_version(&v.name, true) {
+                    match remove_single_idf_version(&v.name, true, config_path) {
                         Ok(_) => {
                             info!("Removed existing IDF version from eim_idf.json: {}", v.name);
                             version_name = Some(v.name.clone());

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -9,7 +9,6 @@ pub mod gui;
 
 #[cfg(feature = "cli")]
 use clap::Parser;
-use idf_im_lib::settings::Settings;
 #[cfg(feature = "cli")]
 use log::{debug, info};
 #[cfg(feature = "cli")]
@@ -116,10 +115,6 @@ async fn main() {
         setup_interactive_console()
     } else {
         false
-    };
-    match Settings::default().initialize_esp_ide_json() {
-        Ok(_) => log::debug!("ESP-IDF JSON initialized successfully."),
-        Err(e) => log::warn!("Failed to initialize ESP-IDF JSON: {}. It is possible you will face issues with persistance and IDE integration.", e),
     };
     #[cfg(not(feature = "gui"))]
     {


### PR DESCRIPTION
## Summary

Fixes [EIM-323](https://jira.espressif.com:8443/browse/EIM-323) — `--esp-idf-json-path` was ignored in several code paths, causing an empty `eim_idf.json` to be created at the default location and version management commands to always read from the default path regardless of user input.

## What changed

### Bug fix: Stop premature `eim_idf.json` creation

- Removed the `Settings::default().initialize_esp_ide_json()` call in `main.rs` that ran at startup *before* CLI arguments were parsed, unconditionally creating an empty file at the default path.
- Deferred `initialize_esp_ide_json()` to after `Settings::new()` in the `Install`, `Wizard`, and `GUI` code paths, so the file is created at the user-specified location.

### Bug fix: Thread custom config path through all version management

- All 8 core functions in `version_manager.rs` (`list_installed_versions`, `get_selected_version`, `get_esp_ide_config`, `select_idf_version`, `rename_idf_version`, `remove_single_idf_version`, `run_command_in_context`, `prepare_settings_for_fix_idf_installation`) now accept `Option<&PathBuf>` for the config file path, falling back to the default when `None`.
- CLI: `config_path` is computed once from `cli.esp_idf_json_path` and passed to every version management call.
- GUI: All 5 Tauri commands in `version_management.rs` read the path from `AppState` settings. `fix_installation` in `installation.rs` does the same.
- `parse_tool_set_config` in `utils.rs` also accepts an optional path for the `import` command.

### Bug fix: Remove duplicate `--esp-idf-json-path` CLI argument

- The flag existed in both `Cli` (global) and `InstallArgs` (subcommand). Clap's subcommand-level shadowing meant `eim install --esp-idf-json-path /foo` bound to `InstallArgs`, leaving `Cli.esp_idf_json_path = None` — so the "already installed" pre-check used the wrong path.
- Removed the field from `InstallArgs` and its `IntoIterator` impl. The global `Cli` field is now the single source of truth.
- `Install`, `Wizard`, and `Gui` branches explicitly set `settings.esp_idf_json_path` from the global arg after `Settings::new()`.

### User-facing hint

- Added `cli.hint.custom_json_path` i18n key (EN/CN) that logs a hint in the 5 version management error branches (`list`, `select`, `rename`, `remove`, `purge`), guiding users to pass `--esp-idf-json-path` if they installed to a custom location.

### Code quality

- Consolidated duplicate `idf_config` imports in `installation.rs`.
- Fixed import ordering in `cli/mod.rs` to match project conventions.
- Added error logging on mutex poison in `get_config_path_from_state()` instead of silently returning `None`.

### Documentation

- `docs/src/cli_commands.md`: Moved `--esp-idf-json-path` from Install options to Global Options.
- `man/eim.1`: Same move to GLOBAL OPTIONS section.
- `docs/src/faq.md`: Added `--esp-idf-json-path` to custom install example and noted it must be passed to subsequent commands.

## Files changed

| File | Change |
|------|--------|
| `src-tauri/src/main.rs` | Removed premature `initialize_esp_ide_json()` |
| `src-tauri/src/cli/cli_args.rs` | Removed duplicate field from `InstallArgs`, updated global help text |
| `src-tauri/src/cli/mod.rs` | Thread config path, inject into Settings, add hints |
| `src-tauri/src/lib/version_manager.rs` | 8 functions accept optional config path |
| `src-tauri/src/lib/utils.rs` | `parse_tool_set_config` accepts optional path |
| `src-tauri/src/gui/mod.rs` | Deferred `initialize_esp_ide_json()` for GUI |
| `src-tauri/src/gui/commands/version_management.rs` | Read path from AppState, log on lock failure |
| `src-tauri/src/gui/commands/installation.rs` | Derive config path from AppState, consolidate imports |
| `src-tauri/locales/app.yml` | Added hint i18n key |
| `docs/src/cli_commands.md` | Global option docs |
| `man/eim.1` | Global option man page |
| `docs/src/faq.md` | Custom install FAQ update |