### PR TITLE
postpone mirror latency check

### DIFF
--- a/src/components/wizard_steps/PrerequisitiesCheck.vue
+++ b/src/components/wizard_steps/PrerequisitiesCheck.vue
@@ -71,7 +71,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { useI18n } from 'vue-i18n';
 import { NButton, NSpin, NProgress, NCard } from 'naive-ui' // Added NCard here
-import { useAppStore } from '../../store'
+import { useAppStore, useMirrorsStore } from '../../store'
 
 export default {
   name: 'PrerequisitiesCheck',
@@ -94,6 +94,7 @@ export default {
     shell_failed: false,
     os: undefined,
     appStore: useAppStore(),
+    mirrorsStore: useMirrorsStore(),
     unlistenInstallComplete: null
   }),
   watch: {
@@ -165,6 +166,8 @@ export default {
 
     await this.get_os();
     await this.check_prerequisites();
+
+    this.mirrorsStore.bootstrapMirrorsBackground();
   },
   unmounted() {
     if (this.unlistenInstallComplete) {

--- a/src/main.js
+++ b/src/main.js
@@ -6,7 +6,6 @@ import router from "./router";
 import naive from "naive-ui";
 import "./assets/main.css"; // Import the CSS file
 import { useAppStore } from './store'
-import { useMirrorsStore } from "./store";
 
 // Translation files
 import en from "./locales/en.json";
@@ -41,8 +40,4 @@ setTimeout(() => {
   }).catch(err => {
     console.error("Failed to initialize system info:", err);
   });
-
-  // Bootstrap mirrors in background (lazy load)
-  const mirrorsStore = useMirrorsStore();
-  mirrorsStore.bootstrapMirrorsBackground();
 }, 100);


### PR DESCRIPTION
As now after #892 only the advanced installation uses any of these mirrors, we can postpone the start of the latency checking so it's not done for the users that will never use the mirrors.