### PR TITLE
Eim 432 add tools to fix command

### DIFF
--- a/docs/src/cli_commands.md
+++ b/docs/src/cli_commands.md
@@ -31,6 +31,7 @@ These options can be used with any command:
 | `select` | Select an ESP-IDF version as active |
 | `rename` | Rename a specific ESP-IDF version |
 | `remove` | Remove a specific ESP-IDF version |
+| `fix` | Fix (repair/reinstall) an existing ESP-IDF installation, preserving its original tools/features unless overridden |
 | `purge` | Purge all ESP-IDF installations |
 | `import` | Import existing ESP-IDF installation using tools_set_config.json |
 | `run` | Run a command in the context of a specific ESP-IDF version |
@@ -215,13 +216,27 @@ This command is planned to discover ESP-IDF installations on your system but is 
 
 ### Fix Command
 
-Fix the ESP-IDF installation by reinstalling the tools and dependencies
+Fix (repair/reinstall) an existing ESP-IDF installation by reinstalling its tools and dependencies.
 
 ```bash
-eim fix [PATH]
+eim fix [OPTIONS]
 ```
 
-If no `PATH` is provided, the user will be presented with selection of all known IDF installation to select from.
+Options:
+- `-p, --path <PATH>`: Path of the existing installation to fix. If omitted, you will be presented with a selection of all known IDF installations to choose from.
+
+`fix` accepts the same options as [`install`](#install-command) / [`wizard`](#wizard-command) (`--idf-features`, `--idf-tools`, `--target`, `-i, --idf-versions`, `-m, --mirror`, etc.). By default, `fix` reinstalls the version using **exactly the configuration it was originally installed with** — the same target, features and tools are preserved, so you don't lose any customization made at install time. Any option you explicitly pass on the command line overrides both the preserved value and the built-in default for that option, letting you fix an installation with a different set of tools/features than it originally had.
+
+```bash
+# Fix (repair) an installation, keeping its original tools/features
+eim fix -p /path/to/existing/esp-idf
+
+# Fix an installation and additionally install the cmake and openocd tools
+eim fix -p /path/to/existing/esp-idf --idf-tools cmake,openocd
+
+# Fix an installation, choosing interactively from all installed versions
+eim fix
+```
 
 ### Completions Command
 
@@ -293,6 +308,12 @@ eim rename v5.3.2 "ESP-IDF 5.3.2 Stable"
 
 # Remove a specific version
 eim remove v5.3.2
+
+# Fix (repair) an installation, keeping its original tools/features
+eim fix -p /path/to/existing/esp-idf
+
+# Fix an installation while also adding tools that weren't installed originally
+eim fix -p /path/to/existing/esp-idf --idf-tools cmake,openocd
 
 # Purge all installations
 eim purge

--- a/docs/src/cli_configuration.md
+++ b/docs/src/cli_configuration.md
@@ -171,6 +171,14 @@ The installer determines which tools to use for each version in the following or
 3. **Interactive selection**: In wizard mode, you'll be prompted to select tools for each version
 4. **Required only**: In non-interactive mode without any tool configuration, only required tools are installed
 
+### Changing Tools or Features on an Existing Installation
+
+The `eim fix` command (see [CLI Commands](./cli_commands.md#fix-command)) accepts the same `--idf-features` / `--idf-tools` (and per-version equivalents) as `install`/`wizard`. By default it reinstalls using the configuration the version was originally installed with, so nothing is lost. Passing `--idf-features`/`--idf-tools` explicitly to `eim fix` overrides the preserved configuration for that run, letting you add (or change) tools/features without redoing the whole installation:
+
+```bash
+eim fix -p /path/to/existing/esp-idf --idf-tools cmake,openocd
+```
+
 ### Interactive Tool Selection
 
 When using the wizard command, you'll be prompted to select tools for each ESP-IDF version:

--- a/docs/src/faq.md
+++ b/docs/src/faq.md
@@ -99,6 +99,20 @@ If EIM detects a valid ESP-IDF Git repository at the selected path, it will:
 - **Utilize that existing repository**: It will not download a new copy or overwrite your existing files.
 - **Ignore selected ESP-IDF versions**: Any specific ESP-IDF version you may have chosen in the GUI or via CLI arguments will be disregarded, as EIM will work with the version already present in your existing repository.
 
+### How do I add more tools to an existing installation?
+
+You don't need to reinstall from scratch to add a tool you skipped the first time around.
+
+**GUI:** Open the **Version Management** dashboard, click **List Tools** on the version you want to change. The modal shows every tool declared in that version's `tools.json`, including optional ones that aren't installed yet. If there are any available to add, an **Add more tools** button appears next to the paths at the top of the modal — click it, check the tools you want, and confirm. This reinstalls the version with the newly selected tools added on top of what's already there; your existing tools and features are left untouched.
+
+**CLI:** Use `eim fix` with `--idf-tools` (or `--idf-features` for optional features), pointing at the existing installation:
+
+```bash
+eim fix -p /path/to/existing/esp-idf --idf-tools cmake,openocd
+```
+
+`eim fix` preserves the configuration the version was originally installed with and only overrides what you explicitly pass, so any tools/features you don't mention stay as they were. See [CLI Commands](./cli_commands.md#fix-command) for details.
+
 ### How does offline installation work?
 
 The offline installation allows you to install ESP-IDF without an internet connection. You need to download an offline installer artifact (a zip file) for your specific OS and ESP-IDF version. This artifact contains the installer and a `.zst` archive with all the necessary data. You then run the installer with the `--use-local-archive` flag, pointing to the `.zst` file. Remember **not** to unpack the `.zst` archive. Also, the offline installation currently requires **Python 3.11 to 3.13**. For detailed instructions, please see the [Offline Installation](./offline_installation.md) guide.

--- a/docs/src/version_management.md
+++ b/docs/src/version_management.md
@@ -6,9 +6,14 @@ On this page, you can see a list of all your installed ESP-IDF versions. For eac
 
   * **Open IDF Terminal**: Open terminal with the appropriate IDF activated
   * **Rename**: Change the name of the installed version.
-  * **Fix/Reinstall**: Rerun the installation process to repair a corrupted environment.
+  * **Fix/Reinstall**: Rerun the installation process to repair a corrupted environment. This preserves the target, features and tools the version was originally installed with, so you don't lose any customization.
   * **Open Folder**: Open the installation directory in your file explorer.
+  * **List Tools**: Open a modal showing every tool declared in the version's `tools.json`, its installed version(s), and whether it's up to date. See **Adding More Tools** below.
   * **Delete**: Uninstall the specific ESP-IDF version.
+
+### Adding More Tools to an Existing Installation
+
+Open **List Tools** for a version to see its full tool catalog, including optional tools that weren't installed. If any optional tools are available to add, an **Add more tools** button appears next to the IDF/tools paths at the top of the modal. Click it, check the tools you want, and confirm — this triggers a repair (the same mechanism as **Fix**) that reinstalls the version with the newly selected tools added on top of what's already there, without touching your existing configuration otherwise.
 
 At the bottom of the page, you'll also find options to:
 

--- a/src-tauri/src/cli/cli_args.rs
+++ b/src-tauri/src/cli/cli_args.rs
@@ -133,8 +133,8 @@ pub enum Commands {
 
     /// Fix the ESP-IDF installation by reinstalling the tools and dependencies
     Fix {
-        #[arg(help = "Fix IDF on a specific path")]
-        path: Option<String>,
+        #[command(flatten)]
+        install_args: InstallArgs,
     },
 
     /// Install drivers for ESP-IDF. This is only available on Windows platforms.
@@ -155,12 +155,12 @@ pub struct InstallArgs {
     #[arg(
         short,
         long,
-        help = "Base Path to which all the files and folder will be installed",
+        help = "Base Path to which all the files and folder will be installed. For the `fix` command, this is the path of the existing installation to fix.",
         value_parser = |s: &str| -> Result<String, String> {
             to_absolute_path(s).map_err(|e| e.to_string())
         }
     )]
-    path: Option<String>,
+    pub path: Option<String>,
 
     #[arg(short, long, value_name = "FILE")]
     pub config: Option<PathBuf>,

--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -742,10 +742,9 @@ pub async fn run_cli(cli: Cli) -> anyhow::Result<()> {
                 Err(err) => Err(anyhow::anyhow!(err)),
             }
         }
-        Commands::Fix { path } => {
-          let path_to_fix = if path.is_some() {
+        Commands::Fix { install_args } => {
+          let path_to_fix = if let Some(path) = install_args.path.clone() {
               // If a path is provided, fix the IDF installation at that path
-              let path = path.unwrap();
                if is_valid_idf_directory(&path) {
                 PathBuf::from(path)
                } else {
@@ -780,8 +779,12 @@ pub async fn run_cli(cli: Cli) -> anyhow::Result<()> {
             }
           };
           info!("{}", t!("fix.fixing", path = path_to_fix.display()));
-          // The fix logic is just instalation with use of existing repository
-          let settings = prepare_settings_for_fix_idf_installation(path_to_fix.clone(), config_path.as_ref()).await?;
+          // The fix logic is just instalation with use of existing repository.
+          // Start from the settings the installation was originally created with (so tools,
+          // features, target etc. are preserved), then let any CLI args the user explicitly
+          // passed to `fix` override those preserved values (and the defaults).
+          let mut settings = prepare_settings_for_fix_idf_installation(path_to_fix.clone(), config_path.as_ref()).await?;
+          settings.apply_cli_overrides(install_args.into_iter())?;
           let result = wizard::run_wizzard_run(settings).await;
           match result {
             Ok(r) => {

--- a/src-tauri/src/gui/commands/installation.rs
+++ b/src-tauri/src/gui/commands/installation.rs
@@ -1167,8 +1167,8 @@ pub async fn start_simple_setup(app_handle: tauri::AppHandle) -> Result<(), Stri
 }
 
 #[tauri::command]
-pub async fn fix_installation(app_handle: AppHandle, id: String) -> Result<(), String> {
-    debug!("Fixing installation with id {}", id);
+pub async fn fix_installation(app_handle: AppHandle, id: String, extra_tools: Option<Vec<String>>) -> Result<(), String> {
+    debug!("Fixing installation with id {}, extra_tools: {:?}", id, extra_tools);
 
     // Set installation flag to indicate installation is running
     set_installation_status(&app_handle, true)?;
@@ -1266,6 +1266,24 @@ pub async fn fix_installation(app_handle: AppHandle, id: String) -> Result<(), S
             return Err(error_msg);
         }
     };
+
+    // If the user picked additional (previously not-installed, on_request) tools in the
+    // "add more tools" picker, merge them into whatever tools this version was already
+    // configured with, keyed the same way `setup_tools` looks them up (by the installation's
+    // current name). The "always" required tools are re-derived by `setup_tools` regardless
+    // of what's in this list, so we only need to add the newly requested ones here.
+    if let Some(extra) = extra_tools.filter(|t| !t.is_empty()) {
+        let version_key = installation.name.clone();
+        let mut per_version = settings.idf_tools_per_version.clone().unwrap_or_default();
+        let mut tools_for_version = per_version.get(&version_key).cloned().unwrap_or_default();
+        for tool in extra {
+            if !tools_for_version.contains(&tool) {
+                tools_for_version.push(tool);
+            }
+        }
+        per_version.insert(version_key, tools_for_version);
+        settings.idf_tools_per_version = Some(per_version);
+    }
 
     let config_path = fix_config_path.clone()
         .unwrap_or_else(idf_im_lib::version_manager::get_default_config_path);

--- a/src-tauri/src/gui/commands/installation.rs
+++ b/src-tauri/src/gui/commands/installation.rs
@@ -1275,7 +1275,10 @@ pub async fn fix_installation(app_handle: AppHandle, id: String, extra_tools: Op
     if let Some(extra) = extra_tools.filter(|t| !t.is_empty()) {
         let version_key = installation.name.clone();
         let mut per_version = settings.idf_tools_per_version.clone().unwrap_or_default();
-        let mut tools_for_version = per_version.get(&version_key).cloned().unwrap_or_default();
+        let mut tools_for_version = per_version
+            .get(&version_key)
+            .cloned()
+            .unwrap_or_else(|| settings.idf_tools.clone().unwrap_or_default());
         for tool in extra {
             if !tools_for_version.contains(&tool) {
                 tools_for_version.push(tool);

--- a/src-tauri/src/lib/settings.rs
+++ b/src-tauri/src/lib/settings.rs
@@ -145,6 +145,42 @@ impl Settings {
         // Start with default settings
         let mut settings = Self::default();
 
+        // If a config file is provided, load it
+        if let Some(config_path) = config_path.clone() {
+          if config_path.exists() {
+            log::info!("Loading config from file: {:?}", config_path);
+            match settings.load(config_path.to_str().unwrap_or_default()) {
+              Ok(_) => log::info!("Config loaded successfully"),
+              Err(e) => log::warn!("Failed to load config from file: {}", e),
+            }
+          } else {
+            log::warn!("Config file does not exist: {:?}", config_path);
+          }
+        }
+        log::debug!("Settings after file load {:?}", settings);
+
+        log::debug!("Settings after config load - idf_features: {:?}", settings.idf_features);
+
+        settings.apply_cli_overrides(cli_settings)?;
+
+        // Set the config file field if not already set
+        if settings.config_file.is_none() {
+            settings.config_file = config_path;
+        }
+        log::debug!("Final settings: {:?}", settings);
+
+
+        Ok(settings)
+    }
+
+    /// Applies explicitly-provided CLI values on top of the current settings, overriding
+    /// whatever was there before (defaults, a loaded config file, or a recovered installation
+    /// config). Fields absent from `cli_settings` (i.e. not explicitly passed on the CLI) are
+    /// left untouched.
+    pub fn apply_cli_overrides(
+        &mut self,
+        cli_settings: impl IntoIterator<Item = (String, Option<config::Value>)>,
+    ) -> Result<(), ConfigError> {
         // Collect CLI settings and track which were EXPLICITLY provided (not None)
         let cli_items: Vec<_> = cli_settings.into_iter().collect();
         let mut cli_overrides: std::collections::HashSet<String> = std::collections::HashSet::new();
@@ -164,22 +200,6 @@ impl Settings {
 
         log::debug!("CLI overrides: {:?}", cli_overrides);
 
-        // If a config file is provided, load it
-        if let Some(config_path) = config_path.clone() {
-          if config_path.exists() {
-            log::info!("Loading config from file: {:?}", config_path);
-            match settings.load(config_path.to_str().unwrap_or_default()) {
-              Ok(_) => log::info!("Config loaded successfully"),
-              Err(e) => log::warn!("Failed to load config from file: {}", e),
-            }
-          } else {
-            log::warn!("Config file does not exist: {:?}", config_path);
-          }
-        }
-        log::debug!("Settings after file load {:?}", settings);
-
-        log::debug!("Settings after config load - idf_features: {:?}", settings.idf_features);
-
         let cli_config = cli_config.build()?;
         if let Ok(cli_settings_struct) = cli_config.try_deserialize::<Settings>() {
           macro_rules! apply_if_overridden {
@@ -187,7 +207,7 @@ impl Settings {
               $(
                 if cli_overrides.contains(stringify!($field)) {
                   log::debug!("Applying CLI override for {}: {:?}", stringify!($field), cli_settings_struct.$field);
-                  settings.$field = cli_settings_struct.$field.clone();
+                  self.$field = cli_settings_struct.$field.clone();
                 }
               )*
             };
@@ -224,14 +244,7 @@ impl Settings {
           );
         }
 
-        // Set the config file field if not already set
-        if settings.config_file.is_none() {
-            settings.config_file = config_path;
-        }
-        log::debug!("Final settings: {:?}", settings);
-
-
-        Ok(settings)
+        Ok(())
     }
 
     pub fn save(&self) -> Result<(), ConfigError> {

--- a/src-tauri/src/lib/version_manager.rs
+++ b/src-tauri/src/lib/version_manager.rs
@@ -520,11 +520,29 @@ pub async fn prepare_settings_for_fix_idf_installation(
     info!("Fixing IDF installation at path: {}", path_to_fix.display());
     // The fix logic is just instalation with use of existing repository
     let mut version_name = None;
+    let mut original_settings: Option<Settings> = None;
     match list_installed_versions(config_path) {
         Ok(versions) => {
             for v in versions {
                 if v.path == path_to_fix.to_str().unwrap() {
                     info!("Found existing IDF version: {}", v.name);
+                    // Recover the settings the installation was originally created with
+                    match &v.installation_config {
+                        Some(config_bytes) => {
+                            match bincode::deserialize::<Settings>(config_bytes.as_slice()) {
+                                Ok(settings) => {
+                                    info!("Recovered original installation settings for {}", v.name);
+                                    original_settings = Some(settings);
+                                }
+                                Err(err) => {
+                                    warn!("Failed to deserialize installation_config for {}: {}. Falling back to defaults.", v.name, err);
+                                }
+                            }
+                        }
+                        None => {
+                            warn!("No installation_config stored for {}. Falling back to defaults.", v.name);
+                        }
+                    }
                     // Remove the existing activation script and eim_idf.json entry
                     match remove_single_idf_version(&v.name, true, config_path) {
                         Ok(_) => {
@@ -543,7 +561,7 @@ pub async fn prepare_settings_for_fix_idf_installation(
         }
     }
 
-    let mut settings = Settings::default();
+    let mut settings = original_settings.unwrap_or_default();
     settings.path = Some(path_to_fix.clone());
     settings.non_interactive = Some(true);
     settings.version_name = version_name;

--- a/src/components/VersionManagement.vue
+++ b/src/components/VersionManagement.vue
@@ -276,15 +276,70 @@
       </div>
 
       <div v-else-if="listToolsReport" class="list-tools-content" data-id="list-tools-content">
-        <!-- Meta strip -->
-        <div class="list-tools-meta">
-          <div class="meta-row">
-            <span class="meta-label">{{ t('versionManagement.modals.listTools.idfPath') }}:</span>
-            <code class="meta-value">{{ listToolsReport.idf.path }}</code>
+        <!-- Meta strip + add-tools trigger, aligned on the same row -->
+        <div class="list-tools-header">
+          <div class="list-tools-meta">
+            <div class="meta-row">
+              <span class="meta-label">{{ t('versionManagement.modals.listTools.idfPath') }}:</span>
+              <code class="meta-value">{{ listToolsReport.idf.path }}</code>
+            </div>
+            <div class="meta-row">
+              <span class="meta-label">{{ t('versionManagement.modals.listTools.toolsPath') }}:</span>
+              <code class="meta-value">{{ listToolsReport.idf_tools_path }}</code>
+            </div>
           </div>
-          <div class="meta-row">
-            <span class="meta-label">{{ t('versionManagement.modals.listTools.toolsPath') }}:</span>
-            <code class="meta-value">{{ listToolsReport.idf_tools_path }}</code>
+
+          <n-button
+            v-if="!showAddToolsPanel"
+            size="small"
+            type="primary"
+            secondary
+            @click="openAddToolsPanel"
+            data-id="show-add-tools-button"
+          >
+            <template #icon><n-icon><PlusCircleOutlined /></n-icon></template>
+            {{ t('versionManagement.modals.listTools.addTools.button') }}
+          </n-button>
+        </div>
+
+        <!-- Add more tools panel -->
+        <div v-if="showAddToolsPanel" class="add-tools-panel" data-id="add-tools-panel">
+          <h4>{{ t('versionManagement.modals.listTools.addTools.title') }}</h4>
+
+          <n-empty
+            v-if="availableToolsToAdd.length === 0"
+            :description="t('versionManagement.modals.listTools.addTools.none')"
+            size="small"
+            data-id="add-tools-none"
+          />
+
+          <n-checkbox-group v-else v-model:value="selectedExtraTools" data-id="add-tools-checkbox-group">
+            <n-space vertical>
+              <n-checkbox
+                v-for="entry in availableToolsToAdd"
+                :key="entry.tool.name"
+                :value="entry.tool.name"
+                :data-id="`add-tools-checkbox-${entry.tool.name}`"
+              >
+                <strong>{{ entry.tool.name }}</strong> — {{ entry.tool.description }}
+              </n-checkbox>
+            </n-space>
+          </n-checkbox-group>
+
+          <div class="add-tools-actions">
+            <n-button size="small" @click="cancelAddToolsPanel" data-id="add-tools-cancel-button">
+              {{ t('versionManagement.modals.listTools.addTools.cancel') }}
+            </n-button>
+            <n-button
+              size="small"
+              type="primary"
+              :disabled="selectedExtraTools.length === 0"
+              :loading="addingTools"
+              @click="confirmAddTools"
+              data-id="add-tools-confirm-button"
+            >
+              {{ t('versionManagement.modals.listTools.addTools.confirm') }}
+            </n-button>
           </div>
         </div>
 
@@ -345,7 +400,7 @@
 </template>
 
 <script>
-import { ref, onMounted, onUnmounted, version } from 'vue'
+import { ref, computed, onMounted, onUnmounted, version } from 'vue'
 import { useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { invoke } from '@tauri-apps/api/core'
@@ -353,7 +408,7 @@ import { listen } from '@tauri-apps/api/event'
 import { save } from '@tauri-apps/plugin-dialog'
 import {
   NButton, NCard, NIcon, NTag, NEmpty, NModal, NInput,
-  NCheckbox, NAlert, NTooltip, NSpin, useMessage
+  NCheckbox, NCheckboxGroup, NSpace, NAlert, NTooltip, NSpin, useMessage
 } from 'naive-ui'
 import {
   FolderOutlined,
@@ -375,7 +430,7 @@ export default {
   name: 'VersionManagement',
   components: {
     NButton, NCard, NIcon, NTag, NEmpty, NModal, NInput,
-    NCheckbox, NAlert, NTooltip, NSpin,
+    NCheckbox, NCheckboxGroup, NSpace, NAlert, NTooltip, NSpin,
     FolderOutlined, FolderOpenOutlined, EditOutlined,
     DeleteOutlined, ToolOutlined, PlusCircleOutlined,
     ClearOutlined, ReloadOutlined, UsbOutlined, LaptopOutlined,
@@ -408,7 +463,21 @@ export default {
     const listToolsVersion = ref(null)
     const listToolsReport = ref(null)
     const listToolsLoading = ref(false)
+    const showAddToolsPanel = ref(false)
+    const selectedExtraTools = ref([])
+    const addingTools = ref(false)
     const appStore = useAppStore()
+
+    // Optional (on_request) tools that are not currently installed for this version -
+    // candidates the user can pick to add on top of the existing fix/install.
+    const availableToolsToAdd = computed(() => {
+      if (!listToolsReport.value) return []
+      return listToolsReport.value.tools.filter(entry =>
+        entry.tool.install === 'on_request' &&
+        entry.version_inspections.some(vi => vi.has_platform_download) &&
+        !entry.version_inspections.some(vi => vi.installed)
+      )
+    })
 
     const loadInstalledVersions = async () => {
       try {
@@ -547,6 +616,8 @@ export default {
       listToolsReport.value = null
       listToolsLoading.value = true
       showListToolsModal.value = true
+      showAddToolsPanel.value = false
+      selectedExtraTools.value = []
       try {
         const report = await invoke('list_idf_tools', { id: version.id })
         if (!report) {
@@ -561,6 +632,48 @@ export default {
         showListToolsModal.value = false
       } finally {
         listToolsLoading.value = false
+      }
+    }
+
+    const openAddToolsPanel = () => {
+      selectedExtraTools.value = []
+      showAddToolsPanel.value = true
+    }
+
+    const cancelAddToolsPanel = () => {
+      showAddToolsPanel.value = false
+      selectedExtraTools.value = []
+    }
+
+    const confirmAddTools = async () => {
+      if (selectedExtraTools.value.length === 0) {
+        return
+      }
+      addingTools.value = true
+      try {
+        const version = listToolsVersion.value
+        await invoke('fix_installation', { id: version.id, extraTools: selectedExtraTools.value })
+
+        message.success(t('versionManagement.messages.success.repairStarted'))
+        showListToolsModal.value = false
+        showAddToolsPanel.value = false
+
+        // Navigate to installation progress with fix mode parameters, same as confirmFix
+        router.push({
+          path: '/installation-progress',
+          query: {
+            mode: 'fix',
+            id: version.id,
+            name: version.name,
+            path: version.path,
+            autotrack: 'true'
+          }
+        })
+      } catch (error) {
+        console.error('Add tools error:', error)
+        message.error(t('versionManagement.messages.error.repair', { error }))
+      } finally {
+        addingTools.value = false
       }
     }
 
@@ -708,6 +821,10 @@ export default {
       listToolsVersion,
       listToolsReport,
       listToolsLoading,
+      showAddToolsPanel,
+      selectedExtraTools,
+      addingTools,
+      availableToolsToAdd,
       formatDate,
       formatSize,
       renameVersion,
@@ -719,6 +836,9 @@ export default {
       fixVersion,
       openInExplorer,
       openListTools,
+      openAddToolsPanel,
+      cancelAddToolsPanel,
+      confirmAddTools,
       statusTagType,
       purgeAll,
       confirmPurge,
@@ -929,4 +1049,42 @@ export default {
 .ver-cell  { font-family: monospace; font-size: 12px; color: #374151; }
 .installed-yes { color: #16a34a; font-size: 12px; display: inline-flex; align-items: center; gap: 4px; }
 .not-installed { color: #9ca3af; }
+
+.list-tools-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+  margin-bottom: 0.75rem;
+}
+
+.list-tools-header button {
+  color:red
+}
+
+.list-tools-header .list-tools-meta {
+  flex: 1;
+  min-width: 0;
+}
+
+.add-tools-panel {
+  margin-bottom: 1rem;
+  padding: 0.75rem 1rem;
+  border: 1px solid #93c5fd;
+  border-radius: 6px;
+  background: #eff6ff;
+}
+
+.add-tools-panel h4 {
+  margin: 0 0 0.75rem 0;
+  font-size: 0.95rem;
+  color: #1f2937;
+}
+
+.add-tools-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
 </style>

--- a/src/locales/cn.json
+++ b/src/locales/cn.json
@@ -433,6 +433,13 @@
           "installed": "已安装",
           "tool": "工具",
           "description": "描述"
+        },
+        "addTools": {
+          "button": "添加更多工具",
+          "title": "选择要安装的可选工具",
+          "none": "所有可选工具均已安装。",
+          "cancel": "取消",
+          "confirm": "安装所选工具"
         }
       }
     },

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -434,6 +434,13 @@
           "installed": "Installed",
           "tool": "Tool",
           "description": "Description"
+        },
+        "addTools": {
+          "button": "Add more tools",
+          "title": "Select optional tools to install",
+          "none": "All optional tools are already installed.",
+          "cancel": "Cancel",
+          "confirm": "Install selected tools"
         }
       }
     },


### PR DESCRIPTION
both CLI and GUI fix now allows user to specify list of tools so users can add more tools to existing installations.
<img width="717" height="156" alt="Tools for v6 0 1" src="https://github.com/user-attachments/assets/e6d27aed-e876-49ca-9d9a-3a760443fb5b" />
<img width="708" height="250" alt="Tools for v6 0 1" src="https://github.com/user-attachments/assets/012737c0-1dc3-4fcb-85f6-3dc8df8c5108" />
