### PR TITLE
EIM-285: Improved error handling and early fail on network issues

### DIFF
--- a/src-tauri/src/cli/wizard.rs
+++ b/src-tauri/src/cli/wizard.rs
@@ -205,7 +205,16 @@ pub fn download_idf(config: DownloadConfig) -> Result<(), DownloadError> {
         }
         Err(err) => {
             if config.non_interactive == Some(true) {
-                Ok(())
+                // No user to prompt in non-interactive mode. Preserve the
+                // idempotent "already exists" behaviour, but surface real
+                // download/network failures instead of silently continuing
+                // (which previously masked the cause with downstream errors).
+                if err.contains("exists") || err.contains("not empty") {
+                    warn!("IDF path already present; continuing (non-interactive): {}", err);
+                    Ok(())
+                } else {
+                    Err(DownloadError::DownloadFailed(err))
+                }
             } else {
                 handle_download_error(err)
             }

--- a/src-tauri/src/cli/wizard.rs
+++ b/src-tauri/src/cli/wizard.rs
@@ -209,7 +209,9 @@ pub fn download_idf(config: DownloadConfig) -> Result<(), DownloadError> {
                 // idempotent "already exists" behaviour, but surface real
                 // download/network failures instead of silently continuing
                 // (which previously masked the cause with downstream errors).
-                if err.contains("exists") || err.contains("not empty") {
+                if (err.contains("exists") && !err.contains("does not exist"))
+                    || err.contains("not empty")
+                {
                     warn!("IDF path already present; continuing (non-interactive): {}", err);
                     Ok(())
                 } else {

--- a/src-tauri/src/lib/command_executor.rs
+++ b/src-tauri/src/lib/command_executor.rs
@@ -75,6 +75,7 @@ impl CommandExecutor for DefaultExecutor {
         Command::new(command)
             .args(args)
             .current_dir(dir)
+            .stderr(std::process::Stdio::piped())
             .spawn()
     }
     fn run_script_from_string(&self, script: &str) -> std::io::Result<Output> {
@@ -252,6 +253,7 @@ impl CommandExecutor for WindowsExecutor {
             .args(args)
             .current_dir(dir)
             .creation_flags(CREATE_NO_WINDOW)
+            .stderr(std::process::Stdio::piped())
             .spawn()
     }
 

--- a/src-tauri/src/lib/git_tools.rs
+++ b/src-tauri/src/lib/git_tools.rs
@@ -2365,6 +2365,7 @@ pub fn clone_with_git_cli(
     // Spawn `git clone` and stream stderr for progress (best-effort).
     let clone_args_ref: Vec<&str> = clone_args.iter().map(|s| s.as_str()).collect();
     let mut child = spawn_with_dir("git", &clone_args_ref, cwd_str)?;
+    let mut stderr_tail: Vec<String> = Vec::new();
     if let Some(stderr) = child.stderr.take() {
         let reader = BufReader::new(stderr);
         for line in reader.lines().map_while(Result::ok) {
@@ -2373,15 +2374,32 @@ pub fn clone_with_git_cli(
                 // post-clone work (commit checkout / submodules).
                 let scaled = (percentage * 80) / 100;
                 let _ = tx.send(ProgressMessage::Update(scaled));
+            } else {
+                // Non-progress lines carry git's actual diagnostics (e.g.
+                // "fatal: unable to access '...': Could not resolve host: github.com").
+                // Keep a bounded tail so we can report the real cause on failure.
+                let trimmed = line.trim();
+                if !trimmed.is_empty() {
+                    stderr_tail.push(trimmed.to_string());
+                    if stderr_tail.len() > 20 {
+                        stderr_tail.remove(0);
+                    }
+                }
             }
         }
     }
     let status = child.wait()?;
     if !status.success() {
+        let details = stderr_tail.join("; ");
         return Err(format!(
-            "git clone failed (exit code {:?}) for {}",
+            "git clone failed (exit code {:?}) for {}{}",
             status.code(),
-            options.url
+            options.url,
+            if details.is_empty() {
+                String::new()
+            } else {
+                format!(": {}", details)
+            }
         )
         .into());
     }


### PR DESCRIPTION
Deliberately minimal and free of heuristics. We do **not** try to classify or re-label errors as "network" the underlying tools (gix, git, reqwest) already produce clear messages. The fix is simply to **stop discarding those messages and fail cleanly**.

- **Capture git's stderr.** While streaming stderr for progress, keep a bounded tail (last ~20 non-progress lines) and append it to the error when the process exits non-zero. `git` is an external process, so its only "error" is its exit code plus the text it prints to stderr; we retain that text as we read the stream.
- **Stop swallowing the error in non-interactive mode.** A genuine clone failure now returns DownloadError::DownloadFailed`, which the caller already logs and aborts on. The idempotent "path already exists / not empty" case is preserved (logged as a warning and allowed to continue), consistent with the interactive path.


## Changes

| File | Change |
| --- | --- |
| `src-tauri/src/lib/git_tools.rs` | Retain git-CLI stderr tail and include it in the clone-failure error |
| `src-tauri/src/cli/wizard.rs` | Non-interactive clone failures propagate instead of being swallowed |