### PR TITLE
EIM-895: Update package test with GUI packages

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1529,7 +1529,7 @@ jobs:
           name: gui-rpm-repackage-input-${{ matrix.package_name }}-${{ (github.event_name == 'release' && github.ref_name) || github.run_number }}
           path: gui-rpm-input/
 
-      - name: Repackage RPM without python upper bound
+      - name: Repackage RPM (fix /usr/bin bug and python upper bound)
         shell: bash
         run: |
           set -euo pipefail
@@ -1549,21 +1549,46 @@ jobs:
           echo "Original dependencies:"
           rpm -qpR "$ORIG_RPM" || true
 
-          # Check if the RPM actually has the python upper bound issue
-          if ! rpm -qpR "$ORIG_RPM" 2>/dev/null | grep -i "python.*<"; then
-            echo "RPM does not have python upper bound issue, using as-is"
+          HAS_PYTHON_BOUND=false
+          if rpm -qpR "$ORIG_RPM" 2>/dev/null | grep -qi "python.*<"; then
+            HAS_PYTHON_BOUND=true
+          fi
+
+          HAS_BIN_BUG=false
+          if rpm -qp --queryformat '[%{FILEMODES:perms} %{FILENAMES}\n]' "$ORIG_RPM" 2>/dev/null \
+              | grep -qE '^-.*[[:space:]]/usr/bin$'; then
+            HAS_BIN_BUG=true
+            echo "Detected known Tauri bug: /usr/bin is packaged as a regular file, not a directory."
+          fi
+
+          if [ "$HAS_PYTHON_BOUND" = "false" ] && [ "$HAS_BIN_BUG" = "false" ]; then
+            echo "RPM looks clean, using as-is"
             mkdir -p "$GITHUB_WORKSPACE/gui_rpm_output"
             cp "$ORIG_RPM" "$GITHUB_WORKSPACE/gui_rpm_output/"
             echo "gui_rpm_available=true" >> $GITHUB_OUTPUT
             exit 0
           fi
 
-          echo "Found python upper bound in RPM, repackaging..."
+          echo "Repackaging (python upper bound: $HAS_PYTHON_BOUND, /usr/bin bug: $HAS_BIN_BUG)..."
 
           # Extract RPM contents into a staging directory
           WORK_DIR=$(mktemp -d)
           cd "$WORK_DIR"
           rpm2cpio "$ORIG_RPM" | cpio -idmv
+
+          if [ -f "usr/bin" ] && [ ! -d "usr/bin" ]; then
+            echo "Repairing extracted tree: moving usr/bin -> usr/bin/eim"
+            mv usr/bin usr/bin.eim-tmp
+            mkdir -p usr/bin
+            mv usr/bin.eim-tmp usr/bin/eim
+            chmod 755 usr/bin/eim
+          fi
+
+          if [ "$HAS_BIN_BUG" = "true" ] && [ ! -f "usr/bin/eim" ]; then
+            echo "FAIL: expected usr/bin/eim to exist after repair, but it doesn't." >&2
+            find usr -maxdepth 2 >&2
+            exit 1
+          fi
 
           # Helper: read an RPM tag, return a fallback if the value is empty or "(none)"
           rpm_tag() {
@@ -1636,8 +1661,11 @@ jobs:
             --define "_rpmdir $GITHUB_WORKSPACE/gui_rpm_output" \
             --target "$ARCH"
 
-          echo "Repackaged RPM dependencies:"
+          echo "Repackaged RPM file listing (confirming /usr/bin is now a directory):"
           NEWRPM=$(find "$GITHUB_WORKSPACE/gui_rpm_output" -name "*.rpm" -type f -print -quit)
+          rpm -qp --queryformat '[%{FILEMODES:perms} %{FILENAMES}\n]' "$NEWRPM" | grep -E '/usr/bin(/eim)?$'
+
+          echo "Repackaged RPM dependencies:"
           rpm -qpR "$NEWRPM" || true
 
           echo "gui_rpm_available=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/test_pkg_managers.yml
+++ b/.github/workflows/test_pkg_managers.yml
@@ -56,10 +56,10 @@ jobs:
           echo "stripped=${STRIPPED}" >> $GITHUB_OUTPUT
           echo "Resolved version: ${STRIPPED:-<none>}"
 
-  # ── 2. Linux — native container, inline YAML matrix ──
+  # ── 2. Linux — native container, inline YAML matrix (CLI + GUI) ──
 
   test-linux:
-    name: PkgMgr (${{ matrix.pkg_manager }}) ${{ matrix.distro_name }}
+    name: PkgMgr (${{ matrix.pkg_manager }}-${{ matrix.package_type }}) ${{ matrix.distro_name }}
     needs: resolve-version
     runs-on: ubuntu-latest
     container:
@@ -71,9 +71,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # Ubuntu / APT — CLI
           - image: ubuntu:latest
             pkg_manager: apt
             distro_name: ubuntu
+            package_type: cli
             package_name: eim-cli
             install_cmd: apt-get install -y eim-cli
             uninstall_cmd: apt-get remove -y eim-cli
@@ -82,13 +84,38 @@ jobs:
               echo 'deb [trusted=yes] https://dl.espressif.com/dl/eim/apt stable main' \
                 | tee /etc/apt/sources.list.d/eim.list
               apt-get update
+          # Ubuntu / APT — GUI (includes CLI functionality per docs)
+          - image: ubuntu:latest
+            pkg_manager: apt
+            distro_name: ubuntu
+            package_type: gui
+            package_name: eim
+            install_cmd: apt-get install -y eim
+            uninstall_cmd: apt-get remove -y eim
+            meta_cmd: dpkg -l eim
+            repo_setup: |
+              echo 'deb [trusted=yes] https://dl.espressif.com/dl/eim/apt stable main' \
+                | tee /etc/apt/sources.list.d/eim.list
+              apt-get update
+          # Fedora / DNF — CLI
           - image: fedora:latest
             pkg_manager: dnf
             distro_name: fedora
+            package_type: cli
             package_name: eim-cli
             install_cmd: dnf install -y eim-cli
             uninstall_cmd: dnf remove -y eim-cli
             meta_cmd: rpm -qi eim-cli
+            repo_setup: curl -fsSL https://dl.espressif.com/dl/eim/rpm/eim.repo -o /etc/yum.repos.d/eim.repo
+          # Fedora / DNF — GUI
+          - image: fedora:latest
+            pkg_manager: dnf
+            distro_name: fedora
+            package_type: gui
+            package_name: eim
+            install_cmd: dnf install -y eim
+            uninstall_cmd: dnf remove -y eim
+            meta_cmd: rpm -qi eim
             repo_setup: curl -fsSL https://dl.espressif.com/dl/eim/rpm/eim.repo -o /etc/yum.repos.d/eim.repo
     steps:
       - name: Install prerequisites
@@ -141,6 +168,15 @@ jobs:
       - name: Verify package metadata
         run: ${{ matrix.meta_cmd }}
 
+      - name: Verify GUI desktop entry
+        if: matrix.package_type == 'gui'
+        run: |
+          if ! find /usr/share/applications /usr/local/share/applications -iname "*eim*" 2>/dev/null | grep -q .; then
+            echo "FAIL: no desktop entry found for GUI package '${{ matrix.package_name }}'"
+            exit 1
+          fi
+          echo "Desktop entry found for GUI package"
+
       - name: Uninstall package
         run: ${{ matrix.uninstall_cmd }}
 
@@ -148,19 +184,34 @@ jobs:
         uses: actions/upload-artifact@v7
         if: always()
         with:
-          name: pkg-manager-logs-${{ matrix.pkg_manager }}-${{ matrix.distro_name }}
+          name: pkg-manager-logs-${{ matrix.pkg_manager }}-${{ matrix.package_type }}-${{ matrix.distro_name }}
           path: /root/.local/share/eim/logs/
           if-no-files-found: ignore
 
-  # ── 3. macOS — Homebrew ──
+  # ── 3. macOS — Homebrew (formula = CLI, cask = GUI) ──
 
   test-brew:
-    name: PkgMgr (brew)
+    name: PkgMgr (brew-${{ matrix.package_type }})
     needs: resolve-version
     runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - package_type: cli
+            install_cmd: brew install espressif/eim/eim
+            uninstall_cmd: brew uninstall espressif/eim/eim
+            list_cmd: brew list espressif/eim/eim
+          - package_type: gui
+            install_cmd: brew install --cask espressif/eim/eim-gui
+            uninstall_cmd: brew uninstall --cask espressif/eim/eim-gui
+            list_cmd: brew list --cask espressif/eim/eim-gui
     steps:
+      - name: Tap Espressif repository
+        run: brew tap espressif/eim
+
       - name: Install package
-        run: brew install espressif/eim/eim
+        run: ${{ matrix.install_cmd }}
 
       - name: Verify binary on PATH
         run: which eim
@@ -176,26 +227,43 @@ jobs:
         run: eim --do-not-track true --help | grep -i install
 
       - name: Verify package metadata
-        run: brew list espressif/eim/eim
+        run: ${{ matrix.list_cmd }}
+
+      - name: Verify GUI app bundle
+        if: matrix.package_type == 'gui'
+        run: |
+          if ! find /Applications -maxdepth 1 -iname "*eim*" | grep -q .; then
+            echo "FAIL: no .app bundle found in /Applications for eim-gui cask"
+            exit 1
+          fi
+          echo "GUI app bundle found in /Applications"
 
       - name: Uninstall package
-        run: brew uninstall espressif/eim/eim
+        run: ${{ matrix.uninstall_cmd }}
 
       - name: Upload EIM logs
         uses: actions/upload-artifact@v7
         if: always()
         with:
-          name: pkg-manager-logs-brew-macos
+          name: pkg-manager-logs-brew-${{ matrix.package_type }}-macos
           path: ~/Library/Application Support/eim/logs/
           if-no-files-found: ignore
 
-  # ── 4. Windows — WinGet (nightly / PR only) ──
+  # ── 4. Windows — WinGet (nightly / PR only), CLI + GUI ──
 
   test-winget:
-    name: PkgMgr (winget)
+    name: PkgMgr (winget-${{ matrix.package_type }})
     needs: resolve-version
     if: inputs.run_mode != 'release'
     runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - package_type: cli
+            winget_id: Espressif.EIM-CLI
+          - package_type: gui
+            winget_id: Espressif.EIM
     steps:
       - name: Exclude workspace from Defender
         run: Add-MpPreference -ExclusionPath "${{ github.workspace }}"
@@ -203,9 +271,38 @@ jobs:
       - name: Install package
         shell: pwsh
         run: |
-          winget install --id Espressif.EIM-CLI --accept-package-agreements --accept-source-agreements
+          winget install --id ${{ matrix.winget_id }} --accept-package-agreements --accept-source-agreements
           $wingetLinks = "$env:LOCALAPPDATA\Microsoft\WinGet\Links"
           if (Test-Path $wingetLinks) { echo $wingetLinks >> $env:GITHUB_PATH }
+
+      - name: Locate GUI binary and add to PATH
+        if: matrix.package_type == 'gui'
+        shell: pwsh
+        run: |
+          if (Get-Command eim.exe -ErrorAction SilentlyContinue) {
+            Write-Host "eim.exe already on PATH, nothing to do"
+            exit 0
+          }
+          $searchRoots = @(
+            "$env:ProgramFiles",
+            "${env:ProgramFiles(x86)}",
+            "$env:LOCALAPPDATA\Programs",
+            "$env:LOCALAPPDATA"
+          ) | Where-Object { $_ -and (Test-Path $_) }
+
+          $found = $null
+          foreach ($root in $searchRoots) {
+            $match = Get-ChildItem -Path $root -Recurse -Filter "eim.exe" -ErrorAction SilentlyContinue -File | Select-Object -First 1
+            if ($match) { $found = $match; break }
+          }
+
+          if (-not $found) {
+            Write-Error "Could not locate eim.exe under Program Files or LocalAppData after GUI install"
+            exit 1
+          }
+
+          Write-Host "Found eim.exe at: $($found.FullName)"
+          Add-Content -Path $env:GITHUB_PATH -Value $found.DirectoryName
 
       - name: Verify binary on PATH
         shell: pwsh
@@ -232,17 +329,27 @@ jobs:
 
       - name: Verify package metadata
         shell: pwsh
-        run: winget list --id Espressif.EIM-CLI
+        run: winget list --id ${{ matrix.winget_id }}
+
+      - name: Verify GUI Start Menu shortcut
+        if: matrix.package_type == 'gui'
+        shell: pwsh
+        run: |
+          $shortcuts = Get-ChildItem -Path "$env:ProgramData\Microsoft\Windows\Start Menu\Programs","$env:APPDATA\Microsoft\Windows\Start Menu\Programs" -Recurse -Filter "*eim*" -ErrorAction SilentlyContinue
+          if (-not $shortcuts) {
+            Write-Error "FAIL: no Start Menu shortcut found for GUI package"; exit 1
+          }
+          Write-Host "Start Menu shortcut found: $($shortcuts[0].FullName)"
 
       - name: Uninstall package
         shell: pwsh
-        run: winget uninstall --id Espressif.EIM-CLI --accept-source-agreements
+        run: winget uninstall --id ${{ matrix.winget_id }} --accept-source-agreements
 
       - name: Upload EIM logs
         uses: actions/upload-artifact@v7
         if: always()
         with:
-          name: pkg-manager-logs-winget-windows
+          name: pkg-manager-logs-winget-${{ matrix.package_type }}-windows
           path: ${{ env.LOCALAPPDATA }}\eim\logs\
           if-no-files-found: ignore
 

--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -219,8 +219,18 @@ jobs:
 
             app "eim.app"
 
+            # The GUI binary is CLI-capable (invoked as \`eim <command>\`), but a
+            # cask only installs the .app bundle by default — nothing lands on
+            # PATH unless we say so explicitly. This symlinks the executable
+            # embedded in the bundle into \$(brew --prefix)/bin, so GUI users
+            # get the same \`eim\` command CLI-only users get, without needing
+            # to separately \`brew install eim\`.
+            binary "#{appdir}/eim.app/Contents/MacOS/eim"
+
             caveats <<~EOS
               ESP-IDF Installation Manager (EIM) has been installed.
+
+              The \`eim\` command is now also available in your terminal.
 
               IMPORTANT: ESP-IDF requires Python 3.9, 3.10, 3.11, 3.12, 3.13 or 3.14.
 


### PR DESCRIPTION
this way we should test both CLI and GUI packages.
it also fixes the GUI rpm package and homebrew GUI formula so it now gives user full CLI capability too