### PR TITLE
Addding eim shell command

### DIFF
--- a/docs/src/cli_commands.md
+++ b/docs/src/cli_commands.md
@@ -36,6 +36,7 @@ These options can be used with any command:
 | `purge` | Purge all ESP-IDF installations |
 | `import` | Import existing ESP-IDF installation using tools_set_config.json |
 | `run` | Run a command in the context of a specific ESP-IDF version |
+| `shell` | Start an interactive shell with the environment of a specific ESP-IDF version activated |
 | `discover` | Discover available ESP-IDF versions (not implemented yet) |
 | `completions` | Generate shell completion script to stdout |
 | `help-json` | Print help in JSON format for machine reading |
@@ -240,6 +241,21 @@ The IDF version can be identified by:
 - **Name**: The display name (e.g., `v5.3.2`)
 - **Path**: The full installation path
 
+### Shell Command
+
+Start an interactive shell with the environment of a specific ESP-IDF version activated. Unlike `run`, which executes a single command and exits, `shell` hands control of the current terminal to you and keeps the environment active until you exit that shell.
+
+```bash
+eim shell [IDF_VERSION]
+```
+
+Arguments:
+- `IDF_VERSION`: The ID, name, or path of the installed IDF version (optional)
+
+If `IDF_VERSION` is not provided, the command uses the currently selected IDF version (set via `eim select`). If no version is selected and none is specified, an error is returned.
+
+The new shell is your normal login shell (`$SHELL`), started with its usual startup files (e.g. `~/.bashrc`, `~/.zshrc`) so your own aliases, functions and prompt customizations are kept, in addition to the ESP-IDF ones — `idf.py`, `esptool.py` and friends are available as real shell functions, not just as commands reachable through `PATH`. Bash, zsh and fish are supported directly; on Windows the environment is activated in a PowerShell session (`-NoExit`). Type `exit` (or press Ctrl+D) to leave the shell and return to your previous one — activation is local to that shell process and is not persisted anywhere.
+
 ### Discover Command
 
 Discover available ESP-IDF versions (not implemented yet).
@@ -393,6 +409,12 @@ eim run "idf.py build"
 
 # Run a command with output redirection (command must be quoted)
 eim run "idf.py size > sizes.txt" v5.4
