### PR TITLE
EIM-892: Added version tag to the binaries for release

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -269,8 +269,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          cp release_cli/${{ matrix.package_name }}/eim.zip eim-cli-${{ matrix.package_name }}.zip
-          gh release upload "${{ github.event.release.tag_name }}" eim-cli-${{ matrix.package_name }}.zip --clobber
+          cp release_cli/${{ matrix.package_name }}/eim.zip eim-cli-${{ matrix.package_name }}_${{ github.event.release.tag_name }}.zip
+          gh release upload "${{ github.event.release.tag_name }}" eim-cli-${{ matrix.package_name }}_${{ github.event.release.tag_name }}.zip --clobber
 
       # offline installer
       - name: Build offline_installer_builder
@@ -298,8 +298,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          cp release_cli/${{ matrix.package_name }}/offline_installer_builder.zip offline_installer_builder-${{ matrix.package_name }}.zip
-          gh release upload "${{ github.event.release.tag_name }}" offline_installer_builder-${{ matrix.package_name }}.zip --clobber
+          cp release_cli/${{ matrix.package_name }}/offline_installer_builder.zip offline_installer_builder-${{ matrix.package_name }}_${{ github.event.release.tag_name }}.zip
+          gh release upload "${{ github.event.release.tag_name }}" offline_installer_builder-${{ matrix.package_name }}_${{ github.event.release.tag_name }}.zip --clobber
 
       - name: Prepare manpage for deb package
         if: github.event_name == 'release' && github.event.action == 'created'
@@ -454,8 +454,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          cp release_cli/linux-armv7/eim.zip eim-cli-linux-armv7.zip
-          gh release upload "${{ github.event.release.tag_name }}" eim-cli-linux-armv7.zip --clobber
+          cp release_cli/linux-armv7/eim.zip eim-cli-linux-armv7_${{ github.event.release.tag_name }}.zip
+          gh release upload "${{ github.event.release.tag_name }}" eim-cli-linux-armv7_${{ github.event.release.tag_name }}.zip --clobber
 
       # offline installer
       - name: Build offline_installer_builder
@@ -490,8 +490,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          cp release_cli/linux-armv7/offline_installer_builder.zip offline_installer_builder-linux-armv7.zip
-          gh release upload "${{ github.event.release.tag_name }}" offline_installer_builder-linux-armv7.zip --clobber
+          cp release_cli/linux-armv7/offline_installer_builder.zip offline_installer_builder-linux-armv7_${{ github.event.release.tag_name }}.zip
+          gh release upload "${{ github.event.release.tag_name }}" offline_installer_builder-linux-armv7_${{ github.event.release.tag_name }}.zip --clobber
 
       # .deb package
       - name: Prepare manpage for deb package
@@ -1057,16 +1057,16 @@ jobs:
           cd release_cli/${{ matrix.package_name }}
           zip -r eim.zip eim
           cd ../..
-          cp release_cli/${{ matrix.package_name }}/eim.zip eim-cli-${{ matrix.package_name }}.zip
-          gh release upload "${{ github.event.release.tag_name }}" eim-cli-${{ matrix.package_name }}.zip --clobber
+          cp release_cli/${{ matrix.package_name }}/eim.zip eim-cli-${{ matrix.package_name }}_${{ github.event.release.tag_name }}.zip
+          gh release upload "${{ github.event.release.tag_name }}" eim-cli-${{ matrix.package_name }}_${{ github.event.release.tag_name }}.zip --clobber
 
       - name: Upload Release Asset (Windows)
         if: github.event_name == 'release' && github.event.action == 'created' && runner.os == 'Windows'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          cp release_cli/${{ matrix.package_name }}/eim.exe eim-cli-${{ matrix.package_name }}.exe
-          gh release upload "${{ github.event.release.tag_name }}" eim-cli-${{ matrix.package_name }}.exe --clobber
+          cp release_cli/${{ matrix.package_name }}/eim.exe eim-cli-${{ matrix.package_name }}_${{ github.event.release.tag_name }}.exe
+          gh release upload "${{ github.event.release.tag_name }}" eim-cli-${{ matrix.package_name }}_${{ github.event.release.tag_name }}.exe --clobber
 
       - name: Build offline_installer_builder (Windows)
         if: runner.os == 'Windows'
@@ -1160,8 +1160,9 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           (cd release_cli/${{ matrix.package_name }} && zip offline_installer_builder.zip offline_installer_builder)
+          cp release_cli/${{ matrix.package_name }}/offline_installer_builder.zip offline_installer_builder-${{ matrix.package_name }}_${{ github.event.release.tag_name }}.zip
           gh release upload "${{ github.event.release.tag_name }}" \
