### PR TITLE
Eim-390: add features to fix command

### DIFF
--- a/docs/src/cli_commands.md
+++ b/docs/src/cli_commands.md
@@ -28,6 +28,7 @@ These options can be used with any command:
 | `wizard` | Run the ESP-IDF Installer Wizard (interactive mode) |
 | `list` | List installed ESP-IDF versions |
 | `list-tools` | List tools declared in an installed ESP-IDF's `tools.json`, with their on-disk installation status |
+| `list-features` | List features declared in an installed ESP-IDF's `requirements.json`, with their install status |
 | `select` | Select an ESP-IDF version as active |
 | `rename` | Rename a specific ESP-IDF version |
 | `remove` | Remove a specific ESP-IDF version |
@@ -119,7 +120,24 @@ For each tool, the output reports:
 
 The IDF installation is resolved from `IDENTIFIER` by matching its `id`, then its `name`, and finally its normalized `path` in `eim_idf.json`.
 
-This command is intended for inspecting the on-disk state of a toolchain — for example, to confirm which tool versions are present after a fresh install, or to detect tools that can be upgraded in place. The report is also serialized in the underlying library (`version_manager::ToolListReport`) so it can be reused by future GUI commands.
+This command is intended for inspecting the on-disk state of a toolchain — for example, to confirm which tool versions are present after a fresh install, or to detect tools that can be upgraded in place. The report is also serialized in the underlying library (`version_manager::ToolListReport`), which the GUI's **List Tools** dashboard action (see [Version Management](./version_management.md)) reuses directly.
+
+### List Features Command
+
+List the features declared in an installed ESP-IDF's `tools/requirements.json`, together with whether each one is currently configured to be installed.
+
+```bash
+eim list-features [IDENTIFIER]
+```
+
+Arguments:
+- `IDENTIFIER`: ID, name, or path of the IDF installation to inspect (optional). If omitted, the command prompts you to choose from the installed IDFs.
+
+For each feature, the output reports:
+- The feature's name and description. Features with `optional: true` in `requirements.json` (e.g. `ci`, `docs`, `pytest`, `gdbgui`, `ide`) are marked with `(optional)`.
+- `[installed]` or `[not installed]`. The required `core` feature is always reported as installed. Optional features are reported as installed if they're part of the version's recorded feature selection — the same selection [`fix`](#fix-command) recovers and preserves.
+
+The IDF installation is resolved from `IDENTIFIER` the same way as `list-tools`: by matching its `id`, then its `name`, and finally its normalized `path` in `eim_idf.json`. Unlike `list-tools`, this command requires no network access — `requirements.json` is read directly from the local ESP-IDF checkout. The underlying report (`version_manager::FeatureListReport`) is what powers the GUI's **List Features** dashboard action (see [Version Management](./version_management.md)).
 
 ### Select Command
 
@@ -234,6 +252,9 @@ eim fix -p /path/to/existing/esp-idf
 # Fix an installation and additionally install the cmake and openocd tools
 eim fix -p /path/to/existing/esp-idf --idf-tools cmake,openocd
 
+# Fix an installation and additionally install the docs and pytest features
+eim fix -p /path/to/existing/esp-idf --idf-features docs,pytest
+
 # Fix an installation, choosing interactively from all installed versions
 eim fix
 ```
@@ -300,6 +321,9 @@ eim list-tools v5.3.2
 # Show only tools whose on-disk version is older than what tools.json declares
 eim list-tools v5.3.2 --outdated
 
+# List the features for an installed IDF and their install status
+eim list-features v5.3.2
+
 # Select a specific version
 eim select v5.3.2
 
@@ -314,6 +338,9 @@ eim fix -p /path/to/existing/esp-idf
 
 # Fix an installation while also adding tools that weren't installed originally
 eim fix -p /path/to/existing/esp-idf --idf-tools cmake,openocd
+
+# Fix an installation while also adding features that weren't installed originally
+eim fix -p /path/to/existing/esp-idf --idf-features docs,pytest
 
 # Purge all installations
 eim purge

--- a/docs/src/cli_configuration.md
+++ b/docs/src/cli_configuration.md
@@ -179,6 +179,8 @@ The `eim fix` command (see [CLI Commands](./cli_commands.md#fix-command)) accept
 eim fix -p /path/to/existing/esp-idf --idf-tools cmake,openocd
 ```
 
+Use [`eim list-tools`](./cli_commands.md#list-tools-command) and [`eim list-features`](./cli_commands.md#list-features-command) to see what's currently installed for a version before deciding what to add.
+
 ### Interactive Tool Selection
 
 When using the wizard command, you'll be prompted to select tools for each ESP-IDF version:

--- a/docs/src/faq.md
+++ b/docs/src/faq.md
@@ -99,17 +99,19 @@ If EIM detects a valid ESP-IDF Git repository at the selected path, it will:
 - **Utilize that existing repository**: It will not download a new copy or overwrite your existing files.
 - **Ignore selected ESP-IDF versions**: Any specific ESP-IDF version you may have chosen in the GUI or via CLI arguments will be disregarded, as EIM will work with the version already present in your existing repository.
 
-### How do I add more tools to an existing installation?
+### How do I add more tools or features to an existing installation?
 
-You don't need to reinstall from scratch to add a tool you skipped the first time around.
+You don't need to reinstall from scratch to add a tool or optional feature (e.g. `docs`, `pytest`) you skipped the first time around.
 
-**GUI:** Open the **Version Management** dashboard, click **List Tools** on the version you want to change. The modal shows every tool declared in that version's `tools.json`, including optional ones that aren't installed yet. If there are any available to add, an **Add more tools** button appears next to the paths at the top of the modal — click it, check the tools you want, and confirm. This reinstalls the version with the newly selected tools added on top of what's already there; your existing tools and features are left untouched.
+**GUI:** Open the **Version Management** dashboard, then click **List Tools** or **List Features** on the version you want to change. The modal shows everything declared in that version's `tools.json`/`requirements.json`, including optional ones that aren't installed yet. If there are any available to add, an **Add more tools** / **Add more features** button appears next to the paths at the top of the modal — click it, check what you want, and confirm. This reinstalls the version with the newly selected tools/features added on top of what's already there; everything else is left untouched.
 
-**CLI:** Use `eim fix` with `--idf-tools` (or `--idf-features` for optional features), pointing at the existing installation:
+**CLI:** Use `eim fix` with `--idf-tools` and/or `--idf-features`, pointing at the existing installation:
 
 ```bash
-eim fix -p /path/to/existing/esp-idf --idf-tools cmake,openocd
+eim fix -p /path/to/existing/esp-idf --idf-tools cmake,openocd --idf-features docs,pytest
 ```
+
+You can also inspect what's currently installed first with [`eim list-tools`](./cli_commands.md#list-tools-command) and [`eim list-features`](./cli_commands.md#list-features-command).
 
 `eim fix` preserves the configuration the version was originally installed with and only overrides what you explicitly pass, so any tools/features you don't mention stay as they were. See [CLI Commands](./cli_commands.md#fix-command) for details.
 

--- a/docs/src/version_management.md
+++ b/docs/src/version_management.md
@@ -9,11 +9,16 @@ On this page, you can see a list of all your installed ESP-IDF versions. For eac
   * **Fix/Reinstall**: Rerun the installation process to repair a corrupted environment. This preserves the target, features and tools the version was originally installed with, so you don't lose any customization.
   * **Open Folder**: Open the installation directory in your file explorer.
   * **List Tools**: Open a modal showing every tool declared in the version's `tools.json`, its installed version(s), and whether it's up to date. See **Adding More Tools** below.
+  * **List Features**: Open a modal showing every optional Python feature declared in the version's `requirements.json` (e.g. `ci`, `docs`, `pytest`, `gdbgui`, `ide`) and whether each one is currently installed. See **Adding More Features** below.
   * **Delete**: Uninstall the specific ESP-IDF version.
 
 ### Adding More Tools to an Existing Installation
 
 Open **List Tools** for a version to see its full tool catalog, including optional tools that weren't installed. If any optional tools are available to add, an **Add more tools** button appears next to the IDF/tools paths at the top of the modal. Click it, check the tools you want, and confirm — this triggers a repair (the same mechanism as **Fix**) that reinstalls the version with the newly selected tools added on top of what's already there, without touching your existing configuration otherwise.
+
+### Adding More Features to an Existing Installation
+
+Open **List Features** for a version the same way. The required `core` feature is always shown as installed; any optional feature (e.g. `docs`, `pytest`) that isn't yet part of the version's configuration appears as a candidate under **Add more features**. Click it, check the features you want, and confirm — like **Add more tools**, this triggers a repair that reinstalls the version with the newly selected features added on top of what's already installed.
 
 At the bottom of the page, you'll also find options to:
 

--- a/src-tauri/locales/app.yml
+++ b/src-tauri/locales/app.yml
@@ -1571,3 +1571,18 @@ list_tools.installed:
 list_tools.not_installed:
   en: " [not installed]"
   cn: " [未安装]"
+list_features.title:
+  en: "Features for IDF: %{name} (%{path})"
+  cn: "IDF 功能：%{name}（%{path}）"
+list_features.idf_prompt:
+  en: "Which IDF installation do you want to list features for?"
+  cn: "你想列出哪个 IDF 安装的功能？"
+list_features.optional_marker:
+  en: " (optional)"
+  cn: "（可选）"
+list_features.installed:
+  en: " [installed]"
+  cn: " [已安装]"
+list_features.not_installed:
+  en: " [not installed]"
+  cn: " [未安装]"

--- a/src-tauri/src/cli/cli_args.rs
+++ b/src-tauri/src/cli/cli_args.rs
@@ -85,6 +85,12 @@ pub enum Commands {
         outdated: bool,
     },
 
+    /// List features declared in an installed ESP-IDF's requirements.json, with install status
+    ListFeatures {
+        #[arg(help = "ID, name or path of the IDF installation")]
+        identifier: Option<String>,
+    },
+
     /// Select an ESP-IDF version as active
     Select {
         #[arg(help = "Version to select as active")]

--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -164,6 +164,35 @@ fn format_tool_list_report(report: &idf_im_lib::version_manager::ToolListReport)
     }
 }
 
+fn format_feature_list_report(report: &idf_im_lib::version_manager::FeatureListReport) {
+    println!(
+        "{}",
+        t!(
+            "list_features.title",
+            name = report.idf.name,
+            path = report.idf.path
+        )
+    );
+    println!();
+    for entry in &report.features {
+        let name_and_desc = match &entry.feature.description {
+            Some(description) => format!("{}: {}", entry.feature.name, description),
+            None => entry.feature.name.clone(),
+        };
+        let optional_marker = if entry.feature.optional {
+            t!("list_features.optional_marker").to_string()
+        } else {
+            String::new()
+        };
+        let installed_marker = if entry.installed {
+            t!("list_features.installed").to_string()
+        } else {
+            t!("list_features.not_installed").to_string()
+        };
+        println!("{}{}{}", name_and_desc, optional_marker, installed_marker);
+    }
+}
+
 pub async fn run_cli(cli: Cli) -> anyhow::Result<()> {
   let do_not_track = cli.do_not_track;
     // Initial tracking of CLI start
@@ -415,6 +444,47 @@ pub async fn run_cli(cli: Cli) -> anyhow::Result<()> {
             match report {
                 Ok(report) => {
                     format_tool_list_report(&report);
+                    Ok(())
+                }
+                Err(err) => {
+                    error!("{}", err);
+                    Err(anyhow::anyhow!(err))
+                }
+            }
+        }
+        Commands::ListFeatures { identifier } => {
+            let identifier = if let Some(id) = identifier {
+                Some(id)
+            } else {
+                match idf_im_lib::version_manager::list_installed_versions(config_path.as_ref()) {
+                    Ok(versions) if versions.is_empty() => {
+                        warn!("{}", t!("list.no_versions"));
+                        return Ok(());
+                    }
+                    Ok(versions) => {
+                        let options: Vec<String> =
+                            versions.iter().map(|v| v.name.clone()).collect();
+                        match generic_select(&t!("list_features.idf_prompt"), &options) {
+                            Ok(selected) => Some(selected),
+                            Err(err) => return Err(anyhow::anyhow!(err)),
+                        }
+                    }
+                    Err(err) => {
+                        debug!("Error: {}", err);
+                        warn!("{}", t!("list.no_versions"));
+                        info!("{}", t!("cli.hint.custom_json_path"));
+                        return Ok(());
+                    }
+                }
+            };
+
+            let report = idf_im_lib::version_manager::list_idf_features(
+                identifier.as_deref(),
+                config_path.as_ref(),
+            );
+            match report {
+                Ok(report) => {
+                    format_feature_list_report(&report);
                     Ok(())
                 }
                 Err(err) => {

--- a/src-tauri/src/gui/commands/installation.rs
+++ b/src-tauri/src/gui/commands/installation.rs
@@ -1167,8 +1167,8 @@ pub async fn start_simple_setup(app_handle: tauri::AppHandle) -> Result<(), Stri
 }
 
 #[tauri::command]
-pub async fn fix_installation(app_handle: AppHandle, id: String, extra_tools: Option<Vec<String>>) -> Result<(), String> {
-    debug!("Fixing installation with id {}, extra_tools: {:?}", id, extra_tools);
+pub async fn fix_installation(app_handle: AppHandle, id: String, extra_tools: Option<Vec<String>>, extra_features: Option<Vec<String>>) -> Result<(), String> {
+    debug!("Fixing installation with id {}, extra_tools: {:?}, extra_features: {:?}", id, extra_tools, extra_features);
 
     // Set installation flag to indicate installation is running
     set_installation_status(&app_handle, true)?;
@@ -1286,6 +1286,26 @@ pub async fn fix_installation(app_handle: AppHandle, id: String, extra_tools: Op
         }
         per_version.insert(version_key, tools_for_version);
         settings.idf_tools_per_version = Some(per_version);
+    }
+
+    // Same idea, but for optional (non-core) features picked in the "add more features"
+    // picker: merge them into whatever features this version was already configured with.
+    // The required "core" feature is always installed regardless of this list (see
+    // `install_python_env`), so we only need to add the newly requested optional ones here.
+    if let Some(extra) = extra_features.filter(|f| !f.is_empty()) {
+        let version_key = installation.name.clone();
+        let mut per_version = settings.idf_features_per_version.clone().unwrap_or_default();
+        let mut features_for_version = per_version
+            .get(&version_key)
+            .cloned()
+            .unwrap_or_else(|| settings.idf_features.clone().unwrap_or_default());
+        for feature in extra {
+            if !features_for_version.contains(&feature) {
+                features_for_version.push(feature);
+            }
+        }
+        per_version.insert(version_key, features_for_version);
+        settings.idf_features_per_version = Some(per_version);
     }
 
     let config_path = fix_config_path.clone()

--- a/src-tauri/src/gui/commands/version_management.rs
+++ b/src-tauri/src/gui/commands/version_management.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use idf_im_lib::idf_config::{IdfInstallation, IDF_CONFIG_FILE_NAME};
 use idf_im_lib::settings::Settings;
-use idf_im_lib::version_manager::ToolListReport;
+use idf_im_lib::version_manager::{FeatureListReport, ToolListReport};
 use log::{debug, error, info};
 use tauri::{AppHandle, Manager};
 
@@ -181,6 +181,27 @@ pub fn list_idf_tools(app_handle: AppHandle, id: String) -> Option<ToolListRepor
     }
     Err(e) => {
       error!("Failed to list tools for {}: {}", id, e);
+      None
+    }
+  }
+}
+
+#[tauri::command]
+pub fn list_idf_features(app_handle: AppHandle, id: String) -> Option<FeatureListReport> {
+  debug!("Listing features for installation {}", id);
+  let config_path = get_config_path_from_state(&app_handle);
+
+  match idf_im_lib::version_manager::list_idf_features(Some(&id), config_path.as_ref()) {
+    Ok(report) => {
+      debug!(
+        "Successfully listed {} features for {}",
+        report.features.len(),
+        id
+      );
+      Some(report)
+    }
+    Err(e) => {
+      error!("Failed to list features for {}: {}", id, e);
       None
     }
   }

--- a/src-tauri/src/gui/mod.rs
+++ b/src-tauri/src/gui/mod.rs
@@ -349,6 +349,7 @@ pub fn run(
             get_selected_tools_per_version,
             generate_installation_config_for_version,
             list_idf_tools,
+            list_idf_features,
             write_text_file,
             get_tool_download_folder_name,
             set_tool_download_folder_name,

--- a/src-tauri/src/lib/version_manager.rs
+++ b/src-tauri/src/lib/version_manager.rs
@@ -20,6 +20,7 @@ use crate::{
     idf_config::{IdfConfig, IdfInstallation},
     settings::Settings,
     idf_tools::{Tool, Version},
+    idf_features::{FeatureInfo, RequirementsMetadata},
 };
 use serde::{Deserialize, Serialize};
 
@@ -765,6 +766,112 @@ pub fn list_idf_tools(
         outdated_only,
         tools,
         outdated,
+    })
+}
+
+// ============================================================================
+// Features inspection (eim list-features)
+// ============================================================================
+
+/// A report of the features declared in an installed ESP-IDF's `tools/requirements.json`,
+/// together with whether each one is currently configured to be installed for that version.
+///
+/// Produced by [`list_idf_features`]. Serializable so it can be reused by GUI commands.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FeatureListReport {
+    pub idf: ToolListIdfContext,
+    pub requirements_json_path: String,
+    pub features: Vec<FeatureListEntry>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FeatureListEntry {
+    pub feature: FeatureInfo,
+    pub installed: bool,
+}
+
+/// Lists the features declared in an installed ESP-IDF's `tools/requirements.json`,
+/// together with whether each one is currently configured to be installed.
+///
+/// Resolves the IDF the same way [`list_idf_tools`] does (by `id`, then `name`, then a
+/// normalized `path` match against `IdfConfig.idf_installed`). Unlike tools, features have
+/// no per-feature install directory to inspect on disk (they're just pip packages merged
+/// into one shared venv), so "installed" is derived from the installation's recovered
+/// configuration instead:
+///
+/// - Required features (`optional: false`, e.g. `core`) are always reported as installed,
+///   mirroring how "always"-install tools are treated regardless of any stored selection.
+/// - Optional features are reported as installed if their name appears in the recovered
+///   `idf_features_per_version` entry for this version, falling back to the global
+///   `idf_features` list when no per-version entry exists (the same fallback used when
+///   merging new tool/feature selections into a `fix` run).
+///
+/// Requires no network access — `tools/requirements.json` is read directly from the local
+/// IDF checkout, the same file `install_python_env` derives feature requirement files from.
+pub fn list_idf_features(
+    identifier: Option<&str>,
+    config_path: Option<&std::path::PathBuf>,
+) -> Result<FeatureListReport, String> {
+    let identifier = identifier.ok_or_else(|| {
+        "no identifier provided; pass an IDF id, name or path".to_string()
+    })?;
+
+    let config_path = config_path
+        .cloned()
+        .unwrap_or_else(get_default_config_path);
+    let ide_config = IdfConfig::from_file(&config_path)
+        .map_err(|e| format!("Failed to read eim_idf.json: {}", e))?;
+
+    let installation = find_installation(&ide_config, identifier)?;
+
+    let requirements_json_path =
+        std::path::Path::new(&installation.path).join("tools/requirements.json");
+    if !requirements_json_path.exists() {
+        return Err(format!(
+            "requirements.json not found at {}",
+            requirements_json_path.display()
+        ));
+    }
+
+    let metadata = RequirementsMetadata::from_file(&requirements_json_path)
+        .map_err(|e| format!("Failed to read requirements.json: {}", e))?;
+
+    // Recover the originally-selected optional features for this version, the same way
+    // `fix_installation` recovers tool selections: per-version entry first, falling back
+    // to the global list when the installation never got a per-version entry (e.g. offline
+    // installs never populate idf_features_per_version for tools, though features do get
+    // one on every wizard run today — this fallback keeps us correct either way).
+    let selected_optional_features: Vec<String> = installation
+        .installation_config
+        .as_ref()
+        .and_then(|bytes| bincode::deserialize::<Settings>(bytes.as_slice()).ok())
+        .map(|settings| {
+            settings
+                .idf_features_per_version
+                .as_ref()
+                .and_then(|per_version| per_version.get(&installation.name).cloned())
+                .unwrap_or_else(|| settings.idf_features.clone().unwrap_or_default())
+        })
+        .unwrap_or_default();
+
+    let features: Vec<FeatureListEntry> = metadata
+        .features
+        .into_iter()
+        .map(|feature| {
+            let installed =
+                !feature.optional || selected_optional_features.contains(&feature.name);
+            FeatureListEntry { feature, installed }
+        })
+        .collect();
+
+    Ok(FeatureListReport {
+        idf: ToolListIdfContext {
+            id: installation.id.clone(),
+            name: installation.name.clone(),
+            path: installation.path.clone(),
+        },
+        requirements_json_path: requirements_json_path.to_string_lossy().to_string(),
+        features,
     })
 }
 

--- a/src/components/VersionManagement.vue
+++ b/src/components/VersionManagement.vue
@@ -107,6 +107,16 @@
             </n-tooltip>
             <n-tooltip trigger="hover">
               <template #trigger>
+                <n-button @click="openListFeatures(version)" quaternary circle :data-id="`list-features-button-${version.id}`">
+                  <template #icon>
+                    <n-icon><AppstoreOutlined /></n-icon>
+                  </template>
+                </n-button>
+              </template>
+              {{ t('versionManagement.version.actions.listFeatures') }}
+            </n-tooltip>
+            <n-tooltip trigger="hover">
+              <template #trigger>
                 <n-button @click="removeVersion(version)" quaternary circle :data-id="`remove-version-button-${version.id}`" type="error">
                   <template #icon>
                     <n-icon><DeleteOutlined /></n-icon>
@@ -396,6 +406,130 @@
         <n-empty v-if="listToolsReport.tools.length === 0" :description="t('versionManagement.modals.listTools.empty')" data-id="list-tools-empty" />
       </div>
     </n-modal>
+
+    <n-modal
+      v-model:show="showListFeaturesModal"
+      preset="card"
+      :title="t('versionManagement.modals.listFeatures.title', { name: listFeaturesVersion?.name })"
+      style="max-width: 900px;"
+      :bordered="false"
+      size="huge"
+      data-id="list-features-modal"
+    >
+      <div v-if="listFeaturesLoading" class="list-tools-loading" data-id="list-features-loading">
+        <n-spin :size="32" />
+        <p>{{ t('versionManagement.modals.listFeatures.loading') }}</p>
+      </div>
+
+      <div v-else-if="listFeaturesReport" class="list-tools-content" data-id="list-features-content">
+        <!-- Meta strip + add-features trigger, aligned on the same row -->
+        <div class="list-tools-header">
+          <div class="list-tools-meta">
+            <div class="meta-row">
+              <span class="meta-label">{{ t('versionManagement.modals.listFeatures.idfPath') }}:</span>
+              <code class="meta-value">{{ listFeaturesReport.idf.path }}</code>
+            </div>
+            <div class="meta-row">
+              <span class="meta-label">{{ t('versionManagement.modals.listFeatures.requirementsPath') }}:</span>
+              <code class="meta-value">{{ listFeaturesReport.requirements_json_path }}</code>
+            </div>
+          </div>
+
+          <n-button
+            v-if="!showAddFeaturesPanel"
+            size="small"
+            type="primary"
+            secondary
+            @click="openAddFeaturesPanel"
+            data-id="show-add-features-button"
+          >
+            <template #icon><n-icon><PlusCircleOutlined /></n-icon></template>
+            {{ t('versionManagement.modals.listFeatures.addFeatures.button') }}
+          </n-button>
+        </div>
+
+        <!-- Add more features panel -->
+        <div v-if="showAddFeaturesPanel" class="add-tools-panel" data-id="add-features-panel">
+          <h4>{{ t('versionManagement.modals.listFeatures.addFeatures.title') }}</h4>
+
+          <n-empty
+            v-if="availableFeaturesToAdd.length === 0"
+            :description="t('versionManagement.modals.listFeatures.addFeatures.none')"
+            size="small"
+            data-id="add-features-none"
+          />
+
+          <n-checkbox-group v-else v-model:value="selectedExtraFeatures" data-id="add-features-checkbox-group">
+            <n-space vertical>
+              <n-checkbox
+                v-for="entry in availableFeaturesToAdd"
+                :key="entry.feature.name"
+                :value="entry.feature.name"
+                :data-id="`add-features-checkbox-${entry.feature.name}`"
+              >
+                <strong>{{ entry.feature.name }}</strong><span v-if="entry.feature.description"> — {{ entry.feature.description }}</span>
+              </n-checkbox>
+            </n-space>
+          </n-checkbox-group>
+
+          <div class="add-tools-actions">
+            <n-button size="small" @click="cancelAddFeaturesPanel" data-id="add-features-cancel-button">
+              {{ t('versionManagement.modals.listFeatures.addFeatures.cancel') }}
+            </n-button>
+            <n-button
+              size="small"
+              type="primary"
+              :disabled="selectedExtraFeatures.length === 0"
+              :loading="addingFeatures"
+              @click="confirmAddFeatures"
+              data-id="add-features-confirm-button"
+            >
+              {{ t('versionManagement.modals.listFeatures.addFeatures.confirm') }}
+            </n-button>
+          </div>
+        </div>
+
+        <!-- Flat features table -->
+        <table class="tools-table" data-id="list-features-table">
+          <thead>
+            <tr>
+              <th class="col-fname">{{ t('versionManagement.modals.listFeatures.columns.feature') }}</th>
+              <th class="col-fdesc">{{ t('versionManagement.modals.listFeatures.columns.description') }}</th>
+              <th class="col-fstatus">{{ t('versionManagement.modals.listFeatures.columns.status') }}</th>
+              <th class="col-finst">{{ t('versionManagement.modals.listFeatures.columns.installed') }}</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              v-for="entry in listFeaturesReport.features"
+              :key="entry.feature.name"
+              :data-id="`list-features-feature-${entry.feature.name}`"
+            >
+              <td class="tool-name-cell">
+                {{ entry.feature.name }}
+                <n-tag v-if="entry.feature.optional" size="tiny" type="info">
+                  {{ t('versionManagement.modals.listFeatures.optional') }}
+                </n-tag>
+              </td>
+              <td class="desc-cell" :title="entry.feature.description">{{ entry.feature.description }}</td>
+              <td>
+                <n-tag :type="entry.feature.optional ? 'info' : 'default'" size="small">
+                  {{ entry.feature.optional
+                    ? t('versionManagement.modals.listFeatures.optionalStatus')
+                    : t('versionManagement.modals.listFeatures.requiredStatus') }}
+                </n-tag>
+              </td>
+              <td>
+                <span v-if="entry.installed" class="installed-yes">{{ t('versionManagement.modals.listFeatures.installedMarker') }}</span>
+                <span v-else class="not-installed">—</span>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+
+        <n-empty v-if="listFeaturesReport.features.length === 0" :description="t('versionManagement.modals.listFeatures.empty')" data-id="list-features-empty" />
+      </div>
+    </n-modal>
   </div>
 </template>
 
@@ -422,7 +556,8 @@ import {
   UsbOutlined,
   LaptopOutlined,
   SaveOutlined,
-  UnorderedListOutlined
+  UnorderedListOutlined,
+  AppstoreOutlined
 } from '@vicons/antd'
 import { useAppStore } from '../store'
 
@@ -434,7 +569,7 @@ export default {
     FolderOutlined, FolderOpenOutlined, EditOutlined,
     DeleteOutlined, ToolOutlined, PlusCircleOutlined,
     ClearOutlined, ReloadOutlined, UsbOutlined, LaptopOutlined,
-    SaveOutlined, UnorderedListOutlined
+    SaveOutlined, UnorderedListOutlined, AppstoreOutlined
   },
   setup() {
     const router = useRouter()
@@ -455,6 +590,7 @@ export default {
     const showFixModal = ref(false)
     const showPurgeModal = ref(false)
     const showListToolsModal = ref(false)
+    const showListFeaturesModal = ref(false)
     const selectedVersion = ref(null)
     const newVersionName = ref('')
     const purgeConfirmed = ref(false)
@@ -468,6 +604,14 @@ export default {
     const addingTools = ref(false)
     const appStore = useAppStore()
 
+    // List-features modal state
+    const listFeaturesVersion = ref(null)
+    const listFeaturesReport = ref(null)
+    const listFeaturesLoading = ref(false)
+    const showAddFeaturesPanel = ref(false)
+    const selectedExtraFeatures = ref([])
+    const addingFeatures = ref(false)
+
     // Optional (on_request) tools that are not currently installed for this version -
     // candidates the user can pick to add on top of the existing fix/install.
     const availableToolsToAdd = computed(() => {
@@ -476,6 +620,15 @@ export default {
         entry.tool.install === 'on_request' &&
         entry.version_inspections.some(vi => vi.has_platform_download) &&
         !entry.version_inspections.some(vi => vi.installed)
+      )
+    })
+
+    // Optional features that are not currently installed for this version -
+    // candidates the user can pick to add on top of the existing fix/install.
+    const availableFeaturesToAdd = computed(() => {
+      if (!listFeaturesReport.value) return []
+      return listFeaturesReport.value.features.filter(entry =>
+        entry.feature.optional && !entry.installed
       )
     })
 
@@ -677,6 +830,72 @@ export default {
       }
     }
 
+    const openListFeatures = async (version) => {
+      listFeaturesVersion.value = version
+      listFeaturesReport.value = null
+      listFeaturesLoading.value = true
+      showListFeaturesModal.value = true
+      showAddFeaturesPanel.value = false
+      selectedExtraFeatures.value = []
+      try {
+        const report = await invoke('list_idf_features', { id: version.id })
+        if (!report) {
+          message.error(t('versionManagement.messages.error.listFeatures'))
+          showListFeaturesModal.value = false
+          return
+        }
+        listFeaturesReport.value = report
+      } catch (error) {
+        console.error('Failed to list features:', error)
+        message.error(t('versionManagement.messages.error.listFeatures', { error }))
+        showListFeaturesModal.value = false
+      } finally {
+        listFeaturesLoading.value = false
+      }
+    }
+
+    const openAddFeaturesPanel = () => {
+      selectedExtraFeatures.value = []
+      showAddFeaturesPanel.value = true
+    }
+
+    const cancelAddFeaturesPanel = () => {
+      showAddFeaturesPanel.value = false
+      selectedExtraFeatures.value = []
+    }
+
+    const confirmAddFeatures = async () => {
+      if (selectedExtraFeatures.value.length === 0) {
+        return
+      }
+      addingFeatures.value = true
+      try {
+        const version = listFeaturesVersion.value
+        await invoke('fix_installation', { id: version.id, extraFeatures: selectedExtraFeatures.value })
+
+        message.success(t('versionManagement.messages.success.repairStarted'))
+        showListFeaturesModal.value = false
+        showAddFeaturesPanel.value = false
+
+        // Navigate to installation progress with fix mode parameters, same as confirmFix
+        router.push({
+          path: '/installation-progress',
+          query: {
+            mode: 'fix',
+            id: version.id,
+            name: version.name,
+            path: version.path,
+            autotrack: 'true'
+          }
+        })
+      } catch (error) {
+        console.error('Add features error:', error)
+        message.error(t('versionManagement.messages.error.repair', { error }))
+      } finally {
+        addingFeatures.value = false
+      }
+    }
+
     const statusTagType = (status) => {
       switch (status) {
         case 'recommended':
@@ -815,6 +1034,7 @@ export default {
       showFixModal,
       showPurgeModal,
       showListToolsModal,
+      showListFeaturesModal,
       selectedVersion,
       newVersionName,
       purgeConfirmed,
@@ -825,6 +1045,13 @@ export default {
       selectedExtraTools,
       addingTools,
       availableToolsToAdd,
+      listFeaturesVersion,
+      listFeaturesReport,
+      listFeaturesLoading,
+      showAddFeaturesPanel,
+      selectedExtraFeatures,
+      addingFeatures,
+      availableFeaturesToAdd,
       formatDate,
       formatSize,
       renameVersion,
@@ -839,6 +1066,10 @@ export default {
       openAddToolsPanel,
       cancelAddToolsPanel,
       confirmAddTools,
+      openListFeatures,
+      openAddFeaturesPanel,
+      cancelAddFeaturesPanel,
+      confirmAddFeatures,
       statusTagType,
       purgeAll,
       confirmPurge,
@@ -941,7 +1172,7 @@ export default {
 
 .version-actions {
   display: flex;
-  gap: 0.5rem;
+  gap: 0.25rem;
   padding-top: 1rem;
   border-top: 1px solid #f3f4f6;
   color: #e5e7eb;
@@ -1043,6 +1274,11 @@ export default {
 .col-ver   { width: 18%; }
 .col-status{ width: 14%; }
 .col-inst  { width: 13%; }
+
+.col-fname   { width: 25%; }
+.col-fdesc   { width: 45%; }
+.col-fstatus { width: 15%; }
+.col-finst   { width: 15%; }
 
 .tool-name-cell { font-weight: 500; font-size: 13px; }
 .desc-cell { color: #6b7280; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }

--- a/src/locales/cn.json
+++ b/src/locales/cn.json
@@ -376,7 +376,8 @@
         "openTerminal": "打开 IDF 终端",
         "remove": "移除",
         "exportConfig": "导出配置",
-        "listTools": "查看工具"
+        "listTools": "查看工具",
+        "listFeatures": "查看功能"
       }
     },
     "quickActions": {
@@ -441,6 +442,30 @@
           "cancel": "取消",
           "confirm": "安装所选工具"
         }
+      },
+      "listFeatures": {
+        "title": "{name} 的功能",
+        "loading": "正在加载功能...",
+        "empty": "此安装没有可用的功能。",
+        "idfPath": "IDF 路径",
+        "requirementsPath": "依赖清单路径",
+        "optional": "可选",
+        "optionalStatus": "可选",
+        "requiredStatus": "必需",
+        "installedMarker": "已安装",
+        "columns": {
+          "feature": "功能",
+          "description": "描述",
+          "status": "状态",
+          "installed": "已安装"
+        },
+        "addFeatures": {
+          "button": "添加更多功能",
+          "title": "选择要安装的可选功能",
+          "none": "所有可选功能均已安装。",
+          "cancel": "取消",
+          "confirm": "安装所选功能"
+        }
       }
     },
     "messages": {
@@ -470,7 +495,8 @@
         "openTerminal": "无法打开 IDF 终端",
         "exportConfig": "导出配置失败",
         "noConfigToExport": "没有可导出的配置",
-        "listTools": "加载工具失败"
+        "listTools": "加载工具失败",
+        "listFeatures": "加载功能失败"
       },
       "warning": {
         "confirmAction": "请确认操作"

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -377,7 +377,8 @@
         "openTerminal": "Open IDF Terminal",
         "remove": "Remove",
         "exportConfig": "Export Configuration",
-        "listTools": "List Tools"
+        "listTools": "List Tools",
+        "listFeatures": "List Features"
       }
     },
     "quickActions": {
@@ -442,6 +443,30 @@
           "cancel": "Cancel",
           "confirm": "Install selected tools"
         }
+      },
+      "listFeatures": {
+        "title": "Features for {name}",
+        "loading": "Loading features...",
+        "empty": "No features available for this installation.",
+        "idfPath": "IDF path",
+        "requirementsPath": "Requirements path",
+        "optional": "Optional",
+        "optionalStatus": "Optional",
+        "requiredStatus": "Required",
+        "installedMarker": "Installed",
+        "columns": {
+          "feature": "Feature",
+          "description": "Description",
+          "status": "Status",
+          "installed": "Installed"
+        },
+        "addFeatures": {
+          "button": "Add more features",
+          "title": "Select optional features to install",
+          "none": "All optional features are already installed.",
+          "cancel": "Cancel",
+          "confirm": "Install selected features"
+        }
       }
     },
     "messages": {
@@ -471,7 +496,8 @@
         "openTerminal": "IDF terminal could not be opened",
         "exportConfig": "Failed to export configuration",
         "noConfigToExport": "No configuration available to export",
-        "listTools": "Failed to load tools"
+        "listTools": "Failed to load tools",
+        "listFeatures": "Failed to load features"
       },
       "warning": {
         "confirmAction": "Please confirm the action"

--- a/tests/CLIRunner.test.js
+++ b/tests/CLIRunner.test.js
@@ -34,6 +34,7 @@ import { runCleanUp } from "./scripts/cleanUpRunner.test.js";
 import { runCLIClonedIDFRepo } from "./scripts/CLICloneIDFRepo.test.js";
 import { runCLIDeactivationTest } from "./scripts/CLIDeactivation.test.js";
 import { runListToolsTest } from "./scripts/CLIListTools.test.js";
+import { runListFeaturesTest } from "./scripts/CLIListFeatures.test.js";
 import logger from "./classes/logger.class.js";
 import {
   IDFMIRRORS,
@@ -466,6 +467,71 @@ function testRun(jsonScript) {
         });
 
         runListToolsTest({
+          id: `${test.id}2`,
+          pathToEIM: pathToEIMCLI,
+          idfList: idfUpdatedList,
+          installFolder,
+        });
+
+        runCleanUp({
+          id: `${test.id}3`,
+          installFolder,
+          toolsFolder: TOOLSFOLDER,
+          deleteAfterTest,
+        });
+      });
+    } else if (test.type === "list-features") {
+      const deleteAfterTest = test.deleteAfterTest ?? true;
+      const testProxyMode = test.testProxyMode ?? false;
+      const proxyBlockList = test.proxyBlockList ?? [];
+
+      let installFolder = test.data.installFolder
+        ? path.join(os.homedir(), test.data.installFolder)
+        : INSTALLFOLDER;
+
+      const targetList = test.data.targetList
+        ? test.data.targetList.split("|")
+        : ["esp32"];
+
+      const idfVersionList = test.data.idfList
+        ? test.data.idfList.split("|")
+        : [IDFDefaultVersion];
+
+      const idfUpdatedList = idfVersionList.map((idf) => resolveIdfToken(idf));
+
+      let installArgs = [];
+      runInDebug && installArgs.push("-vvv");
+      test.data.installFolder && installArgs.push(`-p ${installFolder}`);
+      test.data.targetList && installArgs.push(`-t ${targetList.join(",")}`);
+      test.data.idfList && installArgs.push(`-i ${idfUpdatedList.join(",")}`);
+      test.data.toolsMirror &&
+        installArgs.push(
+          `-m ${TOOLSMIRRORS[test.data.toolsMirror] || "https://github.com"}`
+        );
+      test.data.idfMirror &&
+        installArgs.push(
+          `--idf-mirror ${IDFMIRRORS[test.data.idfMirror] || "https://github.com"}`
+        );
+      test.data.pypiMirror &&
+        installArgs.push(
+          `--pypi-mirror ${PYPIMIRRORS[test.data.pypiMirror] || "https://pypi.org/simple"}`
+        );
+      test.data.recursive && installArgs.push(`-r ${test.data.recursive}`);
+      test.data.nonInteractive &&
+        installArgs.push(`-n ${test.data.nonInteractive}`);
+
+      describe(`Test${test.id}- ${test.name} |`, function () {
+        this.timeout(6000000);
+
+        runCLICustomInstallTest({
+          id: `${test.id}1`,
+          pathToEIM: pathToEIMCLI,
+          args: installArgs,
+          testProxyMode,
+          proxyBlockList,
+        });
+
+        runListFeaturesTest({
           id: `${test.id}2`,
           pathToEIM: pathToEIMCLI,
           idfList: idfUpdatedList,

--- a/tests/scripts/CLIListFeatures.test.js
+++ b/tests/scripts/CLIListFeatures.test.js
@@ -1,0 +1,111 @@
+import { expect } from "chai";
+import { describe, it, after, beforeEach, afterEach } from "mocha";
+import CLITestRunner from "../classes/CLITestRunner.class.js";
+import logger from "../classes/logger.class.js";
+
+/**
+ * This function verifies the `eim list-features` command.
+ *
+ * Assumes a single IDF version has already been installed by a prior test
+ * (typically a `custom` test) at `installFolder`. The function does not
+ * install or remove the IDF itself.
+ */
+export function runListFeaturesTest({
+  id = 0,
+  pathToEIM,
+  idfList,
+  installFolder,
+}) {
+  describe(`${id}- EIM list-features test |`, function () {
+    this.timeout(120000);
+    let testRunner = null;
+    let testStepFailed = false;
+
+    beforeEach(async function () {
+      this.timeout(10000);
+      if (testStepFailed) {
+        logger.info("Test failed, skipping next tests");
+        this.skip();
+      }
+    });
+
+    afterEach(async function () {
+      this.timeout(20000);
+      if (this.currentTest.state === "failed") {
+        logger.info(`Test failed: ${this.currentTest.title}`);
+        if (testRunner) {
+          logger.info(
+            `Terminal output: >>\r ${testRunner.output.slice(-2000)}`
+          );
+          logger.debug(`Terminal output on failure: >>\r ${testRunner.output}`);
+        }
+        testStepFailed = true;
+      }
+      if (testRunner) {
+        try {
+          await testRunner.stop();
+        } catch (error) {
+          logger.info("Error cleaning up terminal after test");
+          logger.info(` Error: ${error}`);
+        } finally {
+          testRunner = null;
+        }
+      }
+    });
+
+    after(function () {
+      logger.info("list-features test completed");
+    });
+
+    const idfIdentifier = idfList[0];
+
+    it("1- EIM list-features with no args prompts for an IDF", async function () {
+      logger.info(`Validating EIM list-features interactive prompt`);
+      testRunner = new CLITestRunner();
+      await testRunner.start();
+      testRunner.callEIM(pathToEIM, ["list-features"]);
+      const prompt = await testRunner.waitForOutput(
+        "Which IDF installation do you want to list features for?",
+        10000
+      );
+      expect(prompt, "EIM list-features not prompting for IDF").to.be.true;
+      // Cancel the prompt without selecting
+      testRunner.sendInput("\x03");
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+    });
+
+    it("2- EIM list-features <name> prints the feature table", async function () {
+      logger.info(`Validating EIM list-features ${idfIdentifier}`);
+      testRunner = new CLITestRunner();
+      await testRunner.start();
+      testRunner.callEIM(pathToEIM, ["list-features", idfIdentifier]);
+      const header = await testRunner.waitForOutput(
+        "Features for IDF:",
+        30000
+      );
+      expect(header, "EIM list-features not printing header").to.be.true;
+      // "core" is a required feature and should always be reported installed
+      expect(testRunner.output, "expected core feature listed").to.include(
+        "core:"
+      );
+      expect(testRunner.output, "expected installed marker").to.include(
+        "[installed]"
+      );
+      expect(testRunner.output, "expected optional marker").to.include(
+        "(optional)"
+      );
+    });
+
+    it("3- EIM list-features <unknown> reports the error", async function () {
+      logger.info(`Validating EIM list-features error path`);
+      testRunner = new CLITestRunner();
+      await testRunner.start();
+      testRunner.callEIM(pathToEIM, ["list-features", "definitely-not-installed"]);
+      const error = await testRunner.waitForOutput(
+        "not found",
+        10000
+      );
+      expect(error, "EIM list-features did not report missing identifier").to.be.true;
+    });
+  });
+}

--- a/tests/scripts/GUIVersionManagement.test.js
+++ b/tests/scripts/GUIVersionManagement.test.js
@@ -169,15 +169,19 @@ export function runGUIVersionManagementTest({
       expect(content, "Expected list-tools modal content to load").to.not.be
         .false;
 
-      const modalText = await content.getText();
+      // Tool/version rows are filtered by platform-download availability
+      // (`has_platform_download`), which varies by CI runner OS/arch (e.g.
+      // a "recommended" version may have no download for this platform
+      // while an older "supported" one does). So we don't assert on
+      // specific status text or on the "optional" marker being present -
+      // only that real row data actually rendered for this installation.
+      const toolRows = await eimRunner.driver.findElements(
+        By.css(`[data-id^="list-tools-tool-"]`)
+      );
       expect(
-        modalText.includes("recommended"),
-        "Expected at least one tool version marked as recommended"
-      ).to.be.true;
-      expect(
-        modalText.includes(tGui("versionManagement.modals.listTools.optional")),
-        "Expected at least one optional tool to be listed"
-      ).to.be.true;
+        toolRows.length,
+        "Expected at least one tool/version row to be rendered"
+      ).to.be.greaterThan(0);
 
       const installedMarker = await eimRunner
         .findByClass("installed-yes", 10000)
@@ -277,27 +281,36 @@ export function runGUIVersionManagementTest({
       );
       expect(coreRow, "Expected the required 'core' feature to be listed").to
         .not.be.false;
-      const coreRowText = await coreRow.getText();
-      expect(
-        coreRowText.includes(
-          tGui("versionManagement.modals.listFeatures.requiredStatus")
-        ),
-        "Expected 'core' feature to be marked as required"
-      ).to.be.true;
-      expect(
-        coreRowText.includes(
-          tGui("versionManagement.modals.listFeatures.installedMarker")
-        ),
-        "Expected 'core' feature to be marked as installed"
-      ).to.be.true;
 
-      const modalText = await content.getText();
-      expect(
-        modalText.includes(
-          tGui("versionManagement.modals.listFeatures.optional")
-        ),
+      // The row element can be located as soon as its <tr> exists, slightly
+      // ahead of naive-ui's nested <n-tag>/conditional cell content actually
+      // painting its text - so poll getText() rather than reading it once,
+      // to avoid a race against that inner render.
+      const requiredStatusText = tGui(
+        "versionManagement.modals.listFeatures.requiredStatus"
+      );
+      await eimRunner.driver.wait(
+        until.elementTextContains(coreRow, requiredStatusText),
+        5000,
+        "Expected 'core' feature to be marked as required"
+      );
+      const installedMarkerText = tGui(
+        "versionManagement.modals.listFeatures.installedMarker"
+      );
+      await eimRunner.driver.wait(
+        until.elementTextContains(coreRow, installedMarkerText),
+        5000,
+        "Expected 'core' feature to be marked as installed"
+      );
+
+      const optionalMarkerText = tGui(
+        "versionManagement.modals.listFeatures.optional"
+      );
+      await eimRunner.driver.wait(
+        until.elementTextContains(content, optionalMarkerText),
+        5000,
         "Expected at least one optional feature to be listed"
-      ).to.be.true;
+      );
 
       const addFeaturesButton = await eimRunner.findByDataId(
         "show-add-features-button",

--- a/tests/scripts/GUIVersionManagement.test.js
+++ b/tests/scripts/GUIVersionManagement.test.js
@@ -149,7 +149,217 @@ export function runGUIVersionManagementTest({
       }
     });
 
-    it("4- Should allow renaming existing installation", async function () {
+    it("4- Should show tool list for an installation, with add-more-tools option", async function () {
+      this.timeout(20000);
+      const cards = await eimRunner.findMultipleByClass("n-card");
+      const listToolsButton = await cards[0]
+        .findElement(By.css(`[data-id^="list-tools-button"]`))
+        .catch(() => false);
+      expect(listToolsButton, "Expected to find list tools button").to.not.be
+        .false;
+      await eimRunner.driver.executeScript(
+        "arguments[0].click();",
+        listToolsButton
+      );
+
+      const content = await eimRunner.findByDataId(
+        "list-tools-content",
+        20000
+      );
+      expect(content, "Expected list-tools modal content to load").to.not.be
+        .false;
+
+      const modalText = await content.getText();
+      expect(
+        modalText.includes("recommended"),
+        "Expected at least one tool version marked as recommended"
+      ).to.be.true;
+      expect(
+        modalText.includes(tGui("versionManagement.modals.listTools.optional")),
+        "Expected at least one optional tool to be listed"
+      ).to.be.true;
+
+      const installedMarker = await eimRunner
+        .findByClass("installed-yes", 10000)
+        .catch(() => false);
+      expect(
+        installedMarker,
+        "Expected at least one tool version to be marked installed"
+      ).to.not.be.false;
+
+      const addToolsButton = await eimRunner.findByDataId(
+        "show-add-tools-button",
+        10000
+      );
+      expect(addToolsButton, "Expected to find 'Add more tools' button").to
+        .not.be.false;
+      await eimRunner.driver.executeScript(
+        "arguments[0].click();",
+        addToolsButton
+      );
+
+      const addToolsPanel = await eimRunner.findByDataId(
+        "add-tools-panel",
+        10000
+      );
+      expect(addToolsPanel, "Expected 'add more tools' panel to open").to.not
+        .be.false;
+
+      // Whether there are on_request tools left to add depends on the
+      // default (non-interactive) tool selection for this target/version -
+      // either outcome (a checkbox list, or the "all installed" empty
+      // state) is valid; the panel just needs to render one of them.
+      const [checkboxGroup, emptyState] = await Promise.all([
+        eimRunner
+          .findByDataId("add-tools-checkbox-group", 3000)
+          .catch(() => false),
+        eimRunner.findByDataId("add-tools-none", 3000).catch(() => false),
+      ]);
+      expect(
+        Boolean(checkboxGroup) || Boolean(emptyState),
+        "Expected either an 'add tools' checkbox list or the empty-state message"
+      ).to.be.true;
+
+      // Close the panel without triggering an actual reinstall
+      const cancelButton = await eimRunner.findByDataId(
+        "add-tools-cancel-button",
+        5000
+      );
+      await eimRunner.driver.executeScript(
+        "arguments[0].click();",
+        cancelButton
+      );
+      await new Promise((resolve) => setTimeout(resolve, 500));
+      const panelAfterCancel = await eimRunner.driver
+        .findElement(By.css(`[data-id="add-tools-panel"]`))
+        .catch(() => false);
+      expect(
+        panelAfterCancel,
+        "Expected 'add more tools' panel to close after cancel"
+      ).to.be.false;
+
+      // Close the list-tools modal itself before the next test interacts
+      // with the dashboard cards again.
+      const closeButton = await eimRunner.findByClass(
+        "n-card-header__close",
+        5000
+      );
+      await eimRunner.driver.executeScript(
+        "arguments[0].click();",
+        closeButton
+      );
+      await new Promise((resolve) => setTimeout(resolve, 500));
+    });
+
+    it("5- Should show feature list for an installation, with add-more-features option", async function () {
+      this.timeout(20000);
+      const cards = await eimRunner.findMultipleByClass("n-card");
+      const listFeaturesButton = await cards[0]
+        .findElement(By.css(`[data-id^="list-features-button"]`))
+        .catch(() => false);
+      expect(listFeaturesButton, "Expected to find list features button").to
+        .not.be.false;
+      await eimRunner.driver.executeScript(
+        "arguments[0].click();",
+        listFeaturesButton
+      );
+
+      const content = await eimRunner.findByDataId(
+        "list-features-content",
+        20000
+      );
+      expect(content, "Expected list-features modal content to load").to.not
+        .be.false;
+
+      const coreRow = await eimRunner.findByDataId(
+        "list-features-feature-core",
+        10000
+      );
+      expect(coreRow, "Expected the required 'core' feature to be listed").to
+        .not.be.false;
+      const coreRowText = await coreRow.getText();
+      expect(
+        coreRowText.includes(
+          tGui("versionManagement.modals.listFeatures.requiredStatus")
+        ),
+        "Expected 'core' feature to be marked as required"
+      ).to.be.true;
+      expect(
+        coreRowText.includes(
+          tGui("versionManagement.modals.listFeatures.installedMarker")
+        ),
+        "Expected 'core' feature to be marked as installed"
+      ).to.be.true;
+
+      const modalText = await content.getText();
+      expect(
+        modalText.includes(
+          tGui("versionManagement.modals.listFeatures.optional")
+        ),
+        "Expected at least one optional feature to be listed"
+      ).to.be.true;
+
+      const addFeaturesButton = await eimRunner.findByDataId(
+        "show-add-features-button",
+        10000
+      );
+      expect(addFeaturesButton, "Expected to find 'Add more features' button")
+        .to.not.be.false;
+      await eimRunner.driver.executeScript(
+        "arguments[0].click();",
+        addFeaturesButton
+      );
+
+      const addFeaturesPanel = await eimRunner.findByDataId(
+        "add-features-panel",
+        10000
+      );
+      expect(addFeaturesPanel, "Expected 'add more features' panel to open")
+        .to.not.be.false;
+
+      // A freshly, non-interactively installed IDF only has the required
+      // "core" feature installed, so every optional feature should be
+      // offered as a candidate to add.
+      const checkboxGroup = await eimRunner
+        .findByDataId("add-features-checkbox-group", 5000)
+        .catch(() => false);
+      expect(
+        checkboxGroup,
+        "Expected optional features available to add on a freshly installed (required-only) IDF"
+      ).to.not.be.false;
+
+      // Close the panel without triggering an actual reinstall
+      const cancelButton = await eimRunner.findByDataId(
+        "add-features-cancel-button",
+        5000
+      );
+      await eimRunner.driver.executeScript(
+        "arguments[0].click();",
+        cancelButton
+      );
+      await new Promise((resolve) => setTimeout(resolve, 500));
+      const panelAfterCancel = await eimRunner.driver
+        .findElement(By.css(`[data-id="add-features-panel"]`))
+        .catch(() => false);
+      expect(
+        panelAfterCancel,
+        "Expected 'add more features' panel to close after cancel"
+      ).to.be.false;
+
+      // Close the list-features modal itself before the next test interacts
+      // with the dashboard cards again.
+      const closeButton = await eimRunner.findByClass(
+        "n-card-header__close",
+        5000
+      );
+      await eimRunner.driver.executeScript(
+        "arguments[0].click();",
+        closeButton
+      );
+      await new Promise((resolve) => setTimeout(resolve, 500));
+    });
+
+    it("6- Should allow renaming existing installation", async function () {
       this.timeout(10000);
       const cards = await eimRunner.findMultipleByClass("n-card");
       const renameButton = await cards[0]
@@ -199,7 +409,7 @@ export function runGUIVersionManagementTest({
       ).to.be.true;
     });
 
-    it("5- Should allow deleting existing installation", async function () {
+    it("7- Should allow deleting existing installation", async function () {
       this.timeout(60000);
       const cards = await eimRunner.findMultipleByClass("n-card");
       const IDFToDelete = await cards[0].findElement(
@@ -256,7 +466,7 @@ export function runGUIVersionManagementTest({
       ).to.not.be.true;
     });
 
-    it("6- Should allow purging all installation", async function () {
+    it("8- Should allow purging all installation", async function () {
       this.timeout(60000);
       const cards = await eimRunner.findMultipleByClass("n-card");
       expect(

--- a/tests/suites/CLI-basic.json
+++ b/tests/suites/CLI-basic.json
@@ -67,6 +67,22 @@
   },
   {
     "id": 8,
+    "type": "list-features",
+    "name": "CLI List Features",
+    "data": {
+      "idfList": "default",
+      "targetList": "esp32",
+      "toolsMirror": "github",
+      "idfMirror": "github",
+      "pypiMirror": "pypi_org",
+      "recursive": true,
+      "nonInteractive": true
+    },
+    "deleteAfterTest": true,
+    "testProxyMode": false
+  },
+  {
+    "id": 9,
     "type": "deactivation",
     "name": "CLI Deactivation Script Lifecycle",
     "data": {
@@ -83,7 +99,7 @@
     "testProxyMode": false
   },
   {
-    "id": 9,
+    "id": 10,
     "type": "offline",
     "name": "CLI Offline Installation",
     "deleteAfterTest": true,

--- a/tests/suites/CLI-listfeatures.json
+++ b/tests/suites/CLI-listfeatures.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": 1,
+    "type": "list-features",
+    "name": "CLI List Features",
+    "data": {
+      "idfList": "default",
+      "targetList": "esp32",
+      "toolsMirror": "github",
+      "idfMirror": "github",
+      "pypiMirror": "pypi_org",
+      "recursive": true,
+      "nonInteractive": true
+    },
+    "deleteAfterTest": true,
+    "testProxyMode": false
+  }
+]


### PR DESCRIPTION
EIM now allows user to add idf-features to existing installations
<img width="773" height="179" alt="Features for IDF" src="https://github.com/user-attachments/assets/c2f19d75-7a10-4b4a-afe2-ab4170a4225a" />
<img width="366" height="192" alt="• tmpesp-pokusv6 0 2es" src="https://github.com/user-attachments/assets/af3358c8-ea65-4136-aa27-6a97fda8a59b" />
<img width="1187" height="966" alt="ESP-IDF Installation Manaper" src="https://github.com/user-attachments/assets/15ac8858-5f24-46e7-bf93-571a8d193954" />
<img width="1188" height="964" alt="ESP-IDE Installatien MaNce" src="https://github.com/user-attachments/assets/249138a9-bb7b-4f48-91a3-10f39c403e5d" />

