### PR TITLE
proper githu athena sync bot author name set

### DIFF
--- a/.github/workflows/sync-athena.yml
+++ b/.github/workflows/sync-athena.yml
@@ -30,7 +30,7 @@ jobs:
         uses: hahihula/sync-athena@v1
         with:
           mode: issue_to_task
-          author: EimGitBot
+          author: sync-ci
           co_authors: "petr.gadorek@espressif.com,ali.azamrana@espressif.com"
           repo: ${{ github.repository }}
           ticket_prefix: EIM
@@ -51,7 +51,7 @@ jobs:
         uses: hahihula/sync-athena@v1
         with:
           mode: pr_to_comment
-          author: EimGitBot
+          author: sync-ci
           repo: ${{ github.repository }}
           ticket_prefix: EIM
           athena_project_uuid: ${{ vars.ATHENA_PROJECT_UUID }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the displayed automation author name from “EimGitBot” to “sync-ci” for issue and pull request task synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->