+
+# Start an interactive shell with a specific IDF version activated
+eim shell v5.3.2
+
+# Start an interactive shell using the currently selected IDF version
+eim shell
 ```
 
 ## Per-Version Feature Configuration

--- a/docs/src/git_bisect.md
+++ b/docs/src/git_bisect.md
@@ -45,7 +45,7 @@ The name is not just a label. It is part of several paths:
 
 - the Python virtual environment: `<tool install folder>/python/<name>/venv`
 - the activation and deactivation scripts: `activate_idf_<name>.sh`, `activate_idf_<name>.fish`, `Microsoft.<name>.PowerShell_profile.ps1`
-- the identifier you pass to `eim select`, `eim run` and `eim remove`
+- the identifier you pass to `eim select`, `eim run`, `eim shell` and `eim remove`
 
 The name is also **frozen at install time**. `eim fix` deliberately keeps it, whatever revision you have checked out, and `eim install` refuses to run a second time on a path that is already registered:
 

--- a/src-tauri/locales/app.yml
+++ b/src-tauri/locales/app.yml
@@ -602,15 +602,21 @@ drivers.success:
 drivers.windows_only:
   en: Driver installation is only supported on Windows.
   cn: 驱动程序安装仅支持 Windows 系统。
-run.using_selected:
+cli.using_selected_idf:
   en: "Using selected IDF version: %{idf}"
   cn: "使用已选择的 IDF 版本：%{idf}"
-run.no_idf_specified_no_selected:
-  en: No IDF version specified and no version is selected. Please specify an IDF version to run the command in its context.
-  cn: 未指定 IDF 版本且未选择版本。请指定一个 IDF 版本以在其上下文中运行命令。
+cli.no_idf_specified_no_selected:
+  en: No IDF version specified and no version is selected. Please specify an IDF version.
+  cn: 未指定 IDF 版本且未选择版本。请指定一个 IDF 版本。
 run.command_failed:
   en: Command failed to execute
   cn: 命令执行失败
+shell.starting:
+  en: "Starting interactive shell with IDF version activated: %{idf}. Type 'exit' to leave."
+  cn: "正在启动已激活 IDF 版本的交互式 shell：%{idf}。输入 “exit” 退出。"
+shell.command_failed:
+  en: Interactive shell exited with an error
+  cn: 交互式 shell 异常退出
 cli.no_command:
   en: No command specified, use --help to see available commands
   cn: 未指定命令，请使用 --help 查看可用命令

--- a/src-tauri/src/cli/cli_args.rs
+++ b/src-tauri/src/cli/cli_args.rs
@@ -121,6 +121,12 @@ pub enum Commands {
         idf: Option<String>,
     },
 
+    /// Start an interactive shell with the environment of a specific ESP-IDF version activated
+    Shell {
+        #[arg(help = "ID, name or version of idf to activate")]
+        idf: Option<String>,
+    },
+
     /// Import existing ESP-IDF installation using tools_set_config.json
     Import {
         #[arg(help = "Import using existing config file")]

--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -19,6 +19,7 @@ use idf_im_lib::version_manager::get_selected_version;
 use idf_im_lib::version_manager::prepare_settings_for_fix_idf_installation;
 use idf_im_lib::version_manager::remove_single_idf_version;
 use idf_im_lib::version_manager::run_command_in_context;
+use idf_im_lib::version_manager::run_interactive_shell_in_context;
 use idf_im_lib::version_manager::select_idf_version;
 use idf_im_lib::logging;
 use log::debug;
@@ -99,6 +100,22 @@ pub fn setup_cli(
 
     log::trace!("CLI logging initialized. Console: {:?}, File: {:?}", console_level, file_level);
     Ok(())
+}
+
+/// Resolves the IDF identifier to operate on: the one explicitly passed on
+/// the command line, or the currently selected version if none was given.
+fn resolve_idf_identifier(
+    idf: Option<String>,
+    config_path: Option<&PathBuf>,
+) -> anyhow::Result<String> {
+    if let Some(idf_str) = idf {
+        Ok(idf_str)
+    } else if let Some(selected) = get_selected_version(config_path) {
+        info!("{}", t!("cli.using_selected_idf", idf = selected.name));
+        Ok(selected.id)
+    } else {
+        Err(anyhow::anyhow!(t!("cli.no_idf_specified_no_selected")))
+    }
 }
 
 fn status_label(status: &InstallationStatus) -> String {
@@ -580,19 +597,26 @@ pub async fn run_cli(cli: Cli) -> anyhow::Result<()> {
             }
         }
         Commands::Run { command, idf } => {
-            let idf_identifier = if let Some(idf_str) = idf {
-                idf_str
-            } else if let Some(selected) = get_selected_version(config_path.as_ref()) {
-                info!("{}", t!("run.using_selected", idf = selected.name));
-                selected.id
-            } else {
-                return Err(anyhow::anyhow!(t!("run.no_idf_specified_no_selected")));
-            };
+            let idf_identifier = resolve_idf_identifier(idf, config_path.as_ref())?;
 
             match run_command_in_context(&idf_identifier, &command, config_path.as_ref()) {
                 Ok(status) => {
                     if !status.success() {
                         return Err(anyhow::anyhow!(t!("run.command_failed")));
+                    }
+                    Ok(())
+                }
+                Err(err) => Err(err),
+            }
+        }
+        Commands::Shell { idf } => {
+            let idf_identifier = resolve_idf_identifier(idf, config_path.as_ref())?;
+
+            info!("{}", t!("shell.starting", idf = idf_identifier));
+            match run_interactive_shell_in_context(&idf_identifier, config_path.as_ref()) {
+                Ok(status) => {
+                    if !status.success() {
+                        return Err(anyhow::anyhow!(t!("shell.command_failed")));
                     }
                     Ok(())
                 }

--- a/src-tauri/src/lib/version_manager.rs
+++ b/src-tauri/src/lib/version_manager.rs
@@ -423,11 +423,10 @@ pub fn find_esp_idf_folders(path: &str) -> Vec<String> {
         .collect()
 }
 
-pub fn run_command_in_context(
+fn find_activation_script_for_identifier(
     identifier: &str,
-    command: &str,
     config_path: Option<&PathBuf>,
-) -> anyhow::Result<ExitStatus> {
+) -> anyhow::Result<String> {
     let installation = match list_installed_versions(config_path) {
         Ok(versions) => versions.into_iter().find(|v| {
             v.id == identifier || v.name == identifier || {
@@ -448,11 +447,26 @@ pub fn run_command_in_context(
         }
     };
 
-    let activation_script = installation.activation_script.as_deref().ok_or_else(|| {
+    installation.activation_script.clone().ok_or_else(|| {
         anyhow!("Installation {} has no activation script set", identifier)
-    })?;
+    })
+}
 
-    run_command_using_activation_script(activation_script, command, None)
+pub fn run_command_in_context(
+    identifier: &str,
+    command: &str,
+    config_path: Option<&PathBuf>,
+) -> anyhow::Result<ExitStatus> {
+    let activation_script = find_activation_script_for_identifier(identifier, config_path)?;
+    run_command_using_activation_script(&activation_script, command, None)
+}
+
+pub fn run_interactive_shell_in_context(
+    identifier: &str,
+    config_path: Option<&PathBuf>,
+) -> anyhow::Result<ExitStatus> {
+    let activation_script = find_activation_script_for_identifier(identifier, config_path)?;
+    run_interactive_shell_using_activation_script(&activation_script)
 }
 
 fn build_activation_script(activation_script: &str, command: &str) -> String {
@@ -492,6 +506,151 @@ pub fn run_command_using_activation_script(
             Err(e) => Err(anyhow!("Failed to execute command: {}", e)),
         }
     }
+}
+
+/// Starts an interactive shell with the given activation script sourced, handing
+/// control of the current terminal to the user until they exit that shell.
+///
+/// Simply sourcing the activation script and then `exec`ing the user's shell
+/// only carries over environment variables: aliases and shell functions (which
+/// the activation script also defines, e.g. `idf.py`) are interpreter state,
+/// not part of the process environment, so they don't survive an `exec` into a
+/// fresh shell process. Instead we start the target shell using its own
+/// startup-file mechanism (bash `--rcfile`, zsh `ZDOTDIR`, fish
+/// `--init-command`) so the activation script is sourced *inside* the very
+/// shell session the user ends up in, alongside their normal rc file.
+#[cfg(target_os = "windows")]
+pub fn run_interactive_shell_using_activation_script(
+    activation_script: &str,
+) -> anyhow::Result<ExitStatus> {
+    debug!(
+        "Starting interactive shell using activation script {}",
+        activation_script
+    );
+    // On Windows the activation profile is run with `-NoExit -File`, so it
+    // executes inside the same PowerShell session the user keeps using -
+    // functions/aliases it defines are naturally still in scope.
+    let script = format!(". \"{}\"\r\npowershell -NoExit -NoLogo", activation_script);
+
+    let executor = crate::command_executor::get_executor();
+    match executor.run_script_from_string_streaming(&script) {
+        Ok(status) => Ok(status),
+        Err(e) => Err(anyhow!("Failed to start interactive shell: {}", e)),
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+pub fn run_interactive_shell_using_activation_script(
+    activation_script: &str,
+) -> anyhow::Result<ExitStatus> {
+    debug!(
+        "Starting interactive shell using activation script {}",
+        activation_script
+    );
+
+    let user_shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/bash".to_string());
+    let shell_name = Path::new(&user_shell)
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("bash");
+
+    match shell_name {
+        "zsh" => run_interactive_zsh_with_activation(activation_script),
+        "fish" => run_interactive_fish_with_activation(activation_script),
+        _ => run_interactive_bash_with_activation(activation_script),
+    }
+}
+
+/// Starts an interactive bash with the activation script sourced from a
+/// generated `--rcfile`, after first sourcing the user's own `~/.bashrc` so
+/// their normal aliases/prompt are kept too.
+#[cfg(not(target_os = "windows"))]
+fn run_interactive_bash_with_activation(activation_script: &str) -> anyhow::Result<ExitStatus> {
+    use std::io::Write;
+
+    let mut rc_file = tempfile::Builder::new()
+        .prefix("eim_shell_bashrc_")
+        .suffix(".sh")
+        .tempfile()
+        .map_err(|e| anyhow!("Failed to create temporary bash rc file: {}", e))?;
+    writeln!(
+        rc_file,
+        "[ -f \"$HOME/.bashrc\" ] && source \"$HOME/.bashrc\"\nsource \"{}\"",
+        activation_script
+    )
+    .map_err(|e| anyhow!("Failed to write temporary bash rc file: {}", e))?;
+
+    let script = format!(
+        "exec bash --rcfile \"{}\" -i",
+        rc_file.path().to_string_lossy()
+    );
+
+    let executor = crate::command_executor::get_executor();
+    let result = executor
+        .run_script_from_string_streaming(&script)
+        .map_err(|e| anyhow!("Failed to start interactive shell: {}", e));
+    // rc_file is kept alive (and thus on disk) until here, i.e. for the whole
+    // duration of the interactive session.
+    drop(rc_file);
+    result
+}
+
+/// Starts an interactive zsh with the activation script sourced via a
+/// generated `ZDOTDIR`, whose `.zshrc` also sources the user's own zshrc.
+#[cfg(not(target_os = "windows"))]
+fn run_interactive_zsh_with_activation(activation_script: &str) -> anyhow::Result<ExitStatus> {
+    let zdotdir = tempfile::tempdir()
+        .map_err(|e| anyhow!("Failed to create temporary ZDOTDIR: {}", e))?;
+
+    let original_zdotdir = std::env::var("ZDOTDIR").unwrap_or_else(|_| {
+        std::env::var("HOME").unwrap_or_default()
+    });
+
+    let rc_content = format!(
+        "export ZDOTDIR=\"{original}\"\n[ -f \"{original}/.zshrc\" ] && source \"{original}/.zshrc\"\nsource \"{activation}\"",
+        original = original_zdotdir,
+        activation = activation_script
+    );
+    std::fs::write(zdotdir.path().join(".zshrc"), rc_content)
+        .map_err(|e| anyhow!("Failed to write temporary zsh rc file: {}", e))?;
+
+    let script = format!(
+        "export ZDOTDIR=\"{}\"\nexec zsh -i",
+        zdotdir.path().to_string_lossy()
+    );
+
+    let executor = crate::command_executor::get_executor();
+    let result = executor
+        .run_script_from_string_streaming(&script)
+        .map_err(|e| anyhow!("Failed to start interactive shell: {}", e));
+    drop(zdotdir);
+    result
+}
+
+/// Starts an interactive fish shell, sourcing the fish variant of the
+/// activation script (generated alongside the POSIX one) via `--init-command`.
+/// Falls back to bash if no fish activation script is available (e.g. an
+/// installation created before fish support was added).
+#[cfg(not(target_os = "windows"))]
+fn run_interactive_fish_with_activation(activation_script: &str) -> anyhow::Result<ExitStatus> {
+    let fish_script = Path::new(activation_script).with_extension("fish");
+    if !fish_script.is_file() {
+        warn!(
+            "No fish activation script found at {}, falling back to bash",
+            fish_script.display()
+        );
+        return run_interactive_bash_with_activation(activation_script);
+    }
+
+    let script = format!(
+        "exec fish --init-command 'source \"{}\"'",
+        fish_script.to_string_lossy()
+    );
+
+    let executor = crate::command_executor::get_executor();
+    executor
+        .run_script_from_string_streaming(&script)
+        .map_err(|e| anyhow!("Failed to start interactive shell: {}", e))
 }
 
 pub fn run_command_using_activation_script_headless(


### PR DESCRIPTION
this adds command for invoking interactive shell with activated IDF environment inside already active tty shell

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an `eim shell` command to open an interactive terminal with a selected ESP-IDF version activated.
  * Supports selecting an installation by ID, name, or version, or using the currently selected version.
  * Works across Windows, Bash, Zsh, and Fish shells, with appropriate environment setup.

* **Documentation**
  * Added CLI reference details and usage examples for the new shell command.
  * Updated command examples to include `eim shell`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->