### PR TITLE
fix: sanitize version/tag name for valid path (EIM-938)

### DIFF
--- a/src-tauri/src/gui/commands/installation.rs
+++ b/src-tauri/src/gui/commands/installation.rs
@@ -37,6 +37,7 @@ use std::os::windows::process::CommandExt;
 use anyhow::{anyhow, Context, Result};
 use idf_im_lib::{
   ensure_path,
+  sanitize_version_name,
   expand_tilde,
   idf_config::{IdfConfig, IDF_CONFIG_FILE_NAME},
   offline_installer::{copy_idf_from_offline_archive, install_prerequisites_offline, use_offline_archive},
@@ -99,7 +100,7 @@ fn prepare_installation_directories(
   settings: &Settings,
   version: &str,
 ) -> Result<PathBuf, Box<dyn std::error::Error>> {
-  let version_path = settings.path.as_ref().unwrap().as_path().join(version);
+  let version_path = settings.path.as_ref().unwrap().as_path().join(sanitize_version_name(version));
 
   ensure_path(version_path.to_str().unwrap())?;
   send_message(

--- a/src-tauri/src/gui/mod.rs
+++ b/src-tauri/src/gui/mod.rs
@@ -5,7 +5,7 @@ use fork::{daemon, Fork};
 use idf_im_lib::get_log_directory;
 use idf_im_lib::logging::formatter;
 use idf_im_lib::{
-    add_path_to_path, ensure_path,
+    add_path_to_path, ensure_path, sanitize_version_name,
     logging,
     settings::Settings,
 };
@@ -34,7 +34,7 @@ fn prepare_installation_directories(
     settings: &Settings,
     version: &str,
 ) -> Result<PathBuf, Box<dyn std::error::Error>> {
-    let version_path = settings.path.as_ref().unwrap().as_path().join(version);
+    let version_path = settings.path.as_ref().unwrap().as_path().join(sanitize_version_name(version));
 
     ensure_path(version_path.to_str().unwrap())?;
     send_message(

--- a/src-tauri/src/lib/idf_config.rs
+++ b/src-tauri/src/lib/idf_config.rs
@@ -244,7 +244,11 @@ impl IdfConfig {
         if let Some(installation) = self
             .idf_installed
             .iter_mut()
-            .find(|install| install.id == identifier || install.name == identifier)
+            .find(|install| {
+                install.id == identifier
+                    || install.name == identifier
+                    || install.name == crate::sanitize_version_name(identifier)
+            })
         {
             installation.name = new_name;
             true
@@ -275,6 +279,7 @@ impl IdfConfig {
             .find(|install| {
                 install.id == identifier
                     || install.name == identifier
+                    || install.name == crate::sanitize_version_name(identifier)
                     || { let normalized_identifier = crate::utils::normalize_path_for_comparison(identifier);
                      normalized_identifier.is_some() && normalized_identifier == crate::utils::normalize_path_for_comparison(&install.path)
                 }
@@ -306,7 +311,11 @@ impl IdfConfig {
         if let Some(index) = self
             .idf_installed
             .iter()
-            .position(|install| install.id == identifier || install.name == identifier)
+            .position(|install| {
+                install.id == identifier
+                    || install.name == identifier
+                    || install.name == crate::sanitize_version_name(identifier)
+            })
         {
             // If we're removing the currently selected installation, clear the selection
             if self.idf_selected_id == self.idf_installed[index].id {
@@ -465,6 +474,44 @@ mod tests {
 
         // Test removing non-existent installation
         assert!(!config.remove_installation("non-existent"));
+    }
+
+    /// Installs of a slashed version (e.g. `release/v5.5`) are stored under the
+    /// sanitized name `release-v5.5`. Lookups must accept the raw slashed form the
+    /// user is likely to type, while still matching the sanitized/stored form.
+    fn create_slashed_test_config() -> IdfConfig {
+        let mut config = create_test_config();
+        config.idf_installed[0].name = String::from("release-v5.5");
+        config.idf_installed[0].id = String::from("esp-idf-release-v5-5");
+        config.idf_selected_id = String::from("esp-idf-release-v5-5");
+        config
+    }
+
+    #[test]
+    fn test_lookup_matches_slashed_version() {
+        // remove: raw slashed input matches the stored sanitized name
+        let mut config = create_slashed_test_config();
+        assert!(config.remove_installation("release/v5.5"));
+        assert!(!config.idf_installed.iter().any(|i| i.name == "release-v5.5"));
+
+        // remove: the sanitized form still matches
+        let mut config = create_slashed_test_config();
+        assert!(config.remove_installation("release-v5.5"));
+
+        // select: raw slashed input selects the sanitized install
+        let mut config = create_slashed_test_config();
+        config.idf_selected_id.clear();
+        assert!(config.select_installation("release/v5.5"));
+        assert_eq!(config.idf_selected_id, "esp-idf-release-v5-5");
+
+        // rename: raw slashed input finds the sanitized install
+        let mut config = create_slashed_test_config();
+        assert!(config.update_installation_name("release/v5.5", String::from("renamed")));
+        assert_eq!(config.idf_installed[0].name, "renamed");
+
+        // a plain (slash-free) name is unaffected
+        let mut config = create_test_config();
+        assert!(config.remove_installation("v5.1.5"));
     }
 
     #[test]

--- a/src-tauri/src/lib/mod.rs
+++ b/src-tauri/src/lib/mod.rs
@@ -1959,6 +1959,15 @@ pub fn ensure_path(directory_path: &str) -> std::io::Result<()> {
     Ok(())
 }
 
+/// Makes an IDF version/tag string safe to use as a directory or file name.
+///
+/// Branch/tag names may contain path separators (e.g. `release/v6.0`)
+/// This can create unnecessary nested directories. Instead replace them with
+/// a hyphen
+pub fn sanitize_version_name(version: &str) -> String {
+    version.replace(['/', '\\'], "-")
+}
+
 /// Adds a directory to the system's PATH environment variable.
 /// If the directory is already present in the PATH, it will not be added again.
 ///
@@ -2601,6 +2610,15 @@ mod tests {
         builder.finish().unwrap();
 
         (dest_dir, tar_path.to_string_lossy().into_owned())
+    }
+
+    #[test]
+    fn test_sanitize_version_name() {
+        assert_eq!(sanitize_version_name("release/v6.0"), "release-v6.0");
+        assert_eq!(sanitize_version_name("release/v5.5"), "release-v5.5");
+        assert_eq!(sanitize_version_name("v5.3.1"), "v5.3.1");
+        assert_eq!(sanitize_version_name("release-v6.0"), "release-v6.0");
+        assert_eq!(sanitize_version_name("release\\v6.0"), "release-v6.0");
     }
 
     #[test]

--- a/src-tauri/src/lib/offline_installer.rs
+++ b/src-tauri/src/lib/offline_installer.rs
@@ -285,7 +285,14 @@ pub fn copy_idf_from_offline_archive(
     let mut everything_copied = true;
     for archive_version in config.clone().idf_versions.unwrap() {
         let src_path = archive_dir.path().join(&archive_version);
-        let dst_path = config.clone().path.unwrap().join(&archive_version);
+        // Sanitize the destination so a slashed version (e.g. "release/v6.0") lands in a
+        // single directory matching what `get_version_paths` builds. The src keeps the raw
+        // form because the archive's internal layout is built with the raw version.
+        let dst_path = config
+            .clone()
+            .path
+            .unwrap()
+            .join(crate::sanitize_version_name(&archive_version));
 
         if let Some(parent) = dst_path.parent() {
             if !parent.exists() {

--- a/src-tauri/src/lib/settings.rs
+++ b/src-tauri/src/lib/settings.rs
@@ -459,10 +459,12 @@ impl Settings {
         (idf_path.clone(), idf_path, actual_version)
       } else {
         // New installation
-        let actual_version = match self.version_name {
+        // Sanitize the version/tag so a slash (e.g. "release/v6.0") does not create
+        // unintended nested directories or break the derived activation-script path.
+        let actual_version = crate::sanitize_version_name(&match self.version_name {
           Some(ref name) => name.to_string(),
           None => version.to_string(),
-        };
+        });
         let version_installation_path = base_path.join(&actual_version);
         let idf_path = version_installation_path.join("esp-idf");
         (idf_path, version_installation_path, actual_version)

--- a/src-tauri/src/lib/utils.rs
+++ b/src-tauri/src/lib/utils.rs
@@ -636,7 +636,7 @@ pub fn parse_tool_set_config(config_path: &str, idf_json_path: Option<&PathBuf>)
         single_version_post_install(
             &paths.activation_script_path.to_string_lossy().into_owned(),
             &tool_set.idf_location,
-            &tool_set.idf_version,
+            &paths.actual_version,
             &new_idf_tools_path,
             new_export_paths,
             idf_python_env_path.as_deref(),
@@ -651,7 +651,7 @@ pub fn parse_tool_set_config(config_path: &str, idf_json_path: Option<&PathBuf>)
             id: tool_set.id.to_string(),
             activation_script: paths.activation_script.to_string_lossy().into_owned(),
             path: tool_set.idf_location,
-            name: tool_set.idf_version,
+            name: paths.actual_version.clone(),
             python: paths.python_path.to_string_lossy().into_owned(),
             idf_tools_path: new_idf_tools_path,
             installation_config: None,

--- a/src-tauri/src/lib/version_manager.rs
+++ b/src-tauri/src/lib/version_manager.rs
@@ -290,7 +290,11 @@ pub fn remove_single_idf_version(
     if let Some(installation) = ide_config
         .idf_installed
         .iter()
-        .find(|install| install.id == identifier || install.name == identifier)
+        .find(|install| {
+            install.id == identifier
+                || install.name == identifier
+                || install.name == crate::sanitize_version_name(identifier)
+        })
         .cloned()
     {
         let installation_folder_path = PathBuf::from(installation.path.clone());
@@ -428,7 +432,10 @@ pub fn run_command_in_context(
 ) -> anyhow::Result<ExitStatus> {
     let installation = match list_installed_versions(config_path) {
         Ok(versions) => versions.into_iter().find(|v| {
-            v.id == identifier || v.name == identifier || {
+            v.id == identifier
+                || v.name == identifier
+                || v.name == crate::sanitize_version_name(identifier)
+                || {
                 let normalized_identifier = crate::utils::normalize_path_for_comparison(identifier);
                 normalized_identifier.is_some()
                     && normalized_identifier == crate::utils::normalize_path_for_comparison(&v.path)
@@ -936,7 +943,11 @@ fn find_installation<'a>(
     if let Some(install) = ide_config
         .idf_installed
         .iter()
-        .find(|i| i.id == identifier || i.name == identifier)
+        .find(|i| {
+            i.id == identifier
+                || i.name == identifier
+                || i.name == crate::sanitize_version_name(identifier)
+        })
     {
         return Ok(install);
     }


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

Installing an ESP-IDF branch/tag that contains a slash — e.g. `eim install -i release/v5.5` — failed, because the version string was used unsanitized as a directory and file name. The `/` was interpreted as a path separator, so the install spread across nested directories.

The git clone itself succeeds (it creates any missing directories), but activation-script generation failed as the script name is built as `activate_idf_release/v5.5.sh`

### Fix

Sanitize the version string wherever it is coverted to a path by replacing / and \ with - (e.g. `release/v5.5` → `release-v5.5`).

Git operations are intentionally left on the original slash form and keep working, because `git_tools` already sanitizes `release-*` ↔ `release/*` when resolving refs. This matches the codebase's existing convention: **store `release-vX.Y` on disk, use `release/vX.Y` for git**.

## Before / After

```
 ❯ eim install -i release/v5.5
2026-07-06 12:49:36 - 12 - 07 - INFO - ESP-IDF JSON file already exists at: "/Users/ak/.espressif/tools/eim_idf.json"
2026-07-06 12:49:36 - 12 - 07 - INFO - All prerequisites are satisfied!
2026-07-06 12:49:36 - 12 - 07 - INFO - Running python sanity check
2026-07-06 12:49:36 - 12 - 07 - INFO - Found python3
.
.
.
2026-07-06 12:50:55 - 12 - 07 - ERROR - Failed to create activation shell script "No such file or directory (os error 2)"
2026-07-06 12:50:55 - 12 - 07 - ERROR - Failed to create deactivation shell script "No such file or directory (os error 2)"
2026-07-06 12:50:55 - 12 - 07 - ERROR - Failed to create fish shell script "No such file or directory (os error 2)"
2026-07-06 12:50:55 - 12 - 07 - ERROR - Failed to create fish deactivation script "No such file or directory (os error 2)"
2026-07-06 12:50:55 - 12 - 07 - INFO - OpenOCD rules copied successfully
bash: /Users/ak/.espressif/tools/activate_idf_release/v5.5.sh: No such file or directory
bash: line 2: compote: command not found
```

```
 ❯ eim install -i release/v5.5
2026-07-23 11:49:41 - 11 - 07 - INFO - ESP-IDF JSON file already exists at: "/Users/ak/.espressif/tools/eim_idf.json"
2026-07-23 11:49:41 - 11 - 07 - INFO - All prerequisites are satisfied!
2026-07-23 11:49:41 - 11 - 07 - INFO - Running python sanity check
2026-07-23 11:49:41 - 11 - 07 - INFO - Found python3
  [PASS] Python Version
  [PASS] pip
  [PASS] venv
  [PASS] Standard Library (json, os, platform)
  [PASS] ctypes
  [PASS] SSL/HTTPS
.
.
.
2026-07-23 11:51:43 - 11 - 07 - INFO - Bash activation script created successfully
2026-07-23 11:51:43 - 11 - 07 - INFO - Bash deactivation script created successfully
2026-07-23 11:51:43 - 11 - 07 - INFO - Fish shell activation script created successfully
2026-07-23 11:51:43 - 11 - 07 - INFO - Fish deactivation script created successfully
2026-07-23 11:51:43 - 11 - 07 - INFO - OpenOCD rules copied successfully
Added environment variable ESP_IDF_VERSION = 5.5
Added environment variable IDF_TOOLS_PATH = /Users/ak/.espressif/tools
Added environment variable IDF_COMPONENT_LOCAL_STORAGE_URL = file:///Users/ak/.espressif/tools
Added environment variable IDF_PATH = /Users/ak/.espressif/release-v5.5/esp-idf
Added environment variable ESP_ROM_ELF_DIR = /Users/ak/.espressif/tools/esp-rom-elfs/20241011/
Added environment variable OPENOCD_SCRIPTS = /Users/ak/.espressif/tools/openocd-esp32/v0.12.0-esp32-20260703/openocd-esp32/share/openocd/scripts
Added environment variable IDF_PYTHON_ENV_PATH = /Users/ak/.espressif/tools/python/release-v5.5/venv
Added proper directory to PATH
Activated virtual environment at /Users/ak/.espressif/tools/python/release-v5.5/venv
```

## Follow-ups

- GUI changes may be required

## Related

<!--
- Use this format to link issue numbers: Fixes #123
- Mention any other PRs related to this one.
-->

## Testing

- Verified `install` and `remove` for branch `release/v5.5`, confirming a flat `~/.espressif/release-v5.5/` install directory and successfully created activation scripts.
- Added unit tests
---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.