-            release_cli/${{ matrix.package_name }}/offline_installer_builder.zip \
+            offline_installer_builder-${{ matrix.package_name }}_${{ github.event.release.tag_name }}.zip \
             --clobber
 
       - name: Upload offline_installer_builder Release Asset (Windows)
@@ -1169,8 +1170,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          cp release_cli/${{ matrix.package_name }}/offline_installer_builder.exe offline_installer_builder-${{ matrix.package_name }}.exe
-          gh release upload "${{ github.event.release.tag_name }}" offline_installer_builder-${{ matrix.package_name }}.exe --clobber
+          cp release_cli/${{ matrix.package_name }}/offline_installer_builder.exe offline_installer_builder-${{ matrix.package_name }}_${{ github.event.release.tag_name }}.exe
+          gh release upload "${{ github.event.release.tag_name }}" offline_installer_builder-${{ matrix.package_name }}_${{ github.event.release.tag_name }}.exe --clobber
 
   build-offline-archives:
     name: Build Offline Archives
@@ -1446,8 +1447,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          cp src-tauri/target/release/eim.exe "eim-gui-${{ matrix.package_name }}.exe"
-          gh release upload "${{ github.event.release.tag_name }}" "eim-gui-${{ matrix.package_name }}.exe" --clobber
+          cp src-tauri/target/release/eim.exe "eim-gui-${{ matrix.package_name }}_${{ github.event.release.tag_name }}.exe"
+          gh release upload "${{ github.event.release.tag_name }}" "eim-gui-${{ matrix.package_name }}_${{ github.event.release.tag_name }}.exe" --clobber
 
       - name: Upload Release Assets (Windows msi)
         if: github.event_name == 'release' && github.event.action == 'created' && runner.os == 'Windows'
@@ -1464,8 +1465,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          cp src-tauri/target/release/eim.zip "eim-gui-${{ matrix.package_name }}.zip"
-          gh release upload "${{ github.event.release.tag_name }}" "eim-gui-${{ matrix.package_name }}.zip" --clobber
+          cp src-tauri/target/release/eim.zip "eim-gui-${{ matrix.package_name }}_${{ github.event.release.tag_name }}.zip"
+          gh release upload "${{ github.event.release.tag_name }}" "eim-gui-${{ matrix.package_name }}_${{ github.event.release.tag_name }}.zip" --clobber
 
       - name: Upload Release Assets (Linux - .deb)
         if: github.event_name == 'release' && github.event.action == 'created' && startsWith(matrix.os, 'ubuntu')
@@ -1482,8 +1483,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          cp src-tauri/target/release/bundle/macos/eim.zip "eim-gui-${{ matrix.package_name }}.zip"
-          gh release upload "${{ github.event.release.tag_name }}" "eim-gui-${{ matrix.package_name }}.zip" --clobber
+          cp src-tauri/target/release/bundle/macos/eim.zip "eim-gui-${{ matrix.package_name }}_${{ github.event.release.tag_name }}.zip"
+          gh release upload "${{ github.event.release.tag_name }}" "eim-gui-${{ matrix.package_name }}_${{ github.event.release.tag_name }}.zip" --clobber
 
       - name: Upload Release Assets (macOS - dmg)
         if: github.event_name == 'release' && github.event.action == 'created' && startsWith(matrix.os, 'macos')

--- a/.github/workflows/test_offline.yml
+++ b/.github/workflows/test_offline.yml
@@ -115,7 +115,7 @@ jobs:
         if: matrix.os != 'windows-latest' && inputs.eim_cli_run_id == 'release'
         run: |
           latest_release=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/espressif/idf-im-ui/releases/latest)
-          eim_cli_url=$(echo "$latest_release" | jq -r '.assets[] | select(.name | test("eim-cli-${{matrix.package_name}}.zip")) | .browser_download_url')
+          eim_cli_url=$(echo "$latest_release" | jq -r '.assets[] | select(.name | test("eim-cli-${{matrix.package_name}}_.*\\.zip$")) | .browser_download_url')
           curl -L -o ./artifacts/eim-cli.zip "$eim_cli_url"
           unzip ./artifacts/eim-cli.zip -d ./artifacts/
 
@@ -166,7 +166,7 @@ jobs:
         if: matrix.os == 'windows-latest' && inputs.eim_cli_run_id == 'release'
         run: |
           $latest_release = Invoke-RestMethod -Uri "https://api.github.com/repos/espressif/idf-im-ui/releases/latest"
-          $eim_cli_url = $latest_release.assets | Where-Object { $_.name -like "eim-cli-${{ matrix.package_name }}.exe" } | Select-Object -ExpandProperty browser_download_url
+          $eim_cli_url = $latest_release.assets | Where-Object { $_.name -like "eim-cli-${{ matrix.package_name }}_*.exe" } | Select-Object -ExpandProperty browser_download_url
           Invoke-WebRequest -Uri $eim_cli_url -OutFile ".\artifacts\eim.exe"
 
       - name: Remove python and git from PATH (Windows)

--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -51,23 +51,26 @@ jobs:
           # Authenticate the request to get proper asset URLs
           ASSETS=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "${{ github.event.release.assets_url || format('https://api.github.com/repos/{0}/releases/tags/{1}', github.repository, steps.tag.outputs.tag_name) }}")
 
+          # Release assets carry the version tag in their filename (e.g. eim-cli-macos-x64_v0.15.0.zip)
+          TAG="${{ steps.tag.outputs.tag_name }}"
+
           # macOS x64 CLI
-          macos_x64_url=$(echo "$ASSETS" | jq -r '.[] | select(.name == "eim-cli-macos-x64.zip") | .browser_download_url')
+          macos_x64_url=$(echo "$ASSETS" | jq -r --arg name "eim-cli-macos-x64_${TAG}.zip" '.[] | select(.name == $name) | .browser_download_url')
           wget -q "$macos_x64_url" -O eim-cli-macos-x64.zip
           macos_x64_sha=$(sha256sum eim-cli-macos-x64.zip | cut -d' ' -f1)
 
           # macOS ARM64 CLI
-          macos_arm64_url=$(echo "$ASSETS" | jq -r '.[] | select(.name == "eim-cli-macos-aarch64.zip") | .browser_download_url')
+          macos_arm64_url=$(echo "$ASSETS" | jq -r --arg name "eim-cli-macos-aarch64_${TAG}.zip" '.[] | select(.name == $name) | .browser_download_url')
           wget -q "$macos_arm64_url" -O eim-cli-macos-aarch64.zip
           macos_arm64_sha=$(sha256sum eim-cli-macos-aarch64.zip | cut -d' ' -f1)
 
           # Linux x64 CLI
-          linux_x64_url=$(echo "$ASSETS" | jq -r '.[] | select(.name == "eim-cli-linux-x64.zip") | .browser_download_url')
+          linux_x64_url=$(echo "$ASSETS" | jq -r --arg name "eim-cli-linux-x64_${TAG}.zip" '.[] | select(.name == $name) | .browser_download_url')
           wget -q "$linux_x64_url" -O eim-cli-linux-x64.zip
           linux_x64_sha=$(sha256sum eim-cli-linux-x64.zip | cut -d' ' -f1)
 
           # Linux ARM64 CLI
-          linux_arm64_url=$(echo "$ASSETS" | jq -r '.[] | select(.name == "eim-cli-linux-aarch64.zip") | .browser_download_url')
+          linux_arm64_url=$(echo "$ASSETS" | jq -r --arg name "eim-cli-linux-aarch64_${TAG}.zip" '.[] | select(.name == $name) | .browser_download_url')
           wget -q "$linux_arm64_url" -O eim-cli-linux-aarch64.zip
           linux_arm64_sha=$(sha256sum eim-cli-linux-aarch64.zip | cut -d' ' -f1)
 

--- a/.github/workflows/update-windows-packages.yml
+++ b/.github/workflows/update-windows-packages.yml
@@ -51,7 +51,7 @@ jobs:
               license = "MIT"
               architecture = @{
                   "64bit" = @{
-                      url = "https://github.com/espressif/idf-im-ui/releases/download/${env:VERSION}/eim-cli-windows-x64.exe#/eim.exe"
+                      url = "https://github.com/espressif/idf-im-ui/releases/download/${env:VERSION}/eim-cli-windows-x64_${env:VERSION}.exe#/eim.exe"
                       hash = $cliHash
                   }
               }
@@ -62,7 +62,7 @@ jobs:
               autoupdate = @{
                   architecture = @{
                       "64bit" = @{
-                          url = "https://github.com/espressif/idf-im-ui/releases/download/v`$version/eim-cli-windows-x64.exe#/eim.exe"
+                          url = "https://github.com/espressif/idf-im-ui/releases/download/v`$version/eim-cli-windows-x64_v`$version.exe#/eim.exe"
                       }
                   }
               }
@@ -78,7 +78,7 @@ jobs:
               license = "MIT"
               architecture = @{
                   "64bit" = @{
-                      url = "https://github.com/espressif/idf-im-ui/releases/download/${env:VERSION}/eim-gui-windows-x64.exe#/eim-gui.exe"
+                      url = "https://github.com/espressif/idf-im-ui/releases/download/${env:VERSION}/eim-gui-windows-x64_${env:VERSION}.exe#/eim-gui.exe"
                       hash = $guiHash
                   }
               }
@@ -92,7 +92,7 @@ jobs:
               autoupdate = @{
                   architecture = @{
                       "64bit" = @{
-                          url = "https://github.com/espressif/idf-im-ui/releases/download/v`$version/eim-gui-windows-x64.exe#/eim-gui.exe"
+                          url = "https://github.com/espressif/idf-im-ui/releases/download/v`$version/eim-gui-windows-x64_v`$version.exe#/eim-gui.exe"
                       }
                   }
               }
@@ -123,7 +123,7 @@ jobs:
         uses: vedantmgoyal9/winget-releaser@v2
         with:
           identifier: Espressif.EIM-CLI
-          installers-regex: 'eim-cli-windows-x64\.exe$'
+          installers-regex: 'eim-cli-windows-x64_.*\.exe$'
           version-filter: ${{ inputs.version }}
           token: ${{ secrets.WINGET_PAT }}
           fork-user: Hahihula


### PR DESCRIPTION
# EIM-892: Add version to CLI and GUI binary filenames

Closes #929

## Summary

Release binaries currently ship with unversioned names (e.g. `eim-gui-windows-x64.exe`), which makes it hard to tell versions apart in a downloads folder and causes duplicate-name collisions like `eim-gui-windows-x64 (1).exe`. This PR adds the release tag to the raw CLI and GUI binary filenames so they look like `eim-gui-windows-x64_v0.15.0.exe`.

Version suffix comes from `${{ github.event.release.tag_name }}` and is only applied on real releases; PR and nightly builds are unaffected.

## What changed

### Release asset names (`.github/workflows/build.yaml`)
Added `_<tag>` before the extension for the raw executable binaries only:
- CLI: `eim-cli-*` `.zip` (linux x64/aarch64/armv7, macOS x64/aarch64) and `eim-cli-windows-x64.exe`
- GUI: `eim-gui-windows-x64.exe` and `eim-gui-*` `.zip` (linux + macOS)
- `offline_installer_builder-*` `.zip`/`.exe` (also fixed the macOS upload, which previously used a non-platform name and could collide between x64/aarch64)

Package formats are intentionally left unchanged: `.deb`, `.rpm`, `.msi`, `.dmg`, pacman.

### Consumer workflows updated to match
- `.github/workflows/update-homebrew.yml` — CLI formula now looks up the versioned `.zip` binaries (GUI cask uses `.dmg`, unchanged).
- `.github/workflows/update-windows-packages.yml` — Scoop CLI/GUI download URLs (static + autoupdate) and the WinGet CLI `installers-regex` now target the versioned `.exe` (WinGet GUI uses `.msi`, unchanged).
- `.github/workflows/test_offline.yml` — release-mode CLI download selectors updated to match the versioned names.

## Not affected (verified)
- **Download page** (`dl_page/index.html`): builds links dynamically from the GitHub API `browser_download_url` and classifies assets by substring, so versioned names work as-is.
- **Linux repos** (`update-linux-repos.yml`): consumes build artifacts and repackages `.deb`/`.rpm`/pacman; never references the renamed binaries.
- **S3 uploads**: the `.zip`/`.exe` binaries are never uploaded to S3 (only published as GitHub release assets; `dl.espressif.com` is a passthrough mirror). S3 only holds the Linux repos, offline `.zst` archives, release-info JSON, and the download page.
- **PR / nightly builds**: all renamed uploads are guarded by `github.event_name == 'release' && github.event.action == 'created'`; `upload-artifact` names are unchanged.

## Before / after

| Before | After |
| --- | --- |
| `eim-gui-windows-x64.exe` | `eim-gui-windows-x64_v0.15.0.exe` |
| `eim-cli-linux-x64.zip` | `eim-cli-linux-x64_v0.15.0.zip` |

## Testing notes
- All four edited workflows pass YAML validation.
- Recommended: run a dry release against a throwaway tag (e.g. `v99.0.0-test`) and confirm the release assets, Homebrew formula, and Scoop/WinGet manifests resolve to the versioned filenames